### PR TITLE
Option to set the DC2Type- Comment on custom types

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,20 @@ return array(
 ),
 ```
 
+### Option to set the doctrine type comment (DC2Type:myType) for custom types
+
+```php
+'doctrine' => array(
+    'connection' => array(
+        'orm_default' => array(
+            'doctrineCommentedTypes' => array(
+                'mytype'
+            ),
+        ),
+    ),
+),
+```
+
 ### How to Define Relationships with Abstract Classes and Interfaces (ResolveTargetEntityListener)
 
 ```php

--- a/src/DoctrineORMModule/Options/DBALConnection.php
+++ b/src/DoctrineORMModule/Options/DBALConnection.php
@@ -85,6 +85,11 @@ class DBALConnection extends AbstractOptions
     protected $doctrineTypeMappings = array();
 
     /**
+     * @var array
+     */
+    protected $doctrineCommentedTypes = array();
+
+    /**
      * @param string $configuration
      */
     public function setConfiguration($configuration)
@@ -150,6 +155,24 @@ class DBALConnection extends AbstractOptions
     public function getDoctrineTypeMappings()
     {
         return $this->doctrineTypeMappings;
+    }
+
+    /**
+     * @param  array                                     $doctrineCommentedTypes
+     * @return \DoctrineORMModule\Options\DBALConnection
+     */
+    public function setDoctrineCommentedTypes($doctrineCommentedTypes)
+    {
+        $this->doctrineCommentedTypes = (array) $doctrineCommentedTypes;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDoctrineCommentedTypes()
+    {
+        return $this->doctrineCommentedTypes;
     }
 
     /**

--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -20,6 +20,7 @@
 namespace DoctrineORMModule\Service;
 
 use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Types\Type;
 use DoctrineModule\Service\AbstractFactory;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -60,6 +61,9 @@ class DBALConnectionFactory extends AbstractFactory
         $platform = $connection->getDatabasePlatform();
         foreach ($options->getDoctrineTypeMappings() as $dbType => $doctrineType) {
             $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
+        }
+        foreach ($options->getDoctrineCommentedTypes() as $type) {
+            $platform->markDoctrineTypeCommented(Type::getType($type));
         }
 
         return $connection;


### PR DESCRIPTION
Added a a new option to mark types as commented. 
It will create the comment (DC2Type:point) on custom types.

Inspired by \Doctrine\Bundle\DoctrineBundle\ConnectionFactory

Config example:

``` php
return array(
    'doctrine' => array(
        'connection' => array(
            'orm_default' => array(
                'doctrineTypeMappings' => array(
                    'point' => 'string',
                ),
                'doctrineCommentedTypes' => array(
                    'point'
                ),
            ),
        ),
        'configuration' => array(
            'orm_default' => array(
                'types' => array(
                    'point' => '\MyNamespace\PointType',
                ),
            ),
        ),
    ),
);
```
