### PR TITLE
Delete Module.php in root directory

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -1,6 +1,0 @@
-<?php
-/**
- * This file is placed here for compatibility with ZendFramework 2's ModuleManager.
- * The original Module.php is in 'src/DoctrineORMModule' in order to respect PSR-0
- */
-require_once __DIR__ . '/src/DoctrineORMModule/Module.php';


### PR DESCRIPTION
I hope I don't missunderstand of https://github.com/doctrine/DoctrineORMModule/pull/388#issuecomment-76683250 As if there is no Module::getAutoloaderConfig() , we can't work without composer /cc @Ocramius ;) 