### PR TITLE
Up ZF to ^2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7

--- a/composer.json
+++ b/composer.json
@@ -32,17 +32,17 @@
         }
     ],
     "require":           {
-        "php":                               ">=5.4",
-        "doctrine/doctrine-module":          "~0.8",
+        "php":                               ">=5.5",
+        "doctrine/doctrine-module":          "^1.0",
         "doctrine/orm":                      ">=2.5,<2.7",
         "doctrine/dbal":                     ">=2.4,<2.7",
-        "zendframework/zend-stdlib":         "~2.3",
-        "zendframework/zend-mvc":            "~2.3",
-        "zendframework/zend-servicemanager": "~2.3",
+        "zendframework/zend-stdlib":         "^2.5",
+        "zendframework/zend-mvc":            "^2.5",
+        "zendframework/zend-servicemanager": "^2.5",
         "symfony/console":                   "~2.5|~3.0"
     },
     "require-dev":       {
-        "zendframework/zendframework":        "~2.3",
+        "zendframework/zendframework":        "^2.5",
         "doctrine/data-fixtures":             "1.0.*",
         "zendframework/zend-developer-tools": "*",
         "doctrine/migrations":                "1.0.*@dev",


### PR DESCRIPTION
In support of moving doctrine-module to zend-hydrator, this module cannot pin versions below 2.5

https://github.com/doctrine/DoctrineModule/pull/548