### PR TITLE
added extra check in handleRequiredField

### DIFF
--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -246,6 +246,10 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
         $metadata  = $event->getParam('metadata');
         $inputSpec = $event->getParam('inputSpec');
 
+        if (!$metadata || !$metadata->hasField($event->getParam('name'))) {
+            return;
+        }
+
         $inputSpec['required'] = !$metadata->isNullable($event->getParam('name'));
     }
 

--- a/tests/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
+++ b/tests/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
@@ -202,6 +202,15 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertFalse($inputSpec['required']);
     }
 
+    public function testHandleRequiredFieldNonFieldProperty()
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+        $event->setParam('name', 'targetMany');
+        $listener->handleRequiredField($event);
+        $this->assertFalse(isset($inputSpec['required']));
+    }
+
     /**
      * @dataProvider eventTypeProvider
      */


### PR DESCRIPTION
We only use the ElementAnnationsListener in our application. But when handleRequiredField is triggered with a property unknown by doctrine or a non column field a mapping exception was thrown. This fix will prevent the listener from throwing exceptions at this point. 