### PR TITLE
Update module.config.php

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -225,10 +225,15 @@ return array(
 
     // Zend\Form\FormElementManager configuration
     'form_elements' => array(
-        'aliases' => array(
+        'invokables' => array(
             'objectselect'        => 'DoctrineModule\Form\Element\ObjectSelect',
             'objectradio'         => 'DoctrineModule\Form\Element\ObjectRadio',
             'objectmulticheckbox' => 'DoctrineModule\Form\Element\ObjectMultiCheckbox',
+        ),
+        'shared' => array(
+            'objectselect'        => false,
+            'objectradio'         => false,
+            'objectmulticheckbox' => false
         ),
         'factories' => array(
             'DoctrineModule\Form\Element\ObjectSelect'        => 'DoctrineORMModule\Service\ObjectSelectFactory',


### PR DESCRIPTION
Doctrine ORM Module use shared elements for ObjectSelect, ObjectRadio and ObjectMultiCheckbox and cause some conflicts when you use ObjectSelect twice in the same form for example.
