### PR TITLE
Allow to set file lock for SLC

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,11 +214,11 @@ public function getServiceConfig()
     'configuration' => array(
         'orm_default' => array(
             'second_level_cache' => array(
-                'enabled'               => true,
-                'default_lifetime'      => 3600,
-                'default_lock_lifetime' => 60,
-
-                'regions'               => array(
+                'enabled'                        => true,
+                'default_lifetime'               => 3600,
+                'default_lock_lifetime'          => 60,
+                'set_file_lock_region_directory' => __DIR__ . '/../my_dir',
+                'regions'                        => array(
                     'My\Region\Name' => array(
                         'lifetime'      => 20,
                         'lock_lifetime' => 200

--- a/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
+++ b/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
@@ -40,6 +40,13 @@ class SecondLevelCacheConfiguration extends AbstractOptions
     protected $defaultLockLifetime = 60;
 
     /**
+     * The file lock region directory (needed for some cache usage)
+     *
+     * @var string
+     */
+    protected $fileLockRegionDirectory = '';
+
+    /**
      * Configure the lifetime and lock lifetime per region. You must pass an associative array like this:
      *
      * array(
@@ -96,6 +103,22 @@ class SecondLevelCacheConfiguration extends AbstractOptions
     public function getDefaultLockLifetime()
     {
         return $this->defaultLockLifetime;
+    }
+
+    /**
+     * @param string $fileLockRegionDirectory
+     */
+    public function setFileLockRegionDirectory($fileLockRegionDirectory)
+    {
+        $this->fileLockRegionDirectory = (string) $fileLockRegionDirectory;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileLockRegionDirectory()
+    {
+        return $this->fileLockRegionDirectory;
     }
 
     /**

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -126,6 +126,7 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
 
                 // As Second Level Cache caches queries results, we reuse the result cache impl
                 $cacheFactory = new DefaultCacheFactory($regionsConfig, $config->getResultCacheImpl());
+                $cacheFactory->setFileLockRegionDirectory($secondLevelCache->getFileLockRegionDirectory());
 
                 $cacheConfiguration = new CacheConfiguration();
                 $cacheConfiguration->setCacheFactory($cacheFactory);

--- a/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
@@ -274,9 +274,10 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                         'result_cache' => 'array',
 
                         'second_level_cache' => array(
-                            'enabled'               => true,
-                            'default_lifetime'      => 200,
-                            'default_lock_lifetime' => 500,
+                            'enabled'                    => true,
+                            'default_lifetime'           => 200,
+                            'default_lock_lifetime'      => 500,
+                            'file_lock_region_directory' => 'my_dir',
 
                             'regions' => array(
                                 'my_first_region' => array(
@@ -304,6 +305,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
         $cacheFactory = $secondLevelCache->getCacheFactory();
         $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultCacheFactory', $cacheFactory);
+        $this->assertEquals('my_dir', $cacheFactory->getFileLockRegionDirectory());
 
         $regionsConfiguration = $secondLevelCache->getRegionsConfiguration();
         $this->assertEquals(200, $regionsConfiguration->getDefaultLifetime());


### PR DESCRIPTION
This addresses a missing option when using cache regions that need a file lock. (https://github.com/doctrine/doctrine2/pull/580)