### PR TITLE
Bump some dependencies versions to be ZF 2.5 compliant

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "doctrine/data-fixtures":             "1.0.*",
         "zendframework/zend-developer-tools": "*",
         "doctrine/migrations":                "1.0.*@dev",
-        "phpunit/phpunit":                    "~3.7",
+        "phpunit/phpunit":                    "~4.0",
         "squizlabs/php_codesniffer":          "1.5.*"
     },
     "suggest":           {

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "zendframework/zend-developer-tools": "*",
         "doctrine/migrations":                "1.0.*@dev",
         "phpunit/phpunit":                    "~4.0",
-        "squizlabs/php_codesniffer":          "1.5.*"
+        "squizlabs/php_codesniffer":          "~2"
     },
     "suggest":           {
         "zendframework/zend-form":            "if you want to use form elements backed by Doctrine",

--- a/tests/DoctrineORMModuleTest/Assets/RepositoryClass.php
+++ b/tests/DoctrineORMModuleTest/Assets/RepositoryClass.php
@@ -19,7 +19,6 @@
 
 namespace DoctrineORMModuleTest\Assets;
 
-
 class RepositoryClass extends \Doctrine\ORM\EntityRepository
 {
 


### PR DESCRIPTION
Because of phpunit set to ~3.7, DoctrineORMModule was stuck to ZF 2.4.*
PHPCodeSniffer has been updated to ~2 too.
