### PR TITLE
logging of queries to firebug if firephp is available (added to require-dev)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,11 @@
     },
     "require-dev": {
         "zendframework/zend-developer-tools": "dev-master"
+        "zolex/firephp": "dev-master"
     },
     "suggest": {
-        "zendframework/zend-developer-tools": "zend-developer-tools if you want to profile operations executed by the ORM during development"
+        "zendframework/zend-developer-tools": "zend-developer-tools if you want to profile operations executed by the ORM during development",
+        "zolex/firephp": "firephp if you want to push all queries to the firebug console"
     },
     "minimum-stability": "dev",
     "autoload": {

--- a/src/DoctrineORMModule/Collector/SQLLoggerCollector.php
+++ b/src/DoctrineORMModule/Collector/SQLLoggerCollector.php
@@ -98,6 +98,14 @@ class SQLLoggerCollector implements CollectorInterface, AutoHideInterface
     {
         return count($this->sqlLogger->queries);
     }
+    
+    /**
+     * @return array
+     */
+    public function getQueries()
+    {
+        return $this->sqlLogger->queries;
+    }
 
     /**
      * @return float

--- a/view/zend-developer-tools/toolbar/doctrine-orm.phtml
+++ b/view/zend-developer-tools/toolbar/doctrine-orm.phtml
@@ -4,7 +4,10 @@
         <span class="zdt-toolbar-info">
             <?php echo $this->collector->getQueryCount(); ?>
             queries in
-            <?php echo $this->ZendDeveloperToolsTime($this->collector->getQueryTime()); ?> s
+            <?php echo $this->ZendDeveloperToolsTime($this->collector->getQueryTime()); ?>
+            <?php if (class_exists('FirePHPCore\FirePHP')): ?>
+                <?php FirePHPCore\FirePHP::getInstance()->log($this->collector->getQueries()) ?>
+            <?php endif ?>
         </span>
     </div>
     <div class="zdt-toolbar-detail">


### PR DESCRIPTION
All queries are logged to the firebug console using firephp which was added as require-dev dependency.
