### PR TITLE
Prevent Zend\Form\Element\File types inherit of StringLength validator...

### DIFF
--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -341,9 +341,13 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
                 break;
             case 'string':
                 $elementSpec = $event->getParam('elementSpec');
-                if (!in_array($elementSpec['spec']['type'], array('File', 'Zend\Form\Element\File')) &&
-                    isset($mapping['length'])
+                if (isset($elementSpec['spec']['type']) &&
+                    in_array($elementSpec['spec']['type'], array('File', 'Zend\Form\Element\File'))
                 ) {
+                    return;
+                }
+
+                if (isset($mapping['length'])) {
                     $inputSpec['validators'][] = array(
                         'name'    => 'StringLength',
                         'options' => array('max' => $mapping['length'])

--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -340,7 +340,10 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
                 $inputSpec['validators'][] = array('name' => 'Int');
                 break;
             case 'string':
-                if (isset($mapping['length'])) {
+                $elementSpec = $event->getParam('elementSpec');
+                if (!in_array($elementSpec['spec']['type'], array('File', 'Zend\Form\Element\File')) &&
+                    isset($mapping['length'])
+                ) {
                     $inputSpec['validators'][] = array(
                         'name'    => 'StringLength',
                         'options' => array('max' => $mapping['length'])

--- a/tests/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
+++ b/tests/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
@@ -144,4 +144,12 @@ class FormEntity
      * @Form\Attributes({"type":"textarea"})
      */
     protected $specificAttributeType;
+
+    /**
+     * @ORM\Column(type="string", length=256)
+     * @Form\Type("File")
+     * @ORM\JoinColumn(nullable=true)
+     * @Form\Options({"label":"Image"})
+     */
+    protected $image;
 }

--- a/tests/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
+++ b/tests/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
@@ -101,6 +101,22 @@ class AnnotationBuilderTest extends TestCase
     }
 
     /**
+     * @link https://github.com/zendframework/zf2/issues/7096
+     */
+    public function testFileTypeDoesntGrabStringLengthValidator()
+    {
+        $validators = $this
+            ->builder
+            ->createForm(new FormEntity())
+            ->getInputFilter()
+            ->get('image')
+            ->getValidatorChain()
+            ->getValidators();
+
+        $this->assertEquals(0, count($validators));
+    }
+
+    /**
      * Ensure prefer_form_input_filter is set to true for the generated form
      */
     public function testPreferFormInputFilterIsTrue()


### PR DESCRIPTION
...when a length is provided
See https://github.com/zendframework/zf2/issues/7096

With annotations, when a file type is specified, the ElementAnnotationsListener attach a string length validator by default. This PR prevents this behavior.