### PR TITLE
[WIP] Moving away from array_map due to error supression

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -133,8 +133,10 @@ class Module implements
                 )
             );
         }
-
-        $cli->addCommands(array_map(array($serviceLocator, 'get'), $commands));
+        
+        foreach($commands as $command) {
+            $cli->add($serviceLocator->get($command));
+        }
 
         /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $serviceLocator->get('doctrine.entitymanager.orm_default');


### PR DESCRIPTION
Due to this bug/feature in php: https://bugs.php.net/bug.php?id=55416

The error message you get is:
`An error occurred while invoking the map callback in Module.php on line 137`

Which is really just not useful or helpful. By switching to the foreach() then normal exception handling and backtrace output can resume.