### PR TITLE
Removed driver reference on multiple db configurations tutorial

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,7 +118,6 @@ return array(
                 'query_cache'       => 'array',
                 'result_cache'      => 'array',
                 'hydration_cache'   => 'array',
-                'driver'            => 'orm_crawler',
                 'generate_proxies'  => true,
                 'proxy_dir'         => 'data/DoctrineORMModule/Proxy',
                 'proxy_namespace'   => 'DoctrineORMModule\Proxy',


### PR DESCRIPTION
I removed this setting because it was causing errors on my application following the tutorial as specified.
It seems to me a typo error given that driver information reside on other entries.

I was getting the following error.

```
Using php 7.0.1
Using phpunit
PHPUnit 5.1.3 by Sebastian Bergmann and contributors.

E                                                                   1 / 1 (100%)

Time: 352 ms, Memory: 16.00Mb

There was 1 error:

1) FiscalTest\Service\TestTest::testTest
Zend\ServiceManager\Exception\ServiceNotCreatedException: An exception was raised while creating "FiscalEntityManager"; no instance returned

/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:946
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/module/Fiscal/tests/src/FiscalTest/Service/TestTest.php:14

Caused by
Zend\ServiceManager\Exception\ServiceNotCreatedException: An exception was raised while creating "doctrine.configuration.orm_fiscal"; no instance returned

/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:946
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-orm-module/src/DoctrineORMModule/Service/EntityManagerFactory.php:37
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:939
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/module/Fiscal/tests/src/FiscalTest/Service/TestTest.php:14

Caused by
Zend\ServiceManager\Exception\ServiceNotCreatedException: An exception was raised while creating "doctrine.driver.orm_fiscal"; no instance returned

/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:946
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-orm-module/src/DoctrineORMModule/Service/ConfigurationFactory.php:71
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:939
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-orm-module/src/DoctrineORMModule/Service/EntityManagerFactory.php:37
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:939
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/module/Fiscal/tests/src/FiscalTest/Service/TestTest.php:14

Caused by
InvalidArgumentException: Drivers must specify a class

/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-module/src/DoctrineModule/Service/DriverFactory.php:72
/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-module/src/DoctrineModule/Service/DriverFactory.php:50
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:939
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-orm-module/src/DoctrineORMModule/Service/ConfigurationFactory.php:71
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:939
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/vendor/doctrine/doctrine-orm-module/src/DoctrineORMModule/Service/EntityManagerFactory.php:37
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:939
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:1097
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:638
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:598
/home/jean/projects/compufacil/Backend/vendor/zendframework/zend-servicemanager/src/ServiceManager.php:530
/home/jean/projects/compufacil/Backend/module/Fiscal/tests/src/FiscalTest/Service/TestTest.php:14

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.

```