### PR TITLE
Use `ResolveTargetEntityListener` as an event subscriber when supported

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,10 +33,10 @@
     ],
     "minimum-stability": "alpha",
     "require":           {
-        "php":                               ">=5.3.23",
+        "php":                               ">=5.4",
         "doctrine/doctrine-module":          "0.9.*",
-        "doctrine/orm":                      ">=2.5,<2.7-dev",
-        "doctrine/dbal":                     ">=2.5,<2.7-dev",
+        "doctrine/orm":                      ">=2.4,<2.7-dev",
+        "doctrine/dbal":                     ">=2.4,<2.7-dev",
         "zendframework/zend-stdlib":         "~2.3",
         "zendframework/zend-mvc":            "~2.3",
         "zendframework/zend-servicemanager": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -31,11 +31,12 @@
             "email": "guilhermeblanco@hotmail.com"
         }
     ],
+    "minimum-stability": "alpha",
     "require":           {
         "php":                               ">=5.3.23",
         "doctrine/doctrine-module":          "0.9.*",
-        "doctrine/orm":                      ">=2.4,<2.6-dev",
-        "doctrine/dbal":                     ">=2.4,<2.6-dev",
+        "doctrine/orm":                      ">=2.5,<2.7-dev",
+        "doctrine/dbal":                     ">=2.5,<2.7-dev",
         "zendframework/zend-stdlib":         "~2.3",
         "zendframework/zend-mvc":            "~2.3",
         "zendframework/zend-servicemanager": "~2.3",

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -21,6 +21,7 @@ namespace DoctrineORMModule\Service;
 
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
+use Doctrine\ORM\Version;
 use DoctrineModule\Service\AbstractFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -42,7 +43,11 @@ class EntityResolverFactory extends AbstractFactory
             $targetEntityListener->addResolveTargetEntity($oldEntity, $newEntity, array());
         }
 
-        $eventManager->addEventSubscriber($targetEntityListener);
+        if (Version::compare('2.5.0') >= 0) {
+            $eventManager->addEventSubscriber($targetEntityListener);
+        } else {
+            $eventManager->addEventListener(Events::loadClassMetadata, $targetEntityListener);
+        }
 
         return $eventManager;
     }

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -19,9 +19,9 @@
 
 namespace DoctrineORMModule\Service;
 
+use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
-use Doctrine\ORM\Version;
 use DoctrineModule\Service\AbstractFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -43,7 +43,8 @@ class EntityResolverFactory extends AbstractFactory
             $targetEntityListener->addResolveTargetEntity($oldEntity, $newEntity, array());
         }
 
-        if (Version::compare('2.5.0') >= 0) {
+        // Starting from Doctrine ORM 2.5, the listener implements EventSubscriber
+        if ($targetEntityListener instanceof EventSubscriber) {
             $eventManager->addEventSubscriber($targetEntityListener);
         } else {
             $eventManager->addEventListener(Events::loadClassMetadata, $targetEntityListener);

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -42,7 +42,7 @@ class EntityResolverFactory extends AbstractFactory
             $targetEntityListener->addResolveTargetEntity($oldEntity, $newEntity, array());
         }
 
-        $eventManager->addEventListener(Events::loadClassMetadata, $targetEntityListener);
+        $eventManager->addEventSubscriber($targetEntityListener);
 
         return $eventManager;
     }

--- a/tests/DoctrineORMModuleTest/Service/EntityResolverFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/EntityResolverFactoryTest.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModuleTest\Service;
 
+use Doctrine\ORM\Events;
 use DoctrineORMModuleTest\Framework\TestCase as TestCase;
 
 class EntityResolverFactoryTest extends TestCase
@@ -30,5 +31,13 @@ class EntityResolverFactoryTest extends TestCase
         $meta          = $classMetadata->associationMappings;
 
         $this->assertSame('DoctrineORMModuleTest\Assets\Entity\TargetEntity', $meta['target']['targetEntity']);
+    }
+
+    public function testAssertSubscriberIsAdded()
+    {
+        $evm = $this->getEntityManager()->getEventManager();
+
+        $this->assertTrue($evm->hasListeners(Events::loadClassMetadata));
+        $this->assertTrue($evm->hasListeners(Events::onClassMetadataNotFound));
     }
 }


### PR DESCRIPTION
Fix #370

The minimum stability has been set to alpha until Doctrine 2.5 is officially released (I think we'll be able to do that once tagging).