### PR TITLE
Add ability to define SQLFilters within ZF2 configuration

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -28,7 +28,8 @@ return array(
 
                 'generate_proxies'  => true,
                 'proxy_dir'         => 'data/DoctrineORMModule/Proxy',
-                'proxy_namespace'   => 'DoctrineORMModule\Proxy'
+                'proxy_namespace'   => 'DoctrineORMModule\Proxy',
+                'filters'           => array()
             )
         ),
 

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -94,6 +94,14 @@ class Configuration extends DBALConfiguration
     protected $numericFunctions = array();
 
     /**
+     * Keys must be the name of the custom filter and the value must be
+     * the class name for the custom filter.
+     * 
+     * @var array
+     */
+    protected $filters = array();
+
+    /**
      * Keys must be the name of the query and values the DQL query string.
      *
      * @var array
@@ -266,6 +274,24 @@ class Configuration extends DBALConfiguration
     public function getNumericFunctions()
     {
         return $this->numericFunctions;
+    }
+
+    /**
+     * 
+     * @param array $filters
+     * @return self
+     */
+    public function setFilters($filters) {
+        $this->filters = $filters;
+        return $this;
+    }
+    
+    /**
+     * 
+     * @return array
+     */
+    public function getFilters() {
+        return $this->filters;
     }
 
     /**

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -51,6 +51,10 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
         foreach ($options->getCustomHydrationModes() AS $modeName => $hydrator) {
             $config->addCustomHydrationMode($modeName, $hydrator);
         }
+        
+        foreach ($options->getFilters() as $name => $class) {
+            $config->addFilter($name, $class);
+        }
 
         $config->setMetadataCacheImpl($serviceLocator->get($options->getMetadataCache()));
         $config->setQueryCacheImpl($serviceLocator->get($options->getQueryCache()));


### PR DESCRIPTION
http://docs.doctrine-project.org/en/latest/reference/filters.html

Including filters:

``` php
return array(
    'doctrine' => array(
        'configuration' => array(
            'orm_default' => array(
                'filters' => array(
                    'filter_name' => 'Filter\Class',
                ),
            ),
        ),
    ),
);
```
