### PR TITLE
Exclusion of GeneratedValue from forms does not work

### DIFF
--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -58,7 +58,7 @@ class ElementAnnotationsListener implements ListenerAggregateInterface
     public function handleAttributesAnnotation($e)
     {
         $annotation = $e->getParam('annotation');
-        if (!$annotation instanceof Mapping\Column) {
+        if (!$annotation instanceof Column) {
             return;
         }
 


### PR DESCRIPTION
`AnnotationBuilder` does not hide `@ORM\GeneratedValue` fields correctly because of a wrong condition. This patch fixes it.
