### PR TITLE
Initializing collector by subscribing to ZDT init event

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -34,6 +34,7 @@ use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
+use Zend\ModuleManager\Feature\InitProviderInterface;
 use Zend\ModuleManager\ModuleManagerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\Loader\AutoloaderFactory;
@@ -63,8 +64,12 @@ class Module implements
     AutoloaderProviderInterface,
     BootstrapListenerInterface,
     ServiceProviderInterface,
-    ConfigProviderInterface
+    ConfigProviderInterface,
+    InitProviderInterface
 {
+    /**
+     * {@inheritDoc}
+     */
     public function init(ModuleManagerInterface $manager)
     {
         $events = $manager->getEventManager();
@@ -122,7 +127,6 @@ class Module implements
             $helperSet->set(new EntityManagerHelper($em), 'em');
         });
 
-        $app->getServiceManager()->get('Config');
         $app->getServiceManager()->get('doctrine.entity_resolver.orm_default');
     }
 


### PR DESCRIPTION
In order to fix #106.

I'm not sure this a very safe way to do it as i request the `serviceManager` in the `Module::init()` method.  There is no way to attach to the `provider_init` ZDT event in `onBootstrap()` as it is [triggered](https://github.com/zendframework/ZendDeveloperTools/blob/master/Module.php#L68) in `Module::init()`.

Is there a better way to do this ? Maybe by attaching to a new DoctrineORMModule event that would be triggered in `onBootstrap()` instead of directly accessing the `serviceManager` ? Then in the callback of that new triggered event we would have a fully merged config so that would be safer.
