### PR TITLE
Changelog release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Release 0.9.0
+
+* [#199](https://github.com/doctrine/DoctrineORMModule/pull/199) Add 'entity_listener_resolver' config key
+* [#281](https://github.com/doctrine/DoctrineORMModule/pull/281) Forced failing unit test for #247
+* [#306](https://github.com/doctrine/DoctrineORMModule/pull/306) Removing PHP 5.3.3 support
+* [#272](https://github.com/doctrine/DoctrineORMModule/pull/272) Fix and test #270, #242, #285
+* [#311](https://github.com/doctrine/DoctrineORMModule/pull/311) remove unused statement
+* [#326](https://github.com/doctrine/DoctrineORMModule/pull/326) Highlight only uppercase words
+* [#329](https://github.com/doctrine/DoctrineORMModule/pull/329) remove unused statements
+* [#328](https://github.com/doctrine/DoctrineORMModule/pull/328) wrong var assignment
+* [#313](https://github.com/doctrine/DoctrineORMModule/pull/313) Prevent overriding of type
+* [#338](https://github.com/doctrine/DoctrineORMModule/pull/338) order the classes
+* [#346](https://github.com/doctrine/DoctrineORMModule/pull/346) Corrected a typo in a comment to better clarify
+* [#357](https://github.com/doctrine/DoctrineORMModule/pull/357) Modify sql_logger_collector class factory
+* [#360](https://github.com/doctrine/DoctrineORMModule/pull/360) Add example for entity_resolver
+* [#359](https://github.com/doctrine/DoctrineORMModule/pull/359) Update deprecated dialog console helper
+* [#363](https://github.com/doctrine/DoctrineORMModule/pull/363) Prevent Zend\Form\Element\File types inherit of StringLength validator...
+* [#365](https://github.com/doctrine/DoctrineORMModule/pull/365) Re-enable scrutinizer code coverage
+* [#373](https://github.com/doctrine/DoctrineORMModule/pull/373) Add doc for cache
+* [#347](https://github.com/doctrine/DoctrineORMModule/pull/347) added extra check in handleRequiredField
+* [#377](https://github.com/doctrine/DoctrineORMModule/pull/377) fix docblocks
+* [#376](https://github.com/doctrine/DoctrineORMModule/pull/376) Add latest migrations command
+* [#375](https://github.com/doctrine/DoctrineORMModule/pull/375) Default repository
+* [#374](https://github.com/doctrine/DoctrineORMModule/pull/374) Use `ResolveTargetEntityListener` as an event subscriber when supported
+* [#318](https://github.com/doctrine/DoctrineORMModule/pull/318) Add support for second level cache
+* [#378](https://github.com/doctrine/DoctrineORMModule/pull/378) Allow to set file lock for SLC
+* [#380](https://github.com/doctrine/DoctrineORMModule/pull/380) Fix typo in configuration file markdown.
+* [#385](https://github.com/doctrine/DoctrineORMModule/pull/385) Allow symfony 3.0 components
+* [#388](https://github.com/doctrine/DoctrineORMModule/pull/388) update comment block in Module.php as no Module::getAutoloaderConfig()
+* [#389](https://github.com/doctrine/DoctrineORMModule/pull/389) Delete Module.php in root directory
+* [#390](https://github.com/doctrine/DoctrineORMModule/pull/390) travis: PHP 5.6, 7.0 nightly added, 5.3 dropped
+* [#392](https://github.com/doctrine/DoctrineORMModule/pull/392) Use-case: caching module' s configuration
+* [#396](https://github.com/doctrine/DoctrineORMModule/pull/396) Removed unnecessary line in travis config
+* [#398](https://github.com/doctrine/DoctrineORMModule/pull/398) Composer * -update for stable version


### PR DESCRIPTION
ping @Ocramius 
pulls 400!!! :tada: :balloon: 

* [#199](https://github.com/doctrine/DoctrineORMModule/pull/199) Add 'entity_listener_resolver' config key
* [#281](https://github.com/doctrine/DoctrineORMModule/pull/281) Forced failing unit test for #247
* [#306](https://github.com/doctrine/DoctrineORMModule/pull/306) Removing PHP 5.3.3 support
* [#272](https://github.com/doctrine/DoctrineORMModule/pull/272) Fix and test #270, #242, #285
* [#311](https://github.com/doctrine/DoctrineORMModule/pull/311) remove unused statement
* [#326](https://github.com/doctrine/DoctrineORMModule/pull/326) Highlight only uppercase words
* [#329](https://github.com/doctrine/DoctrineORMModule/pull/329) remove unused statements
* [#328](https://github.com/doctrine/DoctrineORMModule/pull/328) wrong var assignment
* [#313](https://github.com/doctrine/DoctrineORMModule/pull/313) Prevent overriding of type
* [#338](https://github.com/doctrine/DoctrineORMModule/pull/338) order the classes
* [#346](https://github.com/doctrine/DoctrineORMModule/pull/346) Corrected a typo in a comment to better clarify
* [#357](https://github.com/doctrine/DoctrineORMModule/pull/357) Modify sql_logger_collector class factory
* [#360](https://github.com/doctrine/DoctrineORMModule/pull/360) Add example for entity_resolver
* [#359](https://github.com/doctrine/DoctrineORMModule/pull/359) Update deprecated dialog console helper
* [#363](https://github.com/doctrine/DoctrineORMModule/pull/363) Prevent Zend\Form\Element\File types inherit of StringLength validator...
* [#365](https://github.com/doctrine/DoctrineORMModule/pull/365) Re-enable scrutinizer code coverage
* [#373](https://github.com/doctrine/DoctrineORMModule/pull/373) Add doc for cache
* [#347](https://github.com/doctrine/DoctrineORMModule/pull/347) added extra check in handleRequiredField
* [#377](https://github.com/doctrine/DoctrineORMModule/pull/377) fix docblocks
* [#376](https://github.com/doctrine/DoctrineORMModule/pull/376) Add latest migrations command
* [#375](https://github.com/doctrine/DoctrineORMModule/pull/375) Default repository
* [#374](https://github.com/doctrine/DoctrineORMModule/pull/374) Use `ResolveTargetEntityListener` as an event subscriber when supported
* [#318](https://github.com/doctrine/DoctrineORMModule/pull/318) Add support for second level cache
* [#378](https://github.com/doctrine/DoctrineORMModule/pull/378) Allow to set file lock for SLC
* [#380](https://github.com/doctrine/DoctrineORMModule/pull/380) Fix typo in configuration file markdown.
* [#385](https://github.com/doctrine/DoctrineORMModule/pull/385) Allow symfony 3.0 components
* [#388](https://github.com/doctrine/DoctrineORMModule/pull/388) update comment block in Module.php as no Module::getAutoloaderConfig() 
* [#389](https://github.com/doctrine/DoctrineORMModule/pull/389) Delete Module.php in root directory
* [#390](https://github.com/doctrine/DoctrineORMModule/pull/390) travis: PHP 5.6, 7.0 nightly added, 5.3 dropped
* [#392](https://github.com/doctrine/DoctrineORMModule/pull/392) Use-case: caching module' s configuration
* [#396](https://github.com/doctrine/DoctrineORMModule/pull/396) Removed unnecessary line in travis config
* [#398](https://github.com/doctrine/DoctrineORMModule/pull/398) Composer * -update for stable version

@bakura10 :) WIP!