### PR TITLE
Allow symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "zendframework/zend-stdlib":         "~2.3",
         "zendframework/zend-mvc":            "~2.3",
         "zendframework/zend-servicemanager": "~2.3",
-        "symfony/console":                   "~2.5"
+        "symfony/console":                   "~2.5|~3.0"
     },
     "require-dev":       {
         "zendframework/zendframework":        "~2.3",


### PR DESCRIPTION
Tests should tell if any deprecated interfaces of Symfony are used. If not, then the bundle is defacto compatible with 3.0