### PR TITLE
Fix typo in `doctrine/doctrine-module` required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require": {
         "php":                               ">=5.3.3",
-        "doctrine/doctrine-module":          "0.8.*",
+        "doctrine/doctrine-module":          "0.9.*",
         "doctrine/orm":                      ">=2.3,<2.5-dev",
         "doctrine/dbal":                     ">=2.3,<2.5-dev",
         "zendframework/zend-stdlib":         ">=2.1",


### PR DESCRIPTION
Cause composer error : "doctrine/doctrine-orm-module dev-master requires doctrine/doctrine-module 0.8.\* -> no matching package found"
