### PR TITLE
Add Tableprefix feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ return array(
                     'user'     => 'username',
                     'password' => 'password',
                     'dbname'   => 'database',
-		  			'tableprefix' => 'prefix_',
-		  			'nameing_strategy' => 'underscore_case_lower', // or 'UNDERSCORE_CASE_UPPER' everything else uses defaultNameingStrategy
                 )
             )
         )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,7 +94,7 @@ return array(
                     'password' => 'root',
                     'dbname'   => 'crawler',
 		    		'tableprefix' => 'prefix_',
-		    		'nameing_strategy' => 'underscore_case_lower', // or 'UNDERSCORE_CASE_UPPER' everything else uses defaultNameingStrategy
+		    		'naming_strategy' => 'underscore_case_lower', // or 'UNDERSCORE_CASE_UPPER' everything else uses defaultNameingStrategy
                     'driverOptions' => array(
                         1002 => 'SET NAMES utf8'
                     ),

--- a/src/DoctrineORMModule/Listener/TablePrefixListener.php
+++ b/src/DoctrineORMModule/Listener/TablePrefixListener.php
@@ -1,14 +1,14 @@
 <?php
 
 /*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
 * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -16,32 +16,51 @@
 * This software consists of voluntary contributions made by many individuals
 * and is licensed under the MIT license. For more information, see
 * <http://www.doctrine-project.org>.
+*
 */
-
-// info: http://docs.doctrine-project.org/en/2.0.x/cookbook/sql-table-prefixes.html
 
 namespace DoctrineORMModule\Listener;
 
 use \Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use \Doctrine\Common\EventSubscriber;
+use \Doctrine\ORM\Mapping\ClassMetadataInfo;
 
-class TablePrefixListener
+/**
+ * Listener for used by \DoctrineORMModule\Service\ConfigurationFactory
+ * to enable tableprefixes
+ *
+ * @license MIT
+ * @link http://docs.doctrine-project.org/en/2.0.x/cookbook/sql-table-prefixes.html
+ * @author  unknown - see @link
+ * @author  Dominik Evers <exoon@online.de>
+ */
+class TablePrefixListener implements EventSubscriber
 {
-	protected $prefix = '';
+    protected $prefix = '';
 
-	public function __construct($prefix)
-	{
-		$this->prefix = (string) $prefix;
-	}
+    public function __construct($prefix)
+    {
+        $this->prefix = (string) $prefix;
+    }
 
-	public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
-	{
-		$classMetadata = $eventArgs->getClassMetadata();
-		$classMetadata->setTableName($this->prefix . $classMetadata->getTableName());
-		foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
-			if ($mapping['type'] == \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_MANY) {
-				$mappedTableName = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];
-				$classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
-			}
-		}
-	}
+    public function loadClassMetadata(LoadClassMetadataEventArgs $eventArgs)
+    {
+        $classMetadata = $eventArgs->getClassMetadata();
+        $classMetadata->setTableName($this->prefix . $classMetadata->getTableName());
+        foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
+            if ($mapping['type'] == ClassMetadataInfo::MANY_TO_MANY) {
+                $mappedTableName = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
+            }
+        }
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see \Doctrine\Common\EventSubscriber::getSubscribedEvents()
+     */
+    public function getSubscribedEvents()
+    {
+        return array('loadClassMetadata');
+    }
 }

--- a/src/DoctrineORMModule/Service/EntityManagerFactory.php
+++ b/src/DoctrineORMModule/Service/EntityManagerFactory.php
@@ -6,8 +6,8 @@
 * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-		* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-		* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
@@ -23,58 +23,56 @@ use Doctrine\ORM\EntityManager;
 use DoctrineModule\Service\AbstractFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use DoctrineORMModule\Listener\TablePrefixListener;
+use \Doctrine\ORM\Mapping\UnderscoreNamingStrategy;
 
 class EntityManagerFactory extends AbstractFactory
 {
-	/**
-	 * {@inheritDoc}
-	 * @return EntityManager
-	 */
-	public function createService(ServiceLocatorInterface $sl)
-	{
-		/* @var $options \DoctrineORMModule\Options\EntityManager */
-		$options = $this->getOptions($sl, 'entitymanager');
-		$connection = $sl->get($options->getConnection());
-		$config     = $sl->get($options->getConfiguration());
+    /**
+     * {@inheritDoc}
+     * @return EntityManager
+     */
+    public function createService(ServiceLocatorInterface $sl)
+    {
+        /* @var $options \DoctrineORMModule\Options\EntityManager */
+        $options = $this->getOptions($sl, 'entitymanager');
+        $connection = $sl->get($options->getConnection());
+        $config     = $sl->get($options->getConfiguration());
 
-		$cfg = $sl->get('Config');
-		$cfg = $cfg['doctrine']['connection']['orm_default']['params'];
+        $cfg = $sl->get('Config');
+        $cfg = $cfg['doctrine']['connection']['orm_default']['params'];
 
-		/**
-		 * @todo make naming strategy interface useable
-		 * http://docs.doctrine-project.org/en/latest/reference/namingstrategy.html
-		 */
-		if (isset($cfg['nameing_strategy']))
-		{
-			switch ($cfg['nameing_strategy'])
-			{
-				case 'underscore_case_lower':
-					$namingStrategy = new \Doctrine\ORM\Mapping\UnderscoreNamingStrategy(CASE_LOWER);
-					$config->setNamingStrategy($namingStrategy);
-					break;
-				case 'UNDERSCORE_CASE_UPPER':
-					$namingStrategy = new \Doctrine\ORM\Mapping\UnderscoreNamingStrategy(CASE_UPPER);
-					$config->setNamingStrategy($namingStrategy);
-					break;
-			}
-		}
-		
-		if (isset($cfg['tableprefix']) && $cfg['tableprefix'] != '')
-		{
-			$evm = $connection->getEventManager();
-			$tablePrefixListener = new TablePrefixListener($cfg['tableprefix']);
-			$evm->addEventListener(\Doctrine\ORM\Events::loadClassMetadata, $tablePrefixListener);
-			return EntityManager::create($connection, $config, $evm);
-		}
+        /**
+         * @todo make naming strategy interface useable
+         * http://docs.doctrine-project.org/en/latest/reference/namingstrategy.html
+         */
+        if (isset($cfg['nameing_strategy'])) {
+            switch ($cfg['nameing_strategy']) {
+                case 'underscore_case_lower':
+                    $namingStrategy = new UnderscoreNamingStrategy(CASE_LOWER);
+                    $config->setNamingStrategy($namingStrategy);
+                    break;
+                case 'UNDERSCORE_CASE_UPPER':
+                    $namingStrategy = new UnderscoreNamingStrategy(CASE_UPPER);
+                    $config->setNamingStrategy($namingStrategy);
+                    break;
+            }
+        }
 
-		return EntityManager::create($connection, $config);
-	}
+        if (isset($cfg['tableprefix']) && is_string($cfg['tableprefix'])) {
+            $evm = $connection->getEventManager();
+            $tablePrefixListener = new TablePrefixListener($cfg['tableprefix']);
+            $evm->addEventSubscriber($tablePrefixListener);
+            return EntityManager::create($connection, $config, $evm);
+        }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	public function getOptionsClass()
-	{
-		return 'DoctrineORMModule\Options\EntityManager';
-	}
+        return EntityManager::create($connection, $config);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOptionsClass()
+    {
+        return 'DoctrineORMModule\Options\EntityManager';
+    }
 }

--- a/tests/DoctrineORMModuleTest/Listener/TablePrefixListenerTest.php
+++ b/tests/DoctrineORMModuleTest/Listener/TablePrefixListenerTest.php
@@ -17,14 +17,33 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace DoctrineORMModuleTest\Service;
+namespace DoctrineORMModuleTest\Listener;
 
+use DoctrineORMModule\Listener\TablePrefixListener;
 use PHPUnit_Framework_TestCase;
 
-class EntityManagerFactoryTest extends PHPUnit_Framework_TestCase
+class TablePrefixListenerTest extends PHPUnit_Framework_TestCase
 {
-    public function testAlwaysFail()
+
+    protected $tablePrefixListener;
+    
+    public function setUp()
     {
-        $this->assertNotNull(null);
+        $this->tablePrefixListener = new TablePrefixListener('prefix');
     }
+    
+    public function testIsEventSubscriper()
+    {
+        $this->assertInstanceOf('\Doctrine\Common\EventSubscriber', $this->tablePrefixListener);
+    }
+    
+    public function testSubscribedEvents()
+    {
+         $subscribedEvents = $this->tablePrefixListener->getSubscribedEvents();
+         $count = count($subscribedEvents);
+         
+         $this->assertEquals($count,1);
+         $this->assertEquals($subscribedEvents[0], 'loadClassMetadata');
+    }
+    
 }


### PR DESCRIPTION
If ['doctrine']['connection']['orm_default']['params']['tableprefix'] is set, it will used as tableprefix. Unfortunately I found no other way to get this feature. It would be create if the module can support it in the future.
