### PR TITLE
Medatagrapher fix

### DIFF
--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -106,9 +106,9 @@ class MetadataGrapher
         $bidirectional  = false;
 
         if ($isInverse) {
-            foreach ($class2->getAssociationNames() as $class2Side){
+            foreach ($class2->getAssociationNames() as $class2Side) {
                 $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
-                if ($class1->getName() == $targetClass->getName()){
+                if ($class1->getName() == $targetClass->getName()) {
                     $class2SideName = $class2Side;
                     break;
                 }

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -106,7 +106,13 @@ class MetadataGrapher
         $bidirectional  = false;
 
         if ($isInverse) {
-            $class2SideName = (string) $class1->getAssociationMappedByTargetField($association);
+            foreach($class2->getAssociationNames()as $class2Side){
+                $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
+                if ($class1->getName() == $targetClass->getName()){
+                    $class2SideName = $class2Side;
+                    break;
+                }
+            }
 
             if ($class2SideName) {
                 $class2Count    = $class2->isCollectionValuedAssociation($class2SideName) ? 2 : 1;
@@ -223,7 +229,7 @@ class MetadataGrapher
      */
     private function visitAssociation($className, $association = null)
     {
-        if (null === $association) {
+        if (!$association) {
             if (isset($this->visitedAssociations[$className])) {
                 return false;
             }

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -106,7 +106,7 @@ class MetadataGrapher
         $bidirectional  = false;
 
         if ($isInverse) {
-            foreach($class2->getAssociationNames()as $class2Side){
+            foreach ($class2->getAssociationNames() as $class2Side){
                 $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
                 if ($class1->getName() == $targetClass->getName()){
                     $class2SideName = $class2Side;

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -101,7 +101,7 @@ class MetadataGrapher
         }
 
         $class1SideName = $association;
-        $class2SideName = '';
+        $class2SideName = null;
         $class2Count    = 0;
         $bidirectional  = false;
 
@@ -229,7 +229,7 @@ class MetadataGrapher
      */
     private function visitAssociation($className, $association = null)
     {
-        if (!$association) {
+        if (null === $association) {
             if (isset($this->visitedAssociations[$className])) {
                 return false;
             }

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -43,6 +43,13 @@ class MetadataGrapher
     private $metadata;
 
     /**
+     * Temporary array where reverse association name are stored
+     *
+     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
+     */
+    private $classByNames = array();
+
+    /**
      * Generate a YUML compatible `dsl_text` to describe a given array
      * of entities
      *
@@ -85,6 +92,11 @@ class MetadataGrapher
         return implode(',', $str);
     }
 
+    /**
+     * @param ClassMetadata $class1
+     * @param string $association
+     * @return string
+     */
     private function getAssociationString(ClassMetadata $class1, $association)
     {
         $targetClassName = $class1->getAssociationTargetClass($association);
@@ -101,34 +113,17 @@ class MetadataGrapher
         }
 
         $class1SideName = $association;
-        $class2SideName = null;
+        $class2SideName = $this->getClassReverseAssociationName($class1, $class2);
         $class2Count    = 0;
         $bidirectional  = false;
 
-        if ($isInverse) {
-            foreach ($class2->getAssociationNames() as $class2Side) {
-                $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
-                if ($class1->getName() == $targetClass->getName()) {
-                    $class2SideName = $class2Side;
-                    break;
-                }
-            }
-
-            if ($class2SideName) {
+        if (null !== $class2SideName){
+            if ($isInverse){
                 $class2Count    = $class2->isCollectionValuedAssociation($class2SideName) ? 2 : 1;
                 $bidirectional  = true;
-            }
-        } else {
-            foreach ($class2->getAssociationNames() as $class2Side) {
-                $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
-                if ($class2->isAssociationInverseSide($class2Side)
-                    && ($class1->getName() == $targetClass->getName())
-                ) {
-                    $class2SideName = $class2Side;
-                    $class2Count    = $class2->isCollectionValuedAssociation($class2SideName) ? 2 : 1;
-                    $bidirectional  = true;
-                    break;
-                }
+            } elseif ($class2->isAssociationInverseSide($class2SideName)) {
+                $class2Count    = $class2->isCollectionValuedAssociation($class2SideName) ? 2 : 1;
+                $bidirectional  = true;
             }
         }
 
@@ -143,6 +138,23 @@ class MetadataGrapher
             . ($class1Count > 1 ? '*' : ($class1Count ? '1' : '')) // class1 side single/multi valued
             . (($bidirectional && $isInverse) ? '<>' : '>') // class1 side arrow
             . $this->getClassString($class2);
+    }
+
+    /**
+     * @param ClassMetadata $class1
+     * @param ClassMetadata $class2
+     * @return string|null
+     */
+    private function getClassReverseAssociationName(ClassMetadata $class1,  ClassMetadata $class2)
+    {
+        foreach ($class2->getAssociationNames() as $class2Side) {
+            $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
+            if ($class1->getName() === $targetClass->getName()) {
+                return $class2Side;
+            }
+        }
+
+        return null;
     }
 
     /**
@@ -192,13 +204,15 @@ class MetadataGrapher
      */
     private function getClassByName($className)
     {
-        foreach ($this->metadata as $class) {
-            if ($class->getName() === $className) {
-                return $class;
+        if (!isset($this->classByNames[$className])) {
+            foreach ($this->metadata as $class) {
+                if ($class->getName() === $className) {
+                    $this->classByNames[$className] = $class;
+                }
             }
         }
 
-        return null;
+        return isset($this->classByNames[$className])? $this->classByNames[$className]: null;
     }
 
     /**

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -208,6 +208,7 @@ class MetadataGrapher
             foreach ($this->metadata as $class) {
                 if ($class->getName() === $className) {
                     $this->classByNames[$className] = $class;
+                    break;
                 }
             }
         }

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -145,7 +145,7 @@ class MetadataGrapher
      * @param ClassMetadata $class2
      * @return string|null
      */
-    private function getClassReverseAssociationName(ClassMetadata $class1,  ClassMetadata $class2)
+    private function getClassReverseAssociationName(ClassMetadata $class1, ClassMetadata $class2)
     {
         foreach ($class2->getAssociationNames() as $class2Side) {
             $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -425,7 +425,14 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class3 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class3->expects($this->any())->method('getName')->will($this->returnValue('C'));
         $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
-        $class3->expects($this->any())->method('getAssociationTargetClass')->with($this->logicalOr($this->equalTo('b'),$this->equalTo('c')))->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
+        $class3
+            ->expects($this->any())
+            ->method('getAssociationTargetClass')
+            ->with($this->logicalOr(
+            $this->equalTo('b'),
+            $this->equalTo('c'))
+            )
+            ->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
         $class3->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -428,10 +428,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class3
             ->expects($this->any())
             ->method('getAssociationTargetClass')
-            ->with($this->logicalOr(
-            $this->equalTo('b'),
-            $this->equalTo('c'))
-            )
+            ->with($this->logicalOr($this->equalTo('b'), $this->equalTo('c')))
             ->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
         $class3->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -403,8 +403,23 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
+     * @dataProvider injectMultipleRelationsWithBothBiAndMonoDirectional
      */
-    public function testBugTestCaseFix()
+    public function testDrawMultipleClassRelatedBothBiAndMonoDirectional($class1, $class2, $class3, $expected)
+    {
+        $this->assertSame(
+            $expected,
+            $this->grapher->generateFromMetadata(array($class1, $class2,$class3))
+        );
+    }
+
+    /**
+     * dataProvider to inject classes in every order possible into the test
+     *     testDrawMultipleClassRelatedBothBiAndMonoDirectional
+     *
+     * @return array
+     */
+    public function injectMultipleRelationsWithBothBiAndMonoDirectional()
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
@@ -434,29 +449,13 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
 
-        $this->assertSame(
-            '[A]-c 1>[C],[B]<>b *-c 1>[C]',
-            $this->grapher->generateFromMetadata(array($class1, $class2,$class3))
-        );
-        $this->assertSame(
-            '[A]-c 1>[C],[C]<c 1-b *<>[B]',
-            $this->grapher->generateFromMetadata(array($class1, $class3,$class2))
-        );
-        $this->assertSame(
-            '[B]<>b *-c 1>[C],[A]-c 1>[C]',
-            $this->grapher->generateFromMetadata(array($class2, $class1,$class3))
-        );
-        $this->assertSame(
-            '[B]<>b *-c 1>[C],[A]-c 1>[C]',
-            $this->grapher->generateFromMetadata(array($class2, $class3,$class1))
-        );
-        $this->assertSame(
-            '[C]<c 1-b *<>[B],[A]-c 1>[C]',
-            $this->grapher->generateFromMetadata(array($class3, $class1,$class2))
-        );
-        $this->assertSame(
-            '[C]<c 1-b *<>[B],[A]-c 1>[C]',
-            $this->grapher->generateFromMetadata(array($class3, $class2,$class1))
+        return array(
+            array($class1, $class2, $class3, '[A]-c 1>[C],[B]<>b *-c 1>[C]'),
+            array($class1, $class3, $class2, '[A]-c 1>[C],[C]<c 1-b *<>[B]'),
+            array($class2, $class1, $class3, '[B]<>b *-c 1>[C],[A]-c 1>[C]'),
+            array($class2, $class3, $class1, '[B]<>b *-c 1>[C],[A]-c 1>[C]'),
+            array($class3, $class1, $class2, '[C]<c 1-b *<>[B],[A]-c 1>[C]'),
+            array($class3, $class2, $class1, '[C]<c 1-b *<>[B],[A]-c 1>[C]')
         );
     }
 

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -425,13 +425,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class3 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class3->expects($this->any())->method('getName')->will($this->returnValue('C'));
         $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
-        $class3
-            ->expects($this->any())
-            ->method('getAssociationTargetClass')
-            ->with($this->logicalOr(
-                $this->equalTo('b'),
-                $this->equalTo('c')))
-            ->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
+        $class3->expects($this->any())->method('getAssociationTargetClass')->with($this->logicalOr($this->equalTo('b'),$this->equalTo('c')))->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
         $class3->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -400,4 +400,76 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
             $this->grapher->generateFromMetadata(array($class1, $class2))
         );
     }
+
+    /**
+     * @covers \DoctrineORMModule\Yuml\MetadataGrapher
+     */
+    public function testBugTestCaseFix()
+    {
+        $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('c')));
+        $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
+        $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
+        $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+
+        $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('c')));
+        $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
+        $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
+        $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+
+        $class3 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
+        $class3->expects($this->any())->method('getName')->will($this->returnValue('C'));
+        $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class3
+            ->expects($this->any())
+            ->method('getAssociationTargetClass')
+            ->with($this->logicalOr(
+                $this->equalTo('b'),
+                $this->equalTo('c')))
+            ->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
+        $class3->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
+        $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
+        $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+
+        $this->assertSame(
+            '[A]-c 1>[C],[B]<>b *-c 1>[C]',
+            $this->grapher->generateFromMetadata(array($class1, $class2,$class3))
+        );
+        $this->assertSame(
+            '[A]-c 1>[C],[C]<c 1-b *<>[B]',
+            $this->grapher->generateFromMetadata(array($class1, $class3,$class2))
+        );
+        $this->assertSame(
+            '[B]<>b *-c 1>[C],[A]-c 1>[C]',
+            $this->grapher->generateFromMetadata(array($class2, $class1,$class3))
+        );
+        $this->assertSame(
+            '[B]<>b *-c 1>[C],[A]-c 1>[C]',
+            $this->grapher->generateFromMetadata(array($class2, $class3,$class1))
+        );
+        $this->assertSame(
+            '[C]<c 1-b *<>[B],[A]-c 1>[C]',
+            $this->grapher->generateFromMetadata(array($class3, $class1,$class2))
+        );
+        $this->assertSame(
+            '[C]<c 1-b *<>[B],[A]-c 1>[C]',
+            $this->grapher->generateFromMetadata(array($class3, $class2,$class1))
+        );
+    }
+
+    /**
+     * To mock getAssociationTargetClass method with args
+     *
+     * @param  string $a
+     * @return string
+     */
+    public function getAssociationTargetClassMock($a)
+    {
+        return strtoupper($a);
+    }
 }


### PR DESCRIPTION
Hi Ocramius,

Well... after My last pull request, I created the test as you asked... and the testCase found another bug :) 
=> depending of metadata's order, there was another inconcistency : 
If the inversed side associations were visited first, we had a double arrow for the relation...

Fixed it too :)


I must tell you that I took inspiration from your YumlController to create a Symfony bundle... I Missed yUML diagram so much when I started using Doctrine with CodeIgniter (first) and now with Symfony....

https://packagist.org/packages/onurb/doctrine-yuml-bundle

I first reused in my bundle your MetadataGrapher class as is (only changed the namespace) : I didn't want to load DoctrineORMModule and all its dependencies for only one class !... (the only problem for me is now to write code twice to push you my fixes ;) )

I think it's fair to inform you that you're work has been reused :)

Thank's Marco for you're work on Doctrine (and all the rest of the team of course)... I just love this library !.

Bruno.