### PR TITLE
Update to EXTRA_ORM.md to correct config key

### DIFF
--- a/docs/EXTRAS_ORM.md
+++ b/docs/EXTRAS_ORM.md
@@ -60,7 +60,7 @@ key in you configuration file:
 return array(
     'doctrine' => array(
         'configuration' => array(
-            'my_dbal_default' => array(
+            'orm_default' => array(
                 'types' => array(
                     // You can override a default type
                     'date' => 'My\DBAL\Types\DateType',


### PR DESCRIPTION
As there is no reference to be found to my_dbal_default I found that the correct value needs to be orm_default, as goes for all the other configuration elements.