### PR TITLE
Composer - update for stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "zendframework/zendframework":        "dev-develop",
         "doctrine/data-fixtures":             "1.0.*",
         "zendframework/zend-developer-tools": "*",
-        "doctrine/migrations":                "dev-master",
+        "doctrine/migrations":                "1.0.*@dev",
         "phpunit/phpunit":                    "~3.7",
         "squizlabs/php_codesniffer":          "1.5.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -31,22 +31,21 @@
             "email": "guilhermeblanco@hotmail.com"
         }
     ],
-    "minimum-stability": "alpha",
     "require":           {
         "php":                               ">=5.4",
-        "doctrine/doctrine-module":          "0.9.*",
-        "doctrine/orm":                      ">=2.4,<2.7-dev",
-        "doctrine/dbal":                     ">=2.4,<2.7-dev",
-        "zendframework/zend-stdlib":         "~2.3",
-        "zendframework/zend-mvc":            "~2.3",
-        "zendframework/zend-servicemanager": "~2.3",
+        "doctrine/doctrine-module":          "~0.8.0",
+        "doctrine/orm":                      ">=2.4,<2.7",
+        "doctrine/dbal":                     ">=2.4,<2.7",
+        "zendframework/zend-stdlib":         "~2.3|~2.4",
+        "zendframework/zend-mvc":            "~2.3|~2.4",
+        "zendframework/zend-servicemanager": "~2.3|~2.4",
         "symfony/console":                   "~2.5|~3.0"
     },
     "require-dev":       {
-        "zendframework/zendframework":        "~2.3",
+        "zendframework/zendframework":        "dev-develop",
         "doctrine/data-fixtures":             "1.0.*",
         "zendframework/zend-developer-tools": "*",
-        "doctrine/migrations":                "1.*",
+        "doctrine/migrations":                "dev-master",
         "phpunit/phpunit":                    "~3.7",
         "squizlabs/php_codesniffer":          "1.5.*"
     },
@@ -55,15 +54,9 @@
         "zendframework/zend-developer-tools": "zend-developer-tools if you want to profile operations executed by the ORM during development",
         "doctrine/migrations":                "doctrine migrations if you want to keep your schema definitions versioned"
     },
-    "minimum-stability": "dev",
     "autoload":          {
         "psr-0": {
             "DoctrineORMModule\\": "src/"
-        }
-    },
-    "extra":             {
-        "branch-alias": {
-            "dev-master": "0.9.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,16 +33,16 @@
     ],
     "require":           {
         "php":                               ">=5.4",
-        "doctrine/doctrine-module":          "~0.8.0",
+        "doctrine/doctrine-module":          ">=0.8",
         "doctrine/orm":                      ">=2.4,<2.7",
         "doctrine/dbal":                     ">=2.4,<2.7",
-        "zendframework/zend-stdlib":         "~2.3|~2.4",
-        "zendframework/zend-mvc":            "~2.3|~2.4",
-        "zendframework/zend-servicemanager": "~2.3|~2.4",
+        "zendframework/zend-stdlib":         "~2.3",
+        "zendframework/zend-mvc":            "~2.3",
+        "zendframework/zend-servicemanager": "~2.3",
         "symfony/console":                   "~2.5|~3.0"
     },
     "require-dev":       {
-        "zendframework/zendframework":        "dev-develop",
+        "zendframework/zendframework":        "~2.3",
         "doctrine/data-fixtures":             "1.0.*",
         "zendframework/zend-developer-tools": "*",
         "doctrine/migrations":                "1.0.*@dev",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     ],
     "require":           {
         "php":                               ">=5.4",
-        "doctrine/doctrine-module":          ">=0.8",
+        "doctrine/doctrine-module":          "~0.8",
         "doctrine/orm":                      ">=2.4,<2.7",
         "doctrine/dbal":                     ">=2.4,<2.7",
         "zendframework/zend-stdlib":         "~2.3",


### PR DESCRIPTION
# Stable dependencies

I'm working to push out of door the first stable release of this module.
In my opinion this is a good starting point to work with stable dependencies.
## Zend Framework 2.3 and 2.4

In this moment we will support this two version of Zend Framework. But we work in dev-develop during developer env becuase we look the future :smile: 
## Minimum stabiliy

Bye `alpha` and `develop` this module will be stable :+1: 
