### PR TITLE
Hotfix router config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,15 +31,9 @@
             "email": "guilhermeblanco@hotmail.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/webimpress/DoctrineModule"
-        }
-    ],
     "require":           {
         "php":                               "^5.6 || ^7.0",
-        "doctrine/doctrine-module":          "dev-feature/zf3compat",
+        "doctrine/doctrine-module":          "dev-master",
         "doctrine/orm":                      ">=2.5,<2.7",
         "doctrine/dbal":                     ">=2.4,<2.7",
         "symfony/console":                   "^2.3 || ^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a0ab3a7d37aa9e35111d1a987009f65e",
-    "content-hash": "3ea915609b3f86ab34379dea950ef020",
+    "hash": "45beef2ffb1e8259615c05329c171276",
+    "content-hash": "c7a777bd348da4d97cb29784869d9a94",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -384,16 +384,16 @@
         },
         {
             "name": "doctrine/doctrine-module",
-            "version": "dev-feature/zf3compat",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webimpress/DoctrineModule.git",
-                "reference": "4e2a72aab5eb23b428b12cfacd6dcfd48e0a6270"
+                "url": "https://github.com/doctrine/DoctrineModule.git",
+                "reference": "4329f63dc191cbc2fabe5949c19365e9e0d040b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webimpress/DoctrineModule/zipball/4e2a72aab5eb23b428b12cfacd6dcfd48e0a6270",
-                "reference": "4e2a72aab5eb23b428b12cfacd6dcfd48e0a6270",
+                "url": "https://api.github.com/repos/doctrine/DoctrineModule/zipball/4329f63dc191cbc2fabe5949c19365e9e0d040b1",
+                "reference": "4329f63dc191cbc2fabe5949c19365e9e0d040b1",
                 "shasum": ""
             },
             "require": {
@@ -435,11 +435,7 @@
                     "DoctrineModule\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-0": {
-                    "DoctrineModuleTest\\": "tests/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -450,11 +446,6 @@
                     "homepage": "http://www.spiffyjr.me/"
                 },
                 {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://marco-pivetta.com/"
-                },
-                {
                     "name": "Guilherme Blanco",
                     "email": "guilhermeblanco@hotmail.com"
                 },
@@ -462,6 +453,11 @@
                     "name": "Michaël Gallego",
                     "email": "mic.gallego@gmail.com",
                     "homepage": "http://www.michaelgallego.fr"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://marco-pivetta.com/"
                 }
             ],
             "description": "Zend Framework 2 Module that provides Doctrine basic functionality required for ORM and ODM modules",
@@ -471,10 +467,7 @@
                 "module",
                 "zf2"
             ],
-            "support": {
-                "source": "https://github.com/webimpress/DoctrineModule/tree/feature/zf3compat"
-            },
-            "time": "2016-07-26 14:54:51"
+            "time": "2016-08-01 09:46:47"
         },
         {
             "name": "doctrine/inflector",

--- a/config/controllers.config.php
+++ b/config/controllers.config.php
@@ -17,29 +17,15 @@
  * <http://www.doctrine-project.org>.
  */
 
-use DoctrineORMModule\Yuml\YumlController;
-use Zend\Http\Client;
-use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
+namespace DoctrineORMModule;
 
-return array(
-    'factories' => array(
+use DoctrineORMModule\Yuml\YumlController;
+use DoctrineORMModule\Yuml\YumlControllerFactory;
+
+return [
+    'factories' => [
         // Yuml controller, used to generate Yuml graphs since
         // yuml.me doesn't do redirects on its own
-        'DoctrineORMModule\\Yuml\\YumlController'  => function (AbstractPluginManager $pluginManager) {
-            $config = $pluginManager->getServiceLocator()->get('Config');
-
-            if (! isset($config['zenddevelopertools']['toolbar']['enabled'])
-                || !$config['zenddevelopertools']['toolbar']['enabled']
-            ) {
-                throw new ServiceNotFoundException(
-                    'Service DoctrineORMModule\\Yuml\\YumlController could not be found'
-                );
-            }
-
-            return new YumlController(
-                new Client('http://yuml.me/diagram/plain/class/', array('timeout' => 30))
-            );
-        },
-    ),
-);
+        YumlController::class => YumlControllerFactory::class,
+    ],
+];

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -257,7 +257,7 @@ return array(
     'router' => array(
         'routes' => array(
             'doctrine_orm_module_yuml' => array(
-                'type' => 'Zend\\Mvc\\Router\\Http\\Literal',
+                'type' => 'literal',
                 'options' => array(
                     'route' => '/ocra_service_manager_yuml',
                     'defaults' => array(

--- a/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
@@ -101,7 +101,7 @@ class DBALConfigurationFactory implements FactoryInterface
      */
     public function getOptions(ContainerInterface $serviceLocator)
     {
-        $options = $serviceLocator->get('Config');
+        $options = $serviceLocator->get('config');
         $options = $options['doctrine'];
         $options = isset($options['configuration'][$this->name]) ? $options['configuration'][$this->name] : null;
 

--- a/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
@@ -43,7 +43,7 @@ class MigrationsConfigurationFactory extends AbstractFactory
         $name             = $this->getName();
         /* @var $connection \Doctrine\DBAL\Connection */
         $connection       = $container->get('doctrine.connection.' . $name);
-        $appConfig        = $container->get('Config');
+        $appConfig        = $container->get('config');
         $migrationsConfig = $appConfig['doctrine']['migrations_configuration'][$name];
         $configuration    = new Configuration($connection);
 

--- a/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
@@ -94,7 +94,7 @@ class SQLLoggerCollectorFactory implements FactoryInterface
      */
     protected function getOptions(ContainerInterface $serviceLocator)
     {
-        $options = $serviceLocator->get('Config');
+        $options = $serviceLocator->get('config');
         $options = $options['doctrine'];
         $options = isset($options['sql_logger_collector'][$this->name])
             ? $options['sql_logger_collector'][$this->name]

--- a/src/DoctrineORMModule/Yuml/YumlControllerFactory.php
+++ b/src/DoctrineORMModule/Yuml/YumlControllerFactory.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModule\Yuml;
+
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\Http\Client;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class YumlControllerFactory implements FactoryInterface
+{
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     *
+     * @return YumlController
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        if ($serviceLocator instanceof AbstractPluginManager) {
+            $serviceLocator = $serviceLocator->getServiceLocator() ?: $serviceLocator;
+        }
+
+        return $this($serviceLocator, YumlController::class);
+    }
+
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return YumlController
+     *
+     * @throws \Interop\Container\Exception\NotFoundException
+     * @throws ServiceNotFoundException if unable to resolve the service
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('config');
+
+        if (!isset($config['zenddevelopertools']['toolbar']['enabled'])
+            || !$config['zenddevelopertools']['toolbar']['enabled']
+        ) {
+            throw new ServiceNotFoundException(
+                sprintf('Service %s could not be found', YumlController::class)
+            );
+        }
+
+        return new YumlController(
+            new Client('http://yuml.me/diagram/plain/class/', ['timeout' => 30])
+        );
+    }
+}

--- a/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
@@ -58,7 +58,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $ormConfig = $this->factory->createService($this->serviceManager);
         $this->assertInstanceOf('Doctrine\ORM\Mapping\NamingStrategy', $ormConfig->getNamingStrategy());
     }
@@ -76,7 +76,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
         $this->assertSame($namingStrategy, $ormConfig->getNamingStrategy());
@@ -94,7 +94,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('test_naming_strategy', $namingStrategy);
         $ormConfig = $this->factory->createService($this->serviceManager);
         $this->assertSame($namingStrategy, $ormConfig->getNamingStrategy());
@@ -111,7 +111,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->setExpectedException('Zend\ServiceManager\Exception\InvalidArgumentException');
         $this->factory->createService($this->serviceManager);
     }
@@ -129,7 +129,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
         $this->assertSame($quoteStrategy, $ormConfig->getQuoteStrategy());
@@ -147,7 +147,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('test_quote_strategy', $quoteStrategy);
         $ormConfig = $this->factory->createService($this->serviceManager);
         $this->assertSame($quoteStrategy, $ormConfig->getQuoteStrategy());
@@ -164,7 +164,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->setExpectedException('Zend\ServiceManager\Exception\InvalidArgumentException');
         $this->factory->createService($this->serviceManager);
     }
@@ -180,7 +180,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
         $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $ormConfig->getHydrationCacheImpl());
@@ -201,7 +201,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
 
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
@@ -219,7 +219,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
         $this->assertEquals('Factory', $ormConfig->getClassMetadataFactoryName());
@@ -235,7 +235,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
         $this->assertEquals('Doctrine\ORM\Mapping\ClassMetadataFactory', $ormConfig->getClassMetadataFactoryName());
@@ -251,7 +251,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
 
         $ormConfig = $this->factory->createService($this->serviceManager);
 
@@ -272,7 +272,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
 
         $ormConfig = $this->factory->createService($this->serviceManager);
 
@@ -293,7 +293,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('test_entity_listener_resolver', $entityListenerResolver);
 
         $ormConfig = $this->factory->createService($this->serviceManager);
@@ -311,7 +311,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
 
         $ormConfig = $this->factory->createService($this->serviceManager);
 
@@ -349,7 +349,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
 
         $ormConfig        = $this->factory->createService($this->serviceManager);
         $secondLevelCache = $ormConfig->getSecondLevelCacheConfiguration();

--- a/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -75,7 +75,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
             ->getMock();
 
         $this->serviceManager->setService('doctrine.configuration.orm_default', $configurationMock);
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
 
         $dbal = $this->factory->createService($this->serviceManager);
@@ -110,7 +110,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
                 ),
             ),
         );
-        $this->serviceManager->setService('Config', $config);
+        $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
         $this->serviceManager->setService(
             'doctrine.driver.orm_default',

--- a/tests/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
@@ -52,7 +52,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $configuration = new ORMConfiguration();
         $this->services->setService('doctrine.configuration.orm_default', $configuration);
         $this->services->setService(
-            'Config',
+            'config',
             array(
                 'doctrine' => array(
                     'sql_logger_collector' => array(
@@ -71,7 +71,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $configuration = new ORMConfiguration();
         $this->services->setService('configuration_service_id', $configuration);
         $this->services->setService(
-            'Config',
+            'config',
             array(
                 'doctrine' => array(
                     'sql_logger_collector' => array(
@@ -104,7 +104,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('doctrine.configuration.orm_default', $configuration);
         $this->services->setService('custom_logger', $injectedLogger);
         $this->services->setService(
-            'Config',
+            'config',
             array(
                 'doctrine' => array(
                     'sql_logger_collector' => array(
@@ -128,7 +128,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->services->setService('doctrine.configuration.orm_default', $configuration);
         $this->services->setService('logger_service_id', $logger);
         $this->services->setService(
-            'Config',
+            'config',
             array(
                 'doctrine' => array(
                     'sql_logger_collector' => array(
@@ -147,7 +147,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
     {
         $this->services->setService('doctrine.configuration.orm_default', new ORMConfiguration());
         $this->services->setService(
-            'Config',
+            'config',
             array(
                 'doctrine' => array(
                     'sql_logger_collector' => array(

--- a/tests/DoctrineORMModuleTest/Yuml/YumlControllerFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/YumlControllerFactoryTest.php
@@ -1,0 +1,97 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModuleTest\Yuml;
+
+use PHPUnit_Framework_TestCase;
+use DoctrineORMModule\Yuml\YumlController;
+use DoctrineORMModule\Yuml\YumlControllerFactory;
+use Zend\ServiceManager\AbstractPluginManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class YumlControllerFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testCreateService()
+    {
+        $config = [
+            'zenddevelopertools' => [
+                'toolbar' => [
+                    'enabled' => true,
+                ],
+            ],
+        ];
+
+        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+        $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
+        $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
+
+        $factory = new YumlControllerFactory();
+        $controller = $factory->createService($pluginManager);
+
+        $this->assertInstanceOf(YumlController::class, $controller);
+    }
+
+    public function testCreateServiceWithNotEnabledToolbar()
+    {
+        $config = [
+            'zenddevelopertools' => [
+                'toolbar' => [
+                    'enabled' => false,
+                ],
+            ],
+        ];
+
+        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+        $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
+        $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
+
+        $factory = new YumlControllerFactory();
+
+        $this->setExpectedException(\Zend\ServiceManager\Exception\ServiceNotFoundException::class);
+        $factory->createService($pluginManager);
+    }
+
+    public function testCreateServiceWithNoConfigKey()
+    {
+        $config = [
+            'zenddevelopertools' => [],
+        ];
+
+        $serviceLocator = $this->getMock(ServiceLocatorInterface::class);
+        $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
+        $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
+
+        $factory = new YumlControllerFactory();
+
+        $this->setExpectedException(\Zend\ServiceManager\Exception\ServiceNotFoundException::class);
+        $factory->createService($pluginManager);
+    }
+}


### PR DESCRIPTION
- Fixed route to be compatible with both `zend-mvc`<3.0 and `zend-router`. The route configuration is moved to the Module class implementing `RouteProviderInterface`.

- Replaced `Config` key with the standardized and lowercased `config` key.