### PR TITLE
Fix: Use short array syntax

### DIFF
--- a/config/controllers.config.php
+++ b/config/controllers.config.php
@@ -22,8 +22,8 @@ use Zend\Http\Client;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
 
-return array(
-    'factories' => array(
+return [
+    'factories' => [
         // Yuml controller, used to generate Yuml graphs since
         // yuml.me doesn't do redirects on its own
         'DoctrineORMModule\\Yuml\\YumlController'  => function (AbstractPluginManager $pluginManager) {
@@ -38,8 +38,8 @@ return array(
             }
 
             return new YumlController(
-                new Client('http://yuml.me/diagram/plain/class/', array('timeout' => 30))
+                new Client('http://yuml.me/diagram/plain/class/', ['timeout' => 30])
             );
         },
-    ),
-);
+    ],
+];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -17,11 +17,11 @@
  * <http://www.doctrine-project.org>.
  */
 
-return array(
-    'doctrine' => array(
-        'connection' => array(
+return [
+    'doctrine' => [
+        'connection' => [
             // Configuration for service `doctrine.connection.orm_default` service
-            'orm_default' => array(
+            'orm_default' => [
                 // configuration instance to use. The retrieved service name will
                 // be `doctrine.configuration.$thisSetting`
                 'configuration' => 'orm_default',
@@ -32,21 +32,21 @@ return array(
 
                 // connection parameters, see
                 // http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html
-                'params' => array(
+                'params' => [
                     'host'     => 'localhost',
                     'port'     => '3306',
                     'user'     => 'username',
                     'password' => 'password',
                     'dbname'   => 'database',
-                )
-            ),
-        ),
+                ]
+            ],
+        ],
 
         // Configuration details for the ORM.
         // See http://docs.doctrine-project.org/en/latest/reference/configuration.html
-        'configuration' => array(
+        'configuration' => [
             // Configuration for service `doctrine.configuration.orm_default` service
-            'orm_default' => array(
+            'orm_default' => [
                 // metadata cache instance to use. The retrieved service name will
                 // be `doctrine.cache.$thisSetting`
                 'metadata_cache'    => 'array',
@@ -79,38 +79,38 @@ return array(
                 'proxy_namespace'   => 'DoctrineORMModule\Proxy',
 
                 // SQL filters. See http://docs.doctrine-project.org/en/latest/reference/filters.html
-                'filters'           => array(),
+                'filters'           => [],
 
                 // Custom DQL functions.
                 // You can grab common MySQL ones at https://github.com/beberlei/DoctrineExtensions
                 // Further docs at http://docs.doctrine-project.org/en/latest/cookbook/dql-user-defined-functions.html
-                'datetime_functions' => array(),
-                'string_functions' => array(),
-                'numeric_functions' => array(),
+                'datetime_functions' => [],
+                'string_functions' => [],
+                'numeric_functions' => [],
 
                 // Second level cache configuration (see doc to learn about configuration)
-                'second_level_cache' => array()
-            )
-        ),
+                'second_level_cache' => []
+            ]
+        ],
 
         // Metadata Mapping driver configuration
-        'driver' => array(
+        'driver' => [
             // Configuration for service `doctrine.driver.orm_default` service
-            'orm_default' => array(
+            'orm_default' => [
                 // By default, the ORM module uses a driver chain. This allows multiple
                 // modules to define their own entities
                 'class'   => 'Doctrine\ORM\Mapping\Driver\DriverChain',
 
                 // Map of driver names to be used within this driver chain, indexed by
                 // entity namespace
-                'drivers' => array()
-            )
-        ),
+                'drivers' => []
+            ]
+        ],
 
         // Entity Manager instantiation settings
-        'entitymanager' => array(
+        'entitymanager' => [
             // configuration for the `doctrine.entitymanager.orm_default` service
-            'orm_default' => array(
+            'orm_default' => [
                 // connection instance to use. The retrieved service name will
                 // be `doctrine.connection.$thisSetting`
                 'connection'    => 'orm_default',
@@ -118,78 +118,78 @@ return array(
                 // configuration instance to use. The retrieved service name will
                 // be `doctrine.configuration.$thisSetting`
                 'configuration' => 'orm_default'
-            )
-        ),
+            ]
+        ],
 
-        'eventmanager' => array(
+        'eventmanager' => [
             // configuration for the `doctrine.eventmanager.orm_default` service
-            'orm_default' => array()
-        ),
+            'orm_default' => []
+        ],
 
         // SQL logger collector, used when ZendDeveloperTools and its toolbar are active
-        'sql_logger_collector' => array(
+        'sql_logger_collector' => [
             // configuration for the `doctrine.sql_logger_collector.orm_default` service
-            'orm_default' => array(),
-        ),
+            'orm_default' => [],
+        ],
 
         // mappings collector, used when ZendDeveloperTools and its toolbar are active
-        'mapping_collector' => array(
+        'mapping_collector' => [
             // configuration for the `doctrine.sql_logger_collector.orm_default` service
-            'orm_default' => array(),
-        ),
+            'orm_default' => [],
+        ],
 
         // form annotation builder configuration
-        'formannotationbuilder' => array(
+        'formannotationbuilder' => [
             // Configuration for service `doctrine.formannotationbuilder.orm_default` service
-            'orm_default' => array(),
-        ),
+            'orm_default' => [],
+        ],
 
         // entity resolver configuration, allows mapping associations to interfaces
-        'entity_resolver' => array(
+        'entity_resolver' => [
             // configuration for the `doctrine.entity_resolver.orm_default` service
-            'orm_default' => array()
-        ),
+            'orm_default' => []
+        ],
 
         // authentication service configuration
-        'authentication' => array(
+        'authentication' => [
             // configuration for the `doctrine.authentication.orm_default` authentication service
-            'orm_default' => array(
+            'orm_default' => [
                 // name of the object manager to use. By default, the EntityManager is used
                 'objectManager' => 'doctrine.entitymanager.orm_default',
                 //'identityClass' => 'Application\Model\User',
                 //'identityProperty' => 'username',
                 //'credentialProperty' => 'password'
-            ),
-        ),
+            ],
+        ],
 
         // migrations configuration
-        'migrations_configuration' => array(
-            'orm_default' => array(
+        'migrations_configuration' => [
+            'orm_default' => [
                 'directory' => 'data/DoctrineORMModule/Migrations',
                 'name'      => 'Doctrine Database Migrations',
                 'namespace' => 'DoctrineORMModule\Migrations',
                 'table'     => 'migrations',
                 'column'    => 'version',
-            ),
-        ),
+            ],
+        ],
 
         // migrations commands base config
-        'migrations_cmd' => array(
-            'generate' => array(),
-            'execute'  => array(),
-            'migrate'  => array(),
-            'status'   => array(),
-            'version'  => array(),
-            'diff'     => array(),
-            'latest'   => array()
-        ),
-    ),
+        'migrations_cmd' => [
+            'generate' => [],
+            'execute'  => [],
+            'migrate'  => [],
+            'status'   => [],
+            'version'  => [],
+            'diff'     => [],
+            'latest'   => []
+        ],
+    ],
 
-    'service_manager' => array(
-        'factories' => array(
+    'service_manager' => [
+        'factories' => [
             'Doctrine\ORM\EntityManager' => 'DoctrineORMModule\Service\EntityManagerAliasCompatFactory',
-        ),
-        'invokables' => array(
+        ],
+        'invokables' => [
             // DBAL commands
             'doctrine.dbal_cmd.runsql' => '\Doctrine\DBAL\Tools\Console\Command\RunSqlCommand',
             'doctrine.dbal_cmd.import' => '\Doctrine\DBAL\Tools\Console\Command\ImportCommand',
@@ -211,12 +211,12 @@ return array(
                 => '\Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand',
             'doctrine.orm_cmd.generate_repositories'
                 => '\Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand',
-        ),
-    ),
+        ],
+    ],
 
     // Factory mappings - used to define which factory to use to instantiate a particular doctrine
     // service type
-    'doctrine_factories' => array(
+    'doctrine_factories' => [
         'connection'               => 'DoctrineORMModule\Service\DBALConnectionFactory',
         'configuration'            => 'DoctrineORMModule\Service\ConfigurationFactory',
         'entitymanager'            => 'DoctrineORMModule\Service\EntityManagerFactory',
@@ -226,27 +226,27 @@ return array(
         'formannotationbuilder'    => 'DoctrineORMModule\Service\FormAnnotationBuilderFactory',
         'migrations_configuration' => 'DoctrineORMModule\Service\MigrationsConfigurationFactory',
         'migrations_cmd'           => 'DoctrineORMModule\Service\MigrationsCommandFactory',
-    ),
+    ],
 
     // Zend\Form\FormElementManager configuration
-    'form_elements' => array(
-        'aliases' => array(
+    'form_elements' => [
+        'aliases' => [
             'objectselect'        => 'DoctrineModule\Form\Element\ObjectSelect',
             'objectradio'         => 'DoctrineModule\Form\Element\ObjectRadio',
             'objectmulticheckbox' => 'DoctrineModule\Form\Element\ObjectMultiCheckbox',
-        ),
-        'factories' => array(
+        ],
+        'factories' => [
             'DoctrineModule\Form\Element\ObjectSelect'        => 'DoctrineORMModule\Service\ObjectSelectFactory',
             'DoctrineModule\Form\Element\ObjectRadio'         => 'DoctrineORMModule\Service\ObjectRadioFactory',
             'DoctrineModule\Form\Element\ObjectMultiCheckbox' => 'DoctrineORMModule\Service\ObjectMultiCheckboxFactory',
-        ),
-    ),
+        ],
+    ],
 
-    'hydrators' => array(
-        'factories' => array(
+    'hydrators' => [
+        'factories' => [
             'DoctrineModule\Stdlib\Hydrator\DoctrineObject' => 'DoctrineORMModule\Service\DoctrineObjectHydratorFactory'
-        )
-    ),
+        ]
+    ],
 
     ////////////////////////////////////////////////////////////////////
     // `zendframework/zend-developer-tools` specific settings         //
@@ -254,42 +254,42 @@ return array(
     // zend developer tools                                           //
     ////////////////////////////////////////////////////////////////////
 
-    'router' => array(
-        'routes' => array(
-            'doctrine_orm_module_yuml' => array(
+    'router' => [
+        'routes' => [
+            'doctrine_orm_module_yuml' => [
                 'type' => 'Zend\\Mvc\\Router\\Http\\Literal',
-                'options' => array(
+                'options' => [
                     'route' => '/ocra_service_manager_yuml',
-                    'defaults' => array(
+                    'defaults' => [
                         'controller' => 'DoctrineORMModule\\Yuml\\YumlController',
                         'action'     => 'index',
-                    ),
-                ),
-            ),
-        ),
-    ),
+                    ],
+                ],
+            ],
+        ],
+    ],
 
-    'view_manager' => array(
-        'template_map' => array(
+    'view_manager' => [
+        'template_map' => [
             'zend-developer-tools/toolbar/doctrine-orm-queries'
                 => __DIR__ . '/../view/zend-developer-tools/toolbar/doctrine-orm-queries.phtml',
             'zend-developer-tools/toolbar/doctrine-orm-mappings'
                 => __DIR__ . '/../view/zend-developer-tools/toolbar/doctrine-orm-mappings.phtml',
-        ),
-    ),
+        ],
+    ],
 
-    'zenddevelopertools' => array(
-        'profiler' => array(
-            'collectors' => array(
+    'zenddevelopertools' => [
+        'profiler' => [
+            'collectors' => [
                 'doctrine.sql_logger_collector.orm_default' => 'doctrine.sql_logger_collector.orm_default',
                 'doctrine.mapping_collector.orm_default'    => 'doctrine.mapping_collector.orm_default',
-            ),
-        ),
-        'toolbar' => array(
-            'entries' => array(
+            ],
+        ],
+        'toolbar' => [
+            'entries' => [
                 'doctrine.sql_logger_collector.orm_default' => 'zend-developer-tools/toolbar/doctrine-orm-queries',
                 'doctrine.mapping_collector.orm_default'    => 'zend-developer-tools/toolbar/doctrine-orm-mappings',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];

--- a/docs/EXTRAS_ORM.md
+++ b/docs/EXTRAS_ORM.md
@@ -10,16 +10,16 @@ want to fine tune the results.
 
 ```php
 <?php
-$validator = new \DoctrineModule\Validator\NoObjectExists(array(
+$validator = new \DoctrineModule\Validator\NoObjectExists([
     // object repository to lookup
     'object_repository' => $serviceLocator->get('Doctrine\ORM\EntityManager')->getRepository('My\Entity\User'),
 
     // fields to match
-    'fields' => array('username'),
-));
+    'fields' => ['username'],
+]);
 
 // following works also with simple values if the number of fields to be matched is 1
-echo $validator->isValid(array('username' => 'test')) ? 'Valid' : 'Invalid! Duplicate found!';
+echo $validator->isValid(['username' => 'test']) ? 'Valid' : 'Invalid! Duplicate found!';
 ```
 
 ## Authentication adapter for Zend\Authentication
@@ -57,21 +57,21 @@ key in you configuration file:
 
 ```php
 <?php
-return array(
-    'doctrine' => array(
-        'configuration' => array(
-            'my_dbal_default' => array(
-                'types' => array(
+return [
+    'doctrine' => [
+        'configuration' => [
+            'my_dbal_default' => [
+                'types' => [
                     // You can override a default type
                     'date' => 'My\DBAL\Types\DateType',
 
                     // And set new ones
                     'tinyint' => 'My\DBAL\Types\TinyIntType',
-                ),
-            ),
-        ),
-    ),
-);
+                ],
+            ],
+        ],
+    ],
+];
 ```
 
 You are now able to use them, for example, in your ORM entities:
@@ -98,17 +98,17 @@ of TinyIntType you have to additionally register this mapping with your database
 
 ```php
 <?php
-return array(
-    'doctrine' => array(
-        'connection' => array(
-            'orm_default' => array(
-                'doctrine_type_mappings' => array(
+return [
+    'doctrine' => [
+        'connection' => [
+            'orm_default' => [
+                'doctrine_type_mappings' => [
                     'tinyint' => 'tinyint',
-                ),
-            ),
-        ),
-    ),
-);
+                ],
+            ],
+        ],
+    ],
+];
 ```
 
 Now using Schema-Tool, whenever it detects a column having the "tinyint" it will convert it into a "tinyint"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,134 +1,134 @@
 ### How to Register Custom DQL Functions
 
 ```php
-return array(
-    'doctrine' => array(
-        'configuration' => array(
-            'orm_default' => array(
-                'numeric_functions' => array(
+return [
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
+                'numeric_functions' => [
                     'ROUND' => 'path\to\my\query\round'
-                )
-            )
-        ),
-    ),
-);
+                ]
+            ]
+        ],
+    ],
+];
 ```
 
 ### How to register type mapping
 
 ```php
-return array(
-    'doctrine' => array(
-        'connection' => array(
-            'orm_default' => array(
-                'doctrine_type_mappings' => array(
+return [
+    'doctrine' => [
+        'connection' => [
+            'orm_default' => [
+                'doctrine_type_mappings' => [
                     'enum' => 'string'
-                ),
-            )
-        )
-    ),
-);
+                ],
+            ]
+        ]
+    ],
+];
 ```
 
 ### How to add new type
 
 ```php
-return array(
-    'doctrine' => array(
-        'configuration' => array(
-            'orm_default' => array(
-                'types' => array(
+return [
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
+                'types' => [
                     'mytype' => 'Application\Types\MyType'
-                )
-            )
-        ),
-    ),
-);
+                ]
+            ]
+        ],
+    ],
+];
 ```
 
 ```php
-return array(
-    'doctrine' => array(
-        'connection' => array(
-            'orm_default' => array(
-                'doctrine_type_mappings' => array(
+return [
+    'doctrine' => [
+        'connection' => [
+            'orm_default' => [
+                'doctrine_type_mappings' => [
                     'mytype' => 'mytype'
-                ),
-            )
-        ),
-    ),
-);
+                ],
+            ]
+        ],
+    ],
+];
 ```
 
 ### Option to set the doctrine type comment (DC2Type:myType) for custom types
 
 ```php
-return array(
-    'doctrine' => array(
-        'connection' => array(
-            'orm_default' => array(
-                'doctrineCommentedTypes' => array(
+return [
+    'doctrine' => [
+        'connection' => [
+            'orm_default' => [
+                'doctrineCommentedTypes' => [
                     'mytype'
-                ),
-            ),
-        ),
-    ),
-);
+                ],
+            ],
+        ],
+    ],
+];
 ```
 
 ### How to Define Relationships with Abstract Classes and Interfaces (ResolveTargetEntityListener)
 
 ```php
-return array(
-    'doctrine' => array(
-        'entity_resolver' => array(
-            'orm_default' => array(
-                'resolvers' => array(
+return [
+    'doctrine' => [
+        'entity_resolver' => [
+            'orm_default' => [
+                'resolvers' => [
                     'Acme\\InvoiceModule\\Model\\InvoiceSubjectInterface', 'Acme\\CustomerModule\\Entity\\Customer'
-                )
-            )
-        )
-    )
-);
+                ]
+            ]
+        ]
+    ]
+];
 ```
 
 ### Set a custom default repository
 
 ```php
-return array(
-    'doctrine' => array(
-        'configuration' => array(
-            'orm_default' => array(
+return [
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
                 'default_repository_class_name' => 'MyCustomRepository'
-            )
-        )
-    )
-);
+            ]
+        ]
+    ]
+];
 ```
 
 ### How to Use Two Connections
 
 ```php
-return array(
-    'doctrine' => array(
-            'connection' => array(
-                'orm_crawler' => array(
+return [
+    'doctrine' => [
+            'connection' => [
+                'orm_crawler' => [
                     'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
-                    'params' => array(
+                    'params' => [
                         'host'     => 'localhost',
                         'port'     => '3306',
                         'user'     => 'root',
                         'password' => 'root',
                         'dbname'   => 'crawler',
-                        'driverOptions' => array(
+                        'driverOptions' => [
                             1002 => 'SET NAMES utf8'
-                        ),
-                    )
-                )
-            ),
+                        ],
+                    ]
+                ]
+            ],
     
-            'configuration' => array(
-                'orm_crawler' => array(
+            'configuration' => [
+                'orm_crawler' => [
                     'metadata_cache'    => 'array',
                     'query_cache'       => 'array',
                     'result_cache'      => 'array',
@@ -137,56 +137,56 @@ return array(
                     'generate_proxies'  => true,
                     'proxy_dir'         => 'data/DoctrineORMModule/Proxy',
                     'proxy_namespace'   => 'DoctrineORMModule\Proxy',
-                    'filters'           => array()
-                )
-            ),
+                    'filters'           => []
+                ]
+            ],
     
-            'driver' => array(
-                'Crawler_Driver' => array(
+            'driver' => [
+                'Crawler_Driver' => [
                     'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
                     'cache' => 'array',
-                    'paths' => array(
+                    'paths' => [
                         __DIR__ . '/../src/Crawler/Entity'
-                    )
-                ),
-                'orm_crawler' => array(
+                    ]
+                ],
+                'orm_crawler' => [
                     'class'   => 'Doctrine\ORM\Mapping\Driver\DriverChain',
-                    'drivers' => array(
+                    'drivers' => [
                         'Crawler\Entity' =>  'Crawler_Driver'
-                    )
-                ),
-            ),
+                    ]
+                ],
+            ],
     
-            'entitymanager' => array(
-                'orm_crawler' => array(
+            'entitymanager' => [
+                'orm_crawler' => [
                     'connection'    => 'orm_crawler',
                     'configuration' => 'orm_crawler'
-                )
-            ),
+                ]
+            ],
     
-            'eventmanager' => array(
-                'orm_crawler' => array()
-            ),
+            'eventmanager' => [
+                'orm_crawler' => []
+            ],
     
-            'sql_logger_collector' => array(
-                'orm_crawler' => array(),
-            ),
+            'sql_logger_collector' => [
+                'orm_crawler' => [],
+            ],
     
-            'entity_resolver' => array(
-                'orm_crawler' => array()
-            ),
+            'entity_resolver' => [
+                'orm_crawler' => []
+            ],
     
-        ),
-    ),
-);
+        ],
+    ],
+];
 ```
 
 Module.php
 ```php
 public function getServiceConfig()
 {
-    return array(
-        'factories' => array(
+    return [
+        'factories' => [
             'doctrine.connection.orm_crawler'           => new \DoctrineORMModule\Service\DBALConnectionFactory('orm_crawler'),
             'doctrine.configuration.orm_crawler'        => new \DoctrineORMModule\Service\ConfigurationFactory('orm_crawler'),
             'doctrine.entitymanager.orm_crawler'        => new \DoctrineORMModule\Service\EntityManagerFactory('orm_crawler'),
@@ -199,8 +199,8 @@ public function getServiceConfig()
             'DoctrineORMModule\Form\Annotation\AnnotationBuilder' => function(\Zend\ServiceManager\ServiceLocatorInterface $sl) {
                 return new \DoctrineORMModule\Form\Annotation\AnnotationBuilder($sl->get('doctrine.entitymanager.orm_crawler'));
             },
-        ),
-    );
+        ],
+    ];
 }
 ```
 
@@ -211,20 +211,20 @@ public function getServiceConfig()
 Zend Configuration
 
 ```php
-return array(
-    'service_manager' => array(
-        'invokables' => array(
+return [
+    'service_manager' => [
+        'invokables' => [
             'Doctrine\ORM\Mapping\UnderscoreNamingStrategy' => 'Doctrine\ORM\Mapping\UnderscoreNamingStrategy',
-        ),
-    ),
-    'doctrine' => array(
-        'configuration' => array(
-            'orm_default' => array(
+        ],
+    ],
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
                 'naming_strategy' => 'Doctrine\ORM\Mapping\UnderscoreNamingStrategy'
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];
 ```
 
 ### How to Use Quote Strategy
@@ -234,18 +234,18 @@ return array(
 Zend Configuration
 
 ```php
-return array(
-    'service_manager' => array(
-        'invokables' => array(
+return [
+    'service_manager' => [
+        'invokables' => [
             'Doctrine\ORM\Mapping\AnsiQuoteStrategy' => 'Doctrine\ORM\Mapping\AnsiQuoteStrategy',
-        ),
-    ),
-    'doctrine' => array(
-        'configuration' => array(
-            'orm_default' => array(
+        ],
+    ],
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
                 'quote_strategy' => 'Doctrine\ORM\Mapping\AnsiQuoteStrategy'
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];
 ```

--- a/docs/developer-tools.md
+++ b/docs/developer-tools.md
@@ -41,10 +41,10 @@ class Module
 {
     public function getConfig()
     {
-        return array(
-            'doctrine' => array(
-                'sql_logger_collector' => array(
-                    'other_orm' => array(
+        return [
+            'doctrine' => [
+                'sql_logger_collector' => [
+                    'other_orm' => [
                         // name of the sql logger collector (used by ZendDeveloperTools)
                         'name' => 'other_orm',
 
@@ -54,39 +54,39 @@ class Module
                         // uncomment following if you want to use a particular SQL logger instead of relying on
                         // the attached one
                         //'sql_logger' => 'service_name_of_my_dbal_sql_logger',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
 
-            'zenddevelopertools' => array(
+            'zenddevelopertools' => [
 
                 // registering the profiler with ZendDeveloperTools
-                'profiler' => array(
-                    'collectors' => array(
+                'profiler' => [
+                    'collectors' => [
                         // reference to the service we have defined
                         'other_orm' => 'doctrine.sql_logger_collector.other_orm',
-                    ),
-                ),
+                    ],
+                ],
 
                 // registering a new toolbar item with ZendDeveloperTools (name must be the same of the collector name)
-                'toolbar' => array(
-                    'entries' => array(
+                'toolbar' => [
+                    'entries' => [
                         // this is actually a name of a view script to use - you can use your custom one
                         'other_orm' => 'zend-developer-tools/toolbar/doctrine-orm',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
     }
 
     public function getServiceConfiguration()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                 // defining a service (any name is valid as long as you use it consistently across this example)
                 'doctrine.sql_logger_collector.other_orm' => new \DoctrineORMModule\Service\SQLLoggerCollectorFactory('other_orm'),
-            ),
-        );
+            ],
+        ];
     }
 
     public function onBootstrap(\Zend\EventManager\EventInterface $e)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,17 +1,17 @@
 #### How to configure Doctrine Migrations
 
 ```php
-return array(    
-    'doctrine' => array(
-        'migrations_configuration' => array(
-            'orm_default' => array(
+return [    
+    'doctrine' => [
+        'migrations_configuration' => [
+            'orm_default' => [
                 'directory' => 'path/to/migrations/dir',
                 'name' => 'Migrations Name',
                 'namespace' => 'Migrations  Namespace',
                 'table' => 'migrations_table',
                 'column' => 'version',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];
 ```

--- a/src/DoctrineORMModule/Collector/MappingCollector.php
+++ b/src/DoctrineORMModule/Collector/MappingCollector.php
@@ -50,12 +50,12 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
     /**
      * @var ClassMetadataFactory|null
      */
-    protected $classMetadataFactory = array();
+    protected $classMetadataFactory = [];
 
     /**
      * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata[] indexed by class name
      */
-    protected $classes = array();
+    protected $classes = [];
 
     /**
      * @param ClassMetadataFactory $classMetadataFactory
@@ -94,7 +94,7 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
 
         /* @var $metadata \Doctrine\Common\Persistence\Mapping\ClassMetadata[] */
         $metadata      = $this->classMetadataFactory->getAllMetadata();
-        $this->classes = array();
+        $this->classes = [];
 
         foreach ($metadata as $class) {
             $this->classes[$class->getName()] = $class;
@@ -116,10 +116,10 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
     public function serialize()
     {
         return serialize(
-            array(
+            [
                 'name'    => $this->name,
                 'classes' => $this->classes,
-            )
+            ]
         );
     }
 

--- a/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
+++ b/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
@@ -76,11 +76,11 @@ class AnnotationBuilder extends ZendAnnotationBuilder
         $metadata     = $this->objectManager->getClassMetadata(is_object($entity) ? get_class($entity) : $entity);
         $inputFilter  = $formSpec['input_filter'];
 
-        $formElements = array(
+        $formElements = [
             'DoctrineModule\Form\Element\ObjectSelect',
             'DoctrineModule\Form\Element\ObjectMultiCheckbox',
             'DoctrineModule\Form\Element\ObjectRadio',
-        );
+        ];
 
         foreach ($formSpec['elements'] as $key => $elementSpec) {
             $name          = isset($elementSpec['spec']['name']) ? $elementSpec['spec']['name'] : null;
@@ -95,12 +95,12 @@ class AnnotationBuilder extends ZendAnnotationBuilder
                 $inputFilter[$name] = new \ArrayObject();
             }
 
-            $params = array(
+            $params = [
                 'metadata'    => $metadata,
                 'name'        => $name,
                 'elementSpec' => $elementSpec,
                 'inputSpec'   => $inputFilter[$name]
-            );
+            ];
 
             if ($this->checkForExcludeElementFromMetadata($metadata, $name)) {
                 $elementSpec = $formSpec['elements'];
@@ -122,7 +122,7 @@ class AnnotationBuilder extends ZendAnnotationBuilder
             }
         }
 
-        $formSpec['options'] = array('prefer_form_input_filter' => true);
+        $formSpec['options'] = ['prefer_form_input_filter' => true];
 
         return $formSpec;
     }
@@ -134,7 +134,7 @@ class AnnotationBuilder extends ZendAnnotationBuilder
      */
     protected function checkForExcludeElementFromMetadata(ClassMetadata $metadata, $name)
     {
-        $params = array('metadata' => $metadata, 'name' => $name);
+        $params = ['metadata' => $metadata, 'name' => $name];
         $result = false;
 
         if ($metadata->hasField($name)) {

--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -52,39 +52,39 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     {
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_FIELD,
-            array($this, 'handleFilterField')
+            [$this, 'handleFilterField']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_FIELD,
-            array($this, 'handleTypeField')
+            [$this, 'handleTypeField']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_FIELD,
-            array($this, 'handleValidatorField')
+            [$this, 'handleValidatorField']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_FIELD,
-            array($this, 'handleRequiredField')
+            [$this, 'handleRequiredField']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_EXCLUDE_FIELD,
-            array($this, 'handleExcludeField')
+            [$this, 'handleExcludeField']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_ASSOCIATION,
-            array($this, 'handleToOne')
+            [$this, 'handleToOne']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_ASSOCIATION,
-            array($this, 'handleToMany')
+            [$this, 'handleToMany']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_CONFIGURE_ASSOCIATION,
-            array($this, 'handleRequiredAssociation')
+            [$this, 'handleRequiredAssociation']
         );
         $this->listeners[] = $events->attach(
             AnnotationBuilder::EVENT_EXCLUDE_ASSOCIATION,
-            array($this, 'handleExcludeAssociation')
+            [$this, 'handleExcludeAssociation']
         );
     }
 
@@ -177,12 +177,12 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
         switch ($metadata->getTypeOfField($event->getParam('name'))) {
             case 'bool':
             case 'boolean':
-                $inputSpec['filters'][] = array('name' => 'Boolean');
+                $inputSpec['filters'][] = ['name' => 'Boolean'];
                 break;
             case 'bigint':
             case 'integer':
             case 'smallint':
-                $inputSpec['filters'][] = array('name' => 'Int');
+                $inputSpec['filters'][] = ['name' => 'Int'];
                 break;
             case 'datetime':
             case 'datetimetz':
@@ -190,7 +190,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
             case 'time':
             case 'string':
             case 'text':
-                $inputSpec['filters'][] = array('name' => 'StringTrim');
+                $inputSpec['filters'][] = ['name' => 'StringTrim'];
                 break;
         }
     }
@@ -330,32 +330,32 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
         switch ($metadata->getTypeOfField($event->getParam('name'))) {
             case 'bool':
             case 'boolean':
-                $inputSpec['validators'][] = array(
+                $inputSpec['validators'][] = [
                     'name'    => 'InArray',
-                    'options' => array('haystack' => array('0', '1'))
-                );
+                    'options' => ['haystack' => ['0', '1']]
+                ];
                 break;
             case 'float':
-                $inputSpec['validators'][] = array('name' => 'Float');
+                $inputSpec['validators'][] = ['name' => 'Float'];
                 break;
             case 'bigint':
             case 'integer':
             case 'smallint':
-                $inputSpec['validators'][] = array('name' => 'Int');
+                $inputSpec['validators'][] = ['name' => 'Int'];
                 break;
             case 'string':
                 $elementSpec = $event->getParam('elementSpec');
                 if (isset($elementSpec['spec']['type']) &&
-                    in_array($elementSpec['spec']['type'], array('File', 'Zend\Form\Element\File'))
+                    in_array($elementSpec['spec']['type'], ['File', 'Zend\Form\Element\File'])
                 ) {
                     return;
                 }
 
                 if (isset($mapping['length'])) {
-                    $inputSpec['validators'][] = array(
+                    $inputSpec['validators'][] = [
                         'name'    => 'StringLength',
-                        'options' => array('max' => $mapping['length'])
-                    );
+                        'options' => ['max' => $mapping['length']]
+                    ];
                 }
                 break;
         }
@@ -397,12 +397,12 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
      */
     protected function mergeAssociationOptions(ArrayObject $elementSpec, $targetEntity)
     {
-        $options = isset($elementSpec['spec']['options']) ? $elementSpec['spec']['options'] : array();
+        $options = isset($elementSpec['spec']['options']) ? $elementSpec['spec']['options'] : [];
         $options = array_merge(
-            array(
+            [
                 'object_manager' => $this->objectManager,
                 'target_class'   => $targetEntity
-            ),
+            ],
             $options
         );
 
@@ -419,7 +419,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
      */
     protected function prepareEvent(EventInterface $event)
     {
-        foreach (array('elementSpec', 'inputSpec') as $type) {
+        foreach (['elementSpec', 'inputSpec'] as $type) {
             if (!$event->getParam($type)) {
                 $event->setParam($type, new ArrayObject());
             }
@@ -429,13 +429,13 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
         $inputSpec   = $event->getParam('inputSpec');
 
         if (!isset($elementSpec['spec'])) {
-            $elementSpec['spec'] = array();
+            $elementSpec['spec'] = [];
         }
         if (!isset($inputSpec['filters'])) {
-            $inputSpec['filters'] = array();
+            $inputSpec['filters'] = [];
         }
         if (!isset($inputSpec['validators'])) {
-            $inputSpec['validators'] = array();
+            $inputSpec['validators'] = [];
         }
     }
 }

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -58,7 +58,7 @@ class Module implements
                 $manager->getEvent()->getParam('ServiceManager')->get('doctrine.sql_logger_collector.orm_default');
             }
         );
-        $events->getSharedManager()->attach('doctrine', 'loadCli.post', array($this, 'initializeConsole'));
+        $events->getSharedManager()->attach('doctrine', 'loadCli.post', [$this, 'initializeConsole']);
     }
 
     /**
@@ -82,7 +82,7 @@ class Module implements
      */
     public function getModuleDependencies()
     {
-        return array('DoctrineModule');
+        return ['DoctrineModule'];
     }
 
     /**
@@ -99,7 +99,7 @@ class Module implements
         /* @var $serviceLocator \Zend\ServiceManager\ServiceLocatorInterface */
         $serviceLocator = $event->getParam('ServiceManager');
 
-        $commands = array(
+        $commands = [
             'doctrine.dbal_cmd.runsql',
             'doctrine.dbal_cmd.import',
             'doctrine.orm_cmd.clear_cache_metadata',
@@ -117,12 +117,12 @@ class Module implements
             'doctrine.orm_cmd.run_dql',
             'doctrine.orm_cmd.validate_schema',
             'doctrine.orm_cmd.info',
-        );
+        ];
 
         if (class_exists('Doctrine\\DBAL\\Migrations\\Version')) {
             $commands = ArrayUtils::merge(
                 $commands,
-                array(
+                [
                     'doctrine.migrations_cmd.execute',
                     'doctrine.migrations_cmd.generate',
                     'doctrine.migrations_cmd.migrate',
@@ -130,11 +130,11 @@ class Module implements
                     'doctrine.migrations_cmd.version',
                     'doctrine.migrations_cmd.diff',
                     'doctrine.migrations_cmd.latest',
-                )
+                ]
             );
         }
 
-        $cli->addCommands(array_map(array($serviceLocator, 'get'), $commands));
+        $cli->addCommands(array_map([$serviceLocator, 'get'], $commands));
 
         /* @var $entityManager \Doctrine\ORM\EntityManager */
         $entityManager = $serviceLocator->get('doctrine.entitymanager.orm_default');

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -89,7 +89,7 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $entityNamespaces = array();
+    protected $entityNamespaces = [];
 
     /**
      * Keys must be function names and values the FQCN of the implementing class.
@@ -97,7 +97,7 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $datetimeFunctions = array();
+    protected $datetimeFunctions = [];
 
     /**
      * Keys must be function names and values the FQCN of the implementing class.
@@ -105,7 +105,7 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $stringFunctions = array();
+    protected $stringFunctions = [];
 
     /**
      * Keys must be function names and values the FQCN of the implementing class.
@@ -113,7 +113,7 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $numericFunctions = array();
+    protected $numericFunctions = [];
 
     /**
      * Keys must be the name of the custom filter and the value must be
@@ -121,14 +121,14 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $filters = array();
+    protected $filters = [];
 
     /**
      * Keys must be the name of the query and values the DQL query string.
      *
      * @var array
      */
-    protected $namedQueries = array();
+    protected $namedQueries = [];
 
     /**
      * Keys must be the name of the query and the value is an array containing
@@ -136,7 +136,7 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $namedNativeQueries = array();
+    protected $namedNativeQueries = [];
 
     /**
      * Keys must be the name of the custom hydration method and the value must be
@@ -144,7 +144,7 @@ class Configuration extends DBALConfiguration
      *
      * @var array
      */
-    protected $customHydrationModes = array();
+    protected $customHydrationModes = [];
 
     /**
      * Naming strategy or name of the naming strategy service to be set in ORM

--- a/src/DoctrineORMModule/Options/DBALConfiguration.php
+++ b/src/DoctrineORMModule/Options/DBALConfiguration.php
@@ -52,7 +52,7 @@ class DBALConfiguration extends AbstractOptions
      *
      * @var array
      */
-    protected $types = array();
+    protected $types = [];
 
     /**
      * @param string $resultCache

--- a/src/DoctrineORMModule/Options/DBALConnection.php
+++ b/src/DoctrineORMModule/Options/DBALConnection.php
@@ -77,17 +77,17 @@ class DBALConnection extends AbstractOptions
      *
      * @var array
      */
-    protected $params = array();
+    protected $params = [];
 
     /**
      * @var array
      */
-    protected $doctrineTypeMappings = array();
+    protected $doctrineTypeMappings = [];
 
     /**
      * @var array
      */
-    protected $doctrineCommentedTypes = array();
+    protected $doctrineCommentedTypes = [];
 
     /**
      * @param string $configuration

--- a/src/DoctrineORMModule/Options/EntityResolver.php
+++ b/src/DoctrineORMModule/Options/EntityResolver.php
@@ -22,7 +22,7 @@ class EntityResolver extends AbstractOptions
      *
      * @var array
      */
-    protected $resolvers = array();
+    protected $resolvers = [];
 
     /**
      * @param  string $eventManager

--- a/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
+++ b/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
@@ -55,7 +55,7 @@ class SecondLevelCacheConfiguration extends AbstractOptions
      *
      * @var array
      */
-    protected $regions = array();
+    protected $regions = [];
 
     /**
      * @param boolean $enabled

--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -49,11 +49,11 @@ class DBALConnectionFactory extends AbstractFactory
             $pdo = $container->get($pdo);
         }
 
-        $params = array(
+        $params = [
             'driverClass'  => $options->getDriverClass(),
             'wrapperClass' => $options->getWrapperClass(),
             'pdo'          => $pdo,
-        );
+        ];
         $params = array_merge($params, $options->getParams());
 
         $configuration = $container->get($options->getConfiguration());

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -41,7 +41,7 @@ class EntityResolverFactory extends AbstractFactory
         $targetEntityListener = new ResolveTargetEntityListener();
 
         foreach ($resolvers as $oldEntity => $newEntity) {
-            $targetEntityListener->addResolveTargetEntity($oldEntity, $newEntity, array());
+            $targetEntityListener->addResolveTargetEntity($oldEntity, $newEntity, []);
         }
 
         // Starting from Doctrine ORM 2.5, the listener implements EventSubscriber

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -35,7 +35,7 @@ class MetadataGrapher
      *
      * @var array
      */
-    protected $visitedAssociations = array();
+    protected $visitedAssociations = [];
 
     /**
      * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
@@ -47,7 +47,7 @@ class MetadataGrapher
      *
      * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
      */
-    private $classByNames = array();
+    private $classByNames = [];
 
     /**
      * Generate a YUML compatible `dsl_text` to describe a given array
@@ -60,8 +60,8 @@ class MetadataGrapher
     public function generateFromMetadata(array $metadata)
     {
         $this->metadata            = $metadata;
-        $this->visitedAssociations = array();
-        $str                       = array();
+        $this->visitedAssociations = [];
+        $str                       = [];
 
         foreach ($metadata as $class) {
             $parent = $this->getParent($class);
@@ -170,9 +170,9 @@ class MetadataGrapher
 
         $className    = $class->getName();
         $classText    = '[' . str_replace('\\', '.', $className);
-        $fields       = array();
+        $fields       = [];
         $parent       = $this->getParent($class);
-        $parentFields = $parent ? $parent->getFieldNames() : array();
+        $parentFields = $parent ? $parent->getFieldNames() : [];
 
         foreach ($class->getFieldNames() as $fieldName) {
             if (in_array($fieldName, $parentFields)) {
@@ -249,7 +249,7 @@ class MetadataGrapher
                 return false;
             }
 
-            $this->visitedAssociations[$className] = array();
+            $this->visitedAssociations[$className] = [];
 
             return true;
         }
@@ -259,7 +259,7 @@ class MetadataGrapher
         }
 
         if (!isset($this->visitedAssociations[$className])) {
-            $this->visitedAssociations[$className] = array();
+            $this->visitedAssociations[$className] = [];
         }
 
         $this->visitedAssociations[$className][$association] = true;

--- a/src/DoctrineORMModule/Yuml/YumlController.php
+++ b/src/DoctrineORMModule/Yuml/YumlController.php
@@ -57,7 +57,7 @@ class YumlController extends AbstractActionController
         /* @var $request \Zend\Http\Request */
         $request = $this->getRequest();
         $this->httpClient->setMethod(Request::METHOD_POST);
-        $this->httpClient->setParameterPost(array('dsl_text' => $request->getPost('dsl_text')));
+        $this->httpClient->setParameterPost(['dsl_text' => $request->getPost('dsl_text')]);
         $response = $this->httpClient->send();
 
         if (!$response->isSuccess()) {

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -21,7 +21,7 @@ use DoctrineORMModuleTest\Util\ServiceManagerFactory;
 
 ini_set('error_reporting', E_ALL);
 
-$files = array(__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php');
+$files = [__DIR__ . '/../vendor/autoload.php', __DIR__ . '/../../../autoload.php'];
 
 foreach ($files as $file) {
     if (file_exists($file)) {

--- a/tests/DoctrineORMModuleTest/Collector/MappingCollectorTest.php
+++ b/tests/DoctrineORMModuleTest/Collector/MappingCollectorTest.php
@@ -81,7 +81,7 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
             ->metadataFactory
             ->expects($this->any())
             ->method('getAllMetadata')
-            ->will($this->returnValue(array($m1, $m2)));
+            ->will($this->returnValue([$m1, $m2]));
 
         $this->collector->collect($this->getMock('Zend\\Mvc\\MvcEvent'));
 
@@ -101,7 +101,7 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
 
         $m1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
-        $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue(array($m1)));
+        $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue([$m1]));
 
         $this->collector->collect($this->getMock('Zend\\Mvc\\MvcEvent'));
 
@@ -117,7 +117,7 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
     {
         $m1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
-        $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue(array($m1)));
+        $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue([$m1]));
 
         $this->collector->collect($this->getMock('Zend\\Mvc\\MvcEvent'));
 

--- a/tests/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
+++ b/tests/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
@@ -79,7 +79,7 @@ class AnnotationBuilderTest extends TestCase
         $spec           = $this->builder->getFormSpecification($entity);
         $annotationForm = $this->builder->createForm($entity);
 
-        $attributesToTest = array('specificType', 'specificMultiType', 'specificAttributeType');
+        $attributesToTest = ['specificType', 'specificMultiType', 'specificAttributeType'];
 
         foreach ($spec['elements'] as $element) {
             $elementName = $element['spec']['name'];

--- a/tests/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
+++ b/tests/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
@@ -252,61 +252,61 @@ class ElementAnnotationsListenerTest extends TestCase
 
     public function eventValidatorProvider()
     {
-        return array(
-            array('bool', 'InArray'),
-            array('boolean', 'InArray'),
-            array('bigint', 'Int'),
-            array('float', 'Float'),
-            array('integer', 'Int'),
-            array('smallint', 'Int'),
-            array('datetime', null),
-            array('datetimetz', null),
-            array('date', null),
-            array('time', null),
-            array('string', 'StringLength'),
-            array('stringNullable', null),
-            array('text', null),
-        );
+        return [
+            ['bool', 'InArray'],
+            ['boolean', 'InArray'],
+            ['bigint', 'Int'],
+            ['float', 'Float'],
+            ['integer', 'Int'],
+            ['smallint', 'Int'],
+            ['datetime', null],
+            ['datetimetz', null],
+            ['date', null],
+            ['time', null],
+            ['string', 'StringLength'],
+            ['stringNullable', null],
+            ['text', null],
+        ];
     }
 
     public function eventFilterProvider()
     {
-        return array(
-            array('bool', 'Boolean'),
-            array('boolean', 'Boolean'),
-            array('bigint', 'Int'),
-            array('integer', 'Int'),
-            array('smallint', 'Int'),
-            array('datetime', 'StringTrim'),
-            array('datetimetz', 'StringTrim'),
-            array('date', 'StringTrim'),
-            array('time', 'StringTrim'),
-            array('string', 'StringTrim'),
-            array('text', 'StringTrim'),
-        );
+        return [
+            ['bool', 'Boolean'],
+            ['boolean', 'Boolean'],
+            ['bigint', 'Int'],
+            ['integer', 'Int'],
+            ['smallint', 'Int'],
+            ['datetime', 'StringTrim'],
+            ['datetimetz', 'StringTrim'],
+            ['date', 'StringTrim'],
+            ['time', 'StringTrim'],
+            ['string', 'StringTrim'],
+            ['text', 'StringTrim'],
+        ];
     }
 
     public function eventTypeProvider()
     {
-        return array(
-            array('bool', 'Zend\Form\Element\Checkbox'),
-            array('boolean', 'Zend\Form\Element\Checkbox'),
-            array('bigint', 'Zend\Form\Element\Number'),
-            array('integer', 'Zend\Form\Element\Number'),
-            array('smallint', 'Zend\Form\Element\Number'),
-            array('datetime', 'Zend\Form\Element\DateTime'),
-            array('datetimetz', 'Zend\Form\Element\DateTime'),
-            array('date', 'Zend\Form\Element\Date'),
-            array('time', 'Zend\Form\Element\Time'),
-            array('string', 'Zend\Form\Element'),
-            array('text', 'Zend\Form\Element\Textarea'),
-        );
+        return [
+            ['bool', 'Zend\Form\Element\Checkbox'],
+            ['boolean', 'Zend\Form\Element\Checkbox'],
+            ['bigint', 'Zend\Form\Element\Number'],
+            ['integer', 'Zend\Form\Element\Number'],
+            ['smallint', 'Zend\Form\Element\Number'],
+            ['datetime', 'Zend\Form\Element\DateTime'],
+            ['datetimetz', 'Zend\Form\Element\DateTime'],
+            ['date', 'Zend\Form\Element\Date'],
+            ['time', 'Zend\Form\Element\Time'],
+            ['string', 'Zend\Form\Element'],
+            ['text', 'Zend\Form\Element\Textarea'],
+        ];
     }
 
     public function eventNameProvider()
     {
-        return array(
-            array(
+        return [
+            [
                 'handleFilterField',
                 'handleTypeField',
                 'handleValidatorField',
@@ -316,8 +316,8 @@ class ElementAnnotationsListenerTest extends TestCase
                 'handleExcludeAssociation',
                 'handleToOne',
                 'handleToMany'
-            )
-        );
+            ]
+        ];
     }
 
     protected function getMetadataEvent()

--- a/tests/DoctrineORMModuleTest/Options/DBALConnectionTest.php
+++ b/tests/DoctrineORMModuleTest/Options/DBALConnectionTest.php
@@ -32,13 +32,13 @@ class DBALConnectionTest extends PHPUnit_Framework_TestCase
     {
         $options = new DBALConnection();
         $options->setDoctrineCommentedTypes([]);
-        $this->assertSame(array(), $options->getDoctrineCommentedTypes());
+        $this->assertSame([], $options->getDoctrineCommentedTypes());
     }
 
     public function testSetGetCommentedTypes()
     {
         $options = new DBALConnection();
-        $options->setDoctrineCommentedTypes(array('mytype'));
-        $this->assertSame(array('mytype'), $options->getDoctrineCommentedTypes());
+        $options->setDoctrineCommentedTypes(['mytype']);
+        $this->assertSame(['mytype'], $options->getDoctrineCommentedTypes());
     }
 }

--- a/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
@@ -51,13 +51,13 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillInstantiateConfigWithoutNamingStrategySetting()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(),
-                ),
-            ),
-        );
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $ormConfig = $this->factory->createService($this->serviceManager);
         $this->assertInstanceOf('Doctrine\ORM\Mapping\NamingStrategy', $ormConfig->getNamingStrategy());
@@ -67,15 +67,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     {
         $namingStrategy = $this->getMock('Doctrine\ORM\Mapping\NamingStrategy');
 
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'naming_strategy' => $namingStrategy,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
@@ -85,15 +85,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     public function testWillInstantiateConfigWithNamingStrategyReference()
     {
         $namingStrategy = $this->getMock('Doctrine\ORM\Mapping\NamingStrategy');
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'naming_strategy' => 'test_naming_strategy',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $this->serviceManager->setService('test_naming_strategy', $namingStrategy);
         $ormConfig = $this->factory->createService($this->serviceManager);
@@ -102,15 +102,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillNotInstantiateConfigWithInvalidNamingStrategyReference()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'naming_strategy' => 'test_naming_strategy',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $this->setExpectedException('Zend\ServiceManager\Exception\InvalidArgumentException');
         $this->factory->createService($this->serviceManager);
@@ -120,15 +120,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     {
         $quoteStrategy = $this->getMock('Doctrine\ORM\Mapping\QuoteStrategy');
 
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'quote_strategy' => $quoteStrategy,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
@@ -138,15 +138,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     public function testWillInstantiateConfigWithQuoteStrategyReference()
     {
         $quoteStrategy = $this->getMock('Doctrine\ORM\Mapping\QuoteStrategy');
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'quote_strategy' => 'test_quote_strategy',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $this->serviceManager->setService('test_quote_strategy', $quoteStrategy);
         $ormConfig = $this->factory->createService($this->serviceManager);
@@ -155,15 +155,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillNotInstantiateConfigWithInvalidQuoteStrategyReference()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'quote_strategy' => 'test_quote_strategy',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $this->setExpectedException('Zend\ServiceManager\Exception\InvalidArgumentException');
         $this->factory->createService($this->serviceManager);
@@ -171,15 +171,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillInstantiateConfigWithHydrationCacheSetting()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'hydration_cache' => 'array',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
@@ -190,17 +190,17 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     {
         $repositoryClass = 'DoctrineORMModuleTest\Assets\RepositoryClass';
 
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
 
                         'hydration_cache' => 'array',
                         'default_repository_class_name' => $repositoryClass,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
 
         $factory = new ConfigurationFactory('test_default');
@@ -210,15 +210,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testAcceptsMetadataFactory()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'classMetadataFactoryName' => 'Factory'
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
@@ -227,14 +227,14 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testDefaultMetadatFactory()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
-                    ),
-                ),
-            ),
-        );
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
@@ -243,13 +243,13 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillInstantiateConfigWithoutEntityListenerResolverSetting()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(),
-                ),
-            ),
-        );
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [],
+                ],
+            ],
+        ];
 
         $this->serviceManager->setService('Config', $config);
 
@@ -262,15 +262,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     {
         $entityListenerResolver = $this->getMock('Doctrine\ORM\Mapping\EntityListenerResolver');
 
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'entity_listener_resolver' => $entityListenerResolver,
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->serviceManager->setService('Config', $config);
 
@@ -283,15 +283,15 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
     {
         $entityListenerResolver = $this->getMock('Doctrine\ORM\Mapping\EntityListenerResolver');
 
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'entity_listener_resolver' => 'test_entity_listener_resolver',
-                    ),
-                ),
-            ),
-        );
+                    ],
+                ],
+            ],
+        ];
 
         $this->serviceManager->setService('Config', $config);
         $this->serviceManager->setService('test_entity_listener_resolver', $entityListenerResolver);
@@ -303,13 +303,13 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testDoNotCreateSecondLevelCacheByDefault()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(),
-                ),
-            ),
-        );
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [],
+                ],
+            ],
+        ];
 
         $this->serviceManager->setService('Config', $config);
 
@@ -320,34 +320,34 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testCanInstantiateWithSecondLevelCacheConfig()
     {
-        $config = array(
-            'doctrine' => array(
-                'configuration' => array(
-                    'test_default' => array(
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
                         'result_cache' => 'array',
 
-                        'second_level_cache' => array(
+                        'second_level_cache' => [
                             'enabled'                    => true,
                             'default_lifetime'           => 200,
                             'default_lock_lifetime'      => 500,
                             'file_lock_region_directory' => 'my_dir',
 
-                            'regions' => array(
-                                'my_first_region' => array(
+                            'regions' => [
+                                'my_first_region' => [
                                     'lifetime'      => 800,
                                     'lock_lifetime' => 1000
-                                ),
+                                ],
 
-                                'my_second_region' => array(
+                                'my_second_region' => [
                                     'lifetime'      => 10,
                                     'lock_lifetime' => 20
-                                )
-                            )
-                        )
-                    ),
-                ),
-            ),
-        );
+                                ]
+                            ]
+                        ]
+                    ],
+                ],
+            ],
+        ];
 
         $this->serviceManager->setService('Config', $config);
 

--- a/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -55,21 +55,21 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testDoctrineMappingTypeReturnCorrectParent()
     {
-        $config = array(
-            'doctrine' => array(
-                'connection' => array(
-                    'orm_default' => array(
+        $config = [
+            'doctrine' => [
+                'connection' => [
+                    'orm_default' => [
                         'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
-                        'params' => array(
+                        'params' => [
                             'memory' => true,
-                        ),
-                        'doctrineTypeMappings' => array(
+                        ],
+                        'doctrineTypeMappings' => [
                             'money' => 'string'
-                        ),
-                    )
-                ),
-            ),
-        );
+                        ],
+                    ]
+                ],
+            ],
+        ];
         $configurationMock = $this->getMockBuilder('Doctrine\ORM\Configuration')
             ->disableOriginalConstructor()
             ->getMock();
@@ -85,31 +85,31 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testDoctrineAddCustomCommentedType()
     {
-        $config = array(
-            'doctrine' => array(
-                'connection' => array(
-                    'orm_default' => array(
+        $config = [
+            'doctrine' => [
+                'connection' => [
+                    'orm_default' => [
                         'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
-                        'params' => array(
+                        'params' => [
                             'memory' => true,
-                        ),
-                        'doctrineTypeMappings' => array(
+                        ],
+                        'doctrineTypeMappings' => [
                             'money' => 'money',
-                        ),
-                        'doctrineCommentedTypes' => array(
+                        ],
+                        'doctrineCommentedTypes' => [
                             'money'
-                        ),
-                    )
-                ),
-                'configuration' => array(
-                    'orm_default' => array(
-                        'types' => array(
+                        ],
+                    ]
+                ],
+                'configuration' => [
+                    'orm_default' => [
+                        'types' => [
                             'money' => 'DoctrineORMModuleTest\Assets\Types\MoneyType',
-                        ),
-                    ),
-                ),
-            ),
-        );
+                        ],
+                    ],
+                ],
+            ],
+        ];
         $this->serviceManager->setService('Config', $config);
         $this->serviceManager->setService('Configuration', $config);
         $this->serviceManager->setService(

--- a/tests/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
@@ -53,13 +53,13 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('doctrine.configuration.orm_default', $configuration);
         $this->services->setService(
             'Config',
-            array(
-                'doctrine' => array(
-                    'sql_logger_collector' => array(
-                        'orm_default' => array(),
-                    ),
-                ),
-            )
+            [
+                'doctrine' => [
+                    'sql_logger_collector' => [
+                        'orm_default' => [],
+                    ],
+                ],
+            ]
         );
         $service = $this->factory->createService($this->services);
         $this->assertInstanceOf('DoctrineORMModule\Collector\SQLLoggerCollector', $service);
@@ -72,15 +72,15 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('configuration_service_id', $configuration);
         $this->services->setService(
             'Config',
-            array(
-                'doctrine' => array(
-                    'sql_logger_collector' => array(
-                        'orm_default' => array(
+            [
+                'doctrine' => [
+                    'sql_logger_collector' => [
+                        'orm_default' => [
                             'configuration' => 'configuration_service_id',
-                        ),
-                    ),
-                ),
-            )
+                        ],
+                    ],
+                ],
+            ]
         );
         $this->factory->createService($this->services);
         $this->assertInstanceOf('Doctrine\DBAL\Logging\SQLLogger', $configuration->getSQLLogger());
@@ -105,15 +105,15 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('custom_logger', $injectedLogger);
         $this->services->setService(
             'Config',
-            array(
-                'doctrine' => array(
-                    'sql_logger_collector' => array(
-                        'orm_default' => array(
+            [
+                'doctrine' => [
+                    'sql_logger_collector' => [
+                        'orm_default' => [
                             'sql_logger' => 'custom_logger',
-                        ),
-                    ),
-                ),
-            )
+                        ],
+                    ],
+                ],
+            ]
         );
         $this->factory->createService($this->services);
         /* @var $logger \Doctrine\DBAL\Logging\SQLLogger */
@@ -129,15 +129,15 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('logger_service_id', $logger);
         $this->services->setService(
             'Config',
-            array(
-                'doctrine' => array(
-                    'sql_logger_collector' => array(
-                        'orm_default' => array(
+            [
+                'doctrine' => [
+                    'sql_logger_collector' => [
+                        'orm_default' => [
                             'sql_logger' => 'logger_service_id',
-                        ),
-                    ),
-                ),
-            )
+                        ],
+                    ],
+                ],
+            ]
         );
         $this->factory->createService($this->services);
         $this->assertSame($logger, $configuration->getSQLLogger());
@@ -148,15 +148,15 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('doctrine.configuration.orm_default', new ORMConfiguration());
         $this->services->setService(
             'Config',
-            array(
-                'doctrine' => array(
-                    'sql_logger_collector' => array(
-                        'orm_default' => array(
+            [
+                'doctrine' => [
+                    'sql_logger_collector' => [
+                        'orm_default' => [
                             'name' => 'test_collector_name',
-                        ),
-                    ),
-                ),
-            )
+                        ],
+                    ],
+                ],
+            ]
         );
         /* @var $service \DoctrineORMModule\Collector\SQLLoggerCollector */
         $service = $this->factory->createService($this->services);

--- a/tests/DoctrineORMModuleTest/Util/ServiceManagerFactory.php
+++ b/tests/DoctrineORMModuleTest/Util/ServiceManagerFactory.php
@@ -53,7 +53,7 @@ class ServiceManagerFactory
     {
         $serviceManager = new ServiceManager();
         $serviceManagerConfig = new ServiceManagerConfig(
-            isset(static::$config['service_manager']) ? static::$config['service_manager'] : array()
+            isset(static::$config['service_manager']) ? static::$config['service_manager'] : []
         );
         $serviceManagerConfig->configureServiceManager($serviceManager);
         $serviceManager->setService('ApplicationConfig', static::$config);

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -53,10 +53,10 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
-        $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
-        $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
+        $class->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
+        $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
 
-        $this->assertSame('[Simple.Entity]', $this->grapher->generateFromMetadata(array($class)));
+        $this->assertSame('[Simple.Entity]', $this->grapher->generateFromMetadata([$class]));
     }
 
     /**
@@ -66,8 +66,8 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
-        $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(array('a', 'b', 'c')));
-        $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
+        $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(['a', 'b', 'c']));
+        $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class->expects($this->any())->method('isIdentifier')->will(
             $this->returnCallback(
                 function ($field) {
@@ -76,7 +76,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
             )
         );
 
-        $this->assertSame('[Simple.Entity|+a;b;c]', $this->grapher->generateFromMetadata(array($class)));
+        $this->assertSame('[Simple.Entity|+a;b;c]', $this->grapher->generateFromMetadata([$class]));
     }
 
     /**
@@ -86,18 +86,18 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]-b 1>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]-b 1>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -107,22 +107,22 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class2->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('b'));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<>a 1-b 1>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]<>a 1-b 1>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -132,22 +132,22 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<a 1-b 1<>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]<a 1-b 1<>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -157,22 +157,22 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class2->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('b'));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<>a 1-b *>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]<>a 1-b *>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -182,22 +182,22 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class2->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('b'));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<>a *-b 1>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]<>a *-b 1>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -207,18 +207,18 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]-b *>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]-b *>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -228,18 +228,18 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A],[B]-a *>[A]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A],[B]-a *>[A]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -249,22 +249,22 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class2->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('b'));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<>a *-b *>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]<>a *-b *>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -274,22 +274,22 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<a *-b *<>[B]', $this->grapher->generateFromMetadata(array($class1, $class2)));
+        $this->assertSame('[A]<a *-b *<>[B]', $this->grapher->generateFromMetadata([$class1, $class2]));
     }
 
     /**
@@ -299,13 +299,13 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $this->assertSame('[A]<>-b *>[B]', $this->grapher->generateFromMetadata(array($class1)));
+        $this->assertSame('[A]<>-b *>[B]', $this->grapher->generateFromMetadata([$class1]));
     }
 
     /**
@@ -317,15 +317,15 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $child  = get_class($this->getMock('stdClass'));
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
         $class2->expects($this->any())->method('getName')->will($this->returnValue($child));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $this->assertSame(
             '[stdClass]^[' . str_replace('\\', '.', $child) . ']',
-            $this->grapher->generateFromMetadata(array($class2, $class1))
+            $this->grapher->generateFromMetadata([$class2, $class1])
         );
     }
 
@@ -339,16 +339,16 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $child  = get_class($this->getMock('stdClass'));
 
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array('inherited')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(['inherited']));
 
         $class2->expects($this->any())->method('getName')->will($this->returnValue($child));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array('inherited', 'field2')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(['inherited', 'field2']));
 
         $this->assertSame(
             '[stdClass|inherited]^[' . str_replace('\\', '.', $child) . '|field2]',
-            $this->grapher->generateFromMetadata(array($class2, $class1))
+            $this->grapher->generateFromMetadata([$class2, $class1])
         );
     }
 
@@ -364,14 +364,14 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $child  = get_class($this->getMock('stdClass'));
 
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2->expects($this->any())->method('getName')->will($this->returnValue($child));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('a', 'b')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a', 'b']));
         $class2
             ->expects($this->any())
             ->method('getAssociationTargetClass')
@@ -384,20 +384,20 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
             );
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class3->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class4->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class4->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array()));
-        $class4->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class4->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
+        $class4->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $childName = str_replace('\\', '.', $child);
         $this->assertSame(
             '[stdClass]<>-a *>[A],[stdClass]^[' . $childName . '],[' . $childName . ']<>-b *>[B]',
-            $this->grapher->generateFromMetadata(array($class1, $class2))
+            $this->grapher->generateFromMetadata([$class1, $class2])
         );
     }
 
@@ -409,7 +409,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $this->assertSame(
             $expected,
-            $this->grapher->generateFromMetadata(array($class1, $class2,$class3))
+            $this->grapher->generateFromMetadata([$class1, $class2,$class3])
         );
     }
 
@@ -423,40 +423,40 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
     {
         $class1 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
-        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('c')));
+        $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['c']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
         $class1->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
-        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class2 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
-        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('c')));
+        $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['c']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
         $class2->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(false));
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
-        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
         $class3 = $this->getMock('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata');
         $class3->expects($this->any())->method('getName')->will($this->returnValue('C'));
-        $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(array('b')));
+        $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class3
             ->expects($this->any())
             ->method('getAssociationTargetClass')
             ->with($this->logicalOr($this->equalTo('b'), $this->equalTo('c')))
-            ->will($this->returnCallback(array($this,'getAssociationTargetClassMock')));
+            ->will($this->returnCallback([$this,'getAssociationTargetClassMock']));
         $class3->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
-        $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue(array()));
+        $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        return array(
-            array($class1, $class2, $class3, '[A]-c 1>[C],[B]<>b *-c 1>[C]'),
-            array($class1, $class3, $class2, '[A]-c 1>[C],[C]<c 1-b *<>[B]'),
-            array($class2, $class1, $class3, '[B]<>b *-c 1>[C],[A]-c 1>[C]'),
-            array($class2, $class3, $class1, '[B]<>b *-c 1>[C],[A]-c 1>[C]'),
-            array($class3, $class1, $class2, '[C]<c 1-b *<>[B],[A]-c 1>[C]'),
-            array($class3, $class2, $class1, '[C]<c 1-b *<>[B],[A]-c 1>[C]')
-        );
+        return [
+            [$class1, $class2, $class3, '[A]-c 1>[C],[B]<>b *-c 1>[C]'],
+            [$class1, $class3, $class2, '[A]-c 1>[C],[C]<c 1-b *<>[B]'],
+            [$class2, $class1, $class3, '[B]<>b *-c 1>[C],[A]-c 1>[C]'],
+            [$class2, $class3, $class1, '[B]<>b *-c 1>[C],[A]-c 1>[C]'],
+            [$class3, $class1, $class2, '[C]<c 1-b *<>[B],[A]-c 1>[C]'],
+            [$class3, $class2, $class1, '[C]<c 1-b *<>[B],[A]-c 1>[C]']
+        ];
     }
 
     /**

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -16,49 +16,49 @@
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
-return array(
-    'doctrine' => array(
-        'configuration' => array(
-            'orm_default' => array(
+return [
+    'doctrine' => [
+        'configuration' => [
+            'orm_default' => [
                 'default_repository_class_name' => 'DoctrineORMModuleTest\Assets\RepositoryClass',
-            ),
-        ),
-        'driver' => array(
-            'DoctrineORMModuleTest\Assets\Entity' => array(
+            ],
+        ],
+        'driver' => [
+            'DoctrineORMModuleTest\Assets\Entity' => [
                 'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
                 'cache' => 'array',
-                'paths' => array(
+                'paths' => [
                     __DIR__ . '/DoctrineORMModuleTest/Assets/Entity'
-                ),
-            ),
-            'orm_default' => array(
-                'drivers' => array(
+                ],
+            ],
+            'orm_default' => [
+                'drivers' => [
                     'DoctrineORMModuleTest\Assets\Entity' => 'DoctrineORMModuleTest\Assets\Entity',
-                ),
-            ),
-        ),
-        'entity_resolver' => array(
-            'orm_default' => array(
-                'resolvers' => array(
+                ],
+            ],
+        ],
+        'entity_resolver' => [
+            'orm_default' => [
+                'resolvers' => [
                     'DoctrineORMModuleTest\Assets\Entity\TargetInterface'
                         => 'DoctrineORMModuleTest\Assets\Entity\TargetEntity',
-                ),
-            ),
-        ),
-        'connection' => array(
-            'orm_default' => array(
+                ],
+            ],
+        ],
+        'connection' => [
+            'orm_default' => [
                 'configuration' => 'orm_default',
                 'eventmanager'  => 'orm_default',
                 'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
-                'params' => array(
+                'params' => [
                     'memory' => true,
-                ),
-            ),
-        ),
-        'migrations_configuration' => array(
-            'orm_default' => array(
+                ],
+            ],
+        ],
+        'migrations_configuration' => [
+            'orm_default' => [
                 'directory' => 'build/',
-            ),
-        ),
-    ),
-);
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
This PR

* [x] uses short array syntax

Follows #488.
Related to #479.
