### PR TITLE
Implement `Zend\ModuleManager\Feature\DependencyIndicatorInterface`

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,8 @@
+# 0.8.0
+
+ * `DoctrineORMModule\Module` does not implement `Zend\ModuleManager\Feature\AutoloaderProviderInterface` anymore.
+   Please switch to composer autoloading.
+
 # 0.4.0
 Version `0.4.0` has been rewritten from scratch using the new ServiceManager component of ZF2. This allows for
 drastically increased performance and reduced complexity of setup.

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -19,15 +19,14 @@
 
 namespace DoctrineORMModule;
 
-use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\ControllerProviderInterface;
 use Zend\ModuleManager\Feature\BootstrapListenerInterface;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\ModuleManager\Feature\InitProviderInterface;
+use Zend\ModuleManager\Feature\DependencyIndicatorInterface;
 use Zend\ModuleManager\ModuleManagerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\Loader\AutoloaderFactory;
 use Zend\Loader\StandardAutoloader;
 use Zend\EventManager\EventInterface;
 
@@ -51,12 +50,12 @@ use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
  * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class Module implements
-    AutoloaderProviderInterface,
     ControllerProviderInterface,
     BootstrapListenerInterface,
     ServiceProviderInterface,
     ConfigProviderInterface,
-    InitProviderInterface
+    InitProviderInterface,
+    DependencyIndicatorInterface
 {
     /**
      * {@inheritDoc}
@@ -68,20 +67,6 @@ class Module implements
         $events->attach('profiler_init', function() use ($manager) {
             $manager->getEvent()->getParam('ServiceManager')->get('doctrine.sql_logger_collector.orm_default');
         });
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getAutoloaderConfig()
-    {
-        return array(
-            AutoloaderFactory::STANDARD_AUTOLOADER => array(
-                StandardAutoloader::LOAD_NS => array(
-                    __NAMESPACE__ => __DIR__,
-                ),
-            ),
-        );
     }
 
     /**
@@ -146,5 +131,13 @@ class Module implements
     public function getControllerConfig()
     {
         return include __DIR__ . '/../../config/controllers.config.php';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getModuleDependencies()
+    {
+        return array('DoctrineModule');
     }
 }


### PR DESCRIPTION
As of doctrine/DoctrineModule#186

Also removes autoloader provider (unused/deprecated)
