### PR TITLE
Update MigrationsConfigurationFactory to allow passing migrations name from config

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -159,6 +159,7 @@ return array(
         'migrations_configuration' => array(
             'orm_default' => array(
                 'directory' => 'data/DoctrineORMModule/Migrations',
+                'name'      => 'Doctrine Database Migrations',
                 'namespace' => 'DoctrineORMModule\Migrations',
                 'table'     => 'migrations',
             ),

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,0 +1,16 @@
+#### How to configure Doctrine Migrations
+
+```php
+return array(    
+    'doctrine' => array(
+        'migrations_configuration' => array(
+            'orm_default' => array(
+                'directory' => 'path/to/migrations/dir',
+                'name' => 'Migrations Name',
+                'namespace' => 'Migrations  Namespace',
+                'table' => 'migrations_table',
+            ),
+        ),
+    ),
+)
+```

--- a/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
@@ -47,6 +47,7 @@ class MigrationsConfigurationFactory extends AbstractFactory
         $migrationsConfig = $appConfig['doctrine']['migrations_configuration'][$name];
         $configuration    = new Configuration($connection);
 
+        $configuration->setName($migrationsConfig['name']);
         $configuration->setMigrationsDirectory($migrationsConfig['directory']);
         $configuration->setMigrationsNamespace($migrationsConfig['namespace']);
         $configuration->setMigrationsTableName($migrationsConfig['table']);


### PR DESCRIPTION
- Added default name to module.config.php (Doctrine Database Migrations)
- Added basic documentation with instructions for configuring (I spent ages digging through trying to find why my migrations.yml was being ignored!)
