### PR TITLE
Should not depend on dev-master (especially on Zend Framework)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,13 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/doctrine-module": "dev-master",
-        "doctrine/orm": "dev-master",
-        "doctrine/dbal": "dev-master",
-		"doctrine/migrations": "dev-master",
-        "zendframework/zendframework": "dev-master"
+        "doctrine/doctrine-module": ">=0.4.0",
+        "doctrine/orm": ">=2.0",
+        "doctrine/dbal": ">=2.0",
+        "zendframework/zendframework": ">=2.0.0beta5"
+    },
+    "recommend": {
+        "doctrine/migrations": "dev-master"
     },
     "minimum-stability": "dev",
     "autoload": {


### PR DESCRIPTION
We are using DoctrineORMModule & DoctrineModule in production with ZF beta 5, however, we need to be able to lock in the specific version for change control and qa needs.  The current composer setup forces us to use dev-master (git clones) versus the released tags.  I've simply converted the values in the composer.json file to reflect >= of the latest release.
