### PR TITLE
metadatagrapher - fix diagram inconcistency

### DIFF
--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -114,8 +114,9 @@ class MetadataGrapher
             }
         } else {
             foreach ($class2->getAssociationNames() as $class2Side) {
+                $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
                 if ($class2->isAssociationInverseSide($class2Side)
-                    && ($association === $class2->getAssociationMappedByTargetField($class2Side))
+                    && ($class1->getName() == $targetClass->getName())
                 ) {
                     $class2SideName = $class2Side;
                     $class2Count    = $class2->isCollectionValuedAssociation($class2SideName) ? 2 : 1;


### PR DESCRIPTION
Hi, 

There was a little inconcistency in the yUML class diagram : when an entity had several entities refering to it with ManyToOne and with the same reference name => if these relations were both bidirectional and moodirectional, the link was not correct, refering on the monodirectional side, the relation of the other entity... 

more easy for me to explain with images : 
![bug](https://cloud.githubusercontent.com/assets/5521060/9565443/e195c9aa-4ecf-11e5-987d-42b528b7ac8a.png)

![bug fixed](https://cloud.githubusercontent.com/assets/5521060/9565445/eeb33d3e-4ecf-11e5-95a2-2fbfed24c49c.png)
