### PR TITLE
Delegate to ServiceLocator the SqlLogger inizialization instead of config

### DIFF
--- a/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
@@ -68,9 +68,11 @@ class DBALConfigurationFactory implements FactoryInterface
         $options = $this->getOptions($serviceLocator);
         $config->setResultCacheImpl($serviceLocator->get($options->resultCache));
 
-        if (isset($options->sqlLogger)) {
-            $config->setSQLLogger($serviceLocator->get($options->sqlLogger));
+        $sqlLogger = $options->sqlLogger;
+        if (is_string($sqlLogger) and $serviceLocator->has($sqlLogger)) {
+            $sqlLogger = $serviceLocator->get($sqlLogger);
         }
+        $config->setSQLLogger($sqlLogger);
 
         foreach ($options->types as $name => $class) {
             if (Type::hasType($name)) {


### PR DESCRIPTION
To directly inject SqlLogger to DBAL config now we have to init the logger inside the config.php

``` php
return array(
    'doctrine' => array(
        'configuration' => array(
            'orm_default' => array(
                'sql_logger' => new Doctrine\DBAL\Logging\EchoSQLLogger(),
            ),
        ),
    ),
);
```

With this PR we delegate to the service locator the sql logger inizialization, so we can

``` php
return array(
    'doctrine' => array(
        'configuration' => array(
            'orm_default' => array(
                'sql_logger' => 'my_sql_logger',
            ),
        ),
    ),
    'service_manager' => array(
        'invokables' => array(
            'my_sql_logger' => 'Doctrine\DBAL\Logging\EchoSQLLogger',
        ),
    ),
);
```

NOTE: the build will not pass but only for an integration bug with DoctrineModule+ZendFramework -_-
