### PR TITLE
Highlight only uppercase words

### DIFF
--- a/view/zend-developer-tools/toolbar/doctrine-orm-queries.phtml
+++ b/view/zend-developer-tools/toolbar/doctrine-orm-queries.phtml
@@ -24,7 +24,7 @@
             <span class="zdt-detail-label">SQL</span>
             <span class="zdt-detail-value ddt-detail-query ddt-detail-value">
                 <?php /* highlight UPPERCASE words in the query, which should mostly match SQL keywords */ ?>
-                <?php echo preg_replace('/([A-Z]+)/', '<span class="highlight">$1</span>', $this->escapeHtml($query['sql'])) ?>
+                <?php echo preg_replace('/\b([A-Z]+)\b/', '<span class="highlight">$1</span>', $this->escapeHtml($query['sql'])) ?>
             </span>
             <span class="clear"></span>
             <span class="zdt-detail-label">Params</span>


### PR DESCRIPTION
This was highlighting all uppercase letters, even those in CamelCase words. It now looks for only full uppercase words.
