### PR TITLE
Null empty_option should result in no empty option being included, not a "NULL" select list option

### DIFF
--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -195,7 +195,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
                 if (isset($joinColumn['nullable']) && $joinColumn['nullable']) {
                     $required = false;
 
-                    if (!isset($elementSpec['spec']['options']['empty_option'])) {
+                    if (!array_key_exists('empty_option', $elementSpec['spec']['options'])) {
                         $elementSpec['spec']['options']['empty_option'] = 'NULL';
                     }
                     break;


### PR DESCRIPTION
**Expected behavior:** According to ZF2 docs, setting empty_option to NULL instructs a \Zend\Form\Element\Select that it should _not_ add an "empty option" to a select list.

**Current behavior:** DoctrineORMModule's ElementAnnotationListener ignores a NULL value and includes an empty option (with display string "NULL") in all select lists generated from annotations.  This is because of the use of isset() which causes an intentionally set NULL value to be overwritten.

**Solution:** Replace isset() with array_key_exists().
