### PR TITLE
order the classes

### DIFF
--- a/src/DoctrineORMModule/Collector/MappingCollector.php
+++ b/src/DoctrineORMModule/Collector/MappingCollector.php
@@ -99,6 +99,7 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
         foreach ($metadata as $class) {
             $this->classes[$class->getName()] = $class;
         }
+        ksort($this->classes);
     }
 
     /**


### PR DESCRIPTION
Order alphabetically the classes by name. So we can find more easily our mapping in the Zend Developper Toolbar
