### PR TITLE
Doctrine\Migrations require dialog helper

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -29,6 +29,7 @@ use Symfony\Component\Console\Helper\QuestionHelper;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
 use Zend\Stdlib\ArrayUtils;
+use Symfony\Component\Console\Helper\DialogHelper;
 
 /**
  * Base module for Doctrine ORM.
@@ -142,5 +143,8 @@ class Module implements
         $helperSet->set(new QuestionHelper(), 'question');
         $helperSet->set(new ConnectionHelper($entityManager->getConnection()), 'db');
         $helperSet->set(new EntityManagerHelper($entityManager), 'em');
+        if (class_exists('Doctrine\\DBAL\\Migrations\\Version')) {
+            $helperSet->set(new DialogHelper(), 'dialog');
+        }
     }
 }


### PR DESCRIPTION
Reference [#398-issuecomment-95072327](https://github.com/doctrine/DoctrineORMModule/pull/398#issuecomment-95072327) 
## Problem

In this moment we don't manage a dialog helper for doctrine\migrations component.
This Helper is deprecated but doctrine/migrations use it now.

ping @lastzero for feedback :)
