### PR TITLE
travis: PHP 5.6, 7.0 nightly added, 5.3 dropped

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
   - hhvm
 
 matrix:
   allow_failures:
+    - php: 7.0
     - php: hhvm
 
 before_script:
@@ -15,9 +17,9 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/clover.xml
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php build/coverage-checker.php build/clover.xml 70; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != '5.3' ]; then ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/; fi"
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ]; then php build/coverage-checker.php build/clover.xml 70; fi
+  - if [ $TRAVIS_PHP_VERSION != '5.3' ]; then ./vendor/bin/phpcs --standard=PSR2 ./src/ ./tests/; fi
 
 after_script:
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover ./build/clover.xml; fi"
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ $TRAVIS_PHP_VERSION != 'hhvm' ]; then php ocular.phar code-coverage:upload --format=php-clover ./build/clover.xml; fi


### PR DESCRIPTION
To be compatible with [version in composer.json](https://github.com/doctrine/DoctrineORMModule/blob/51c64bfc5a87148379a03139e0c986c09c81d6af/composer.json#L36)

Bash syntax cleanup

Next idea: running coverage only once? 