### PR TITLE
Added possibility to configure command using the module config files

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -109,11 +109,14 @@ class Module implements
                 new VersionCommand(),
             );
             
-            foreach ($commands as $command) {
+            if (is_array($migrationsConfig)) {
                 
-                if (method_exists($command, 'setArrayConfig')) {
+                foreach ($commands as $command) {
                     
-                    $command->setArrayConfig($migrationsConfig);
+                    if (method_exists($command, 'setArrayConfig')) {
+                        
+                        $command->setArrayConfig($migrationsConfig);
+                    }
                 }
             }
             


### PR DESCRIPTION
It's now possible to configure multiple paths to migrations in the zend module configs. this allows each module to have their own migrations.

Requires doctrine/migrations#87
