### PR TITLE
Add empty console route configuration to handle ZF 2.2.1 changes

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -259,6 +259,14 @@ return array(
         ),
     ),
 
+    'console' => array(
+        'router' => array(
+            'routes' => array(
+
+            )
+        )
+    ),
+
     'view_manager' => array(
         'template_map' => array(
             'zend-developer-tools/toolbar/doctrine-orm-queries'


### PR DESCRIPTION
Add empty console route configuration to prevent the zf console from attempting to load web routes.

Console and Web routes extend different base classes. The "Literal" type isn't an option for console routes and was causing a "Given route does not implement Console route interface" exception.

fixes #238
