### PR TITLE
Delegate addCommands to Doctrine ConsoleRunner

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -20,6 +20,7 @@
 namespace DoctrineORMModule;
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
+use Doctrine\ORM\Tools\Console\ConsoleRunner as ORMConsoleRunner;
 use DoctrineModule\Service as CommonService;
 use DoctrineORMModule\Service as ORMService;
 
@@ -72,28 +73,7 @@ class Module implements ServiceProviderInterface, ConfigProviderInterface
             /* @var $cli \Symfony\Component\Console\Application */
             $cli = $e->getTarget();
 
-            $cli->addCommands(array(
-                // DBAL Commands
-                new \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand(),
-                new \Doctrine\DBAL\Tools\Console\Command\ImportCommand(),
-
-                // ORM Commands
-                new \Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\GenerateEntitiesCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\RunDqlCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand(),
-                new \Doctrine\ORM\Tools\Console\Command\InfoCommand()
-            ));
+            ORMConsoleRunner::addCommands($cli);
 
             /* @var $sm ServiceLocatorInterface */
             $sm = $e->getParam('ServiceManager');


### PR DESCRIPTION
DoctrineORM already ships, updates and mantains the list of commands for the console app, so let it do this job for us :)

[![Build Status](https://secure.travis-ci.org/Slamdunk/DoctrineORMModule.png?branch=delegate-addcommands)](http://travis-ci.org/#!/Slamdunk/DoctrineORMModule/builds/1774253)
