### PR TITLE
Update ElementAnnotationsListener.php

### DIFF
--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -299,7 +299,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
                 $type = 'Zend\Form\Element\Textarea';
                 break;
             default:
-                $type = 'Zend\Form\Element';
+                $type = isset($elementSpec['spec']['type'])?$elementSpec['spec']['type']:'Zend\Form\Element';
                 break;
         }
 


### PR DESCRIPTION
This modification will make annotations like `@Annotation\Type("Zend\Form\Element\Email")` work again.
