### PR TITLE
Add example for entity_resolver

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,20 @@ return array(
 ),
 ```
 
+### How to Define Relationships with Abstract Classes and Interfaces (ResolveTargetEntityListener)
+
+```php
+'doctrine' => array(
+    'entity_resolver' => array(
+        'orm_default' => array(
+            'resolvers' => array(
+                'Acme\\InvoiceModule\\Model\\InvoiceSubjectInterface', 'Acme\\CustomerModule\\Entity\\Customer'
+            )
+        )
+    )
+)
+```
+
 ### How to Use Two Connections
 
 ```php


### PR DESCRIPTION
I couldn't find an example anywhere that detailed using the "resolvers" array.

Without it, you get an error  'The option "<class>" does not have a matching set<class> setter method which must be defined' error.

I gleened the answer from the tests for the EntityResolverFactory class. Apologies if this is documented somewhere else and I missed it.
