### PR TITLE
Fix: Missing view helper "zendDeveloperToolsTime"

### DIFF
--- a/view/zend-developer-tools/toolbar/doctrine-orm-queries.phtml
+++ b/view/zend-developer-tools/toolbar/doctrine-orm-queries.phtml
@@ -5,7 +5,7 @@
         <span class="zdt-toolbar-info">
             <?php echo $collector->getQueryCount(); ?>
             queries in
-            <?php echo $this->zendDeveloperToolsTime($collector->getQueryTime()); ?>
+            <?php echo $this->ZendDeveloperToolsTime($collector->getQueryTime()); ?>
         </span>
     </div>
     <div class="zdt-toolbar-detail">


### PR DESCRIPTION
Fixes the error 'A plugin by the name "zendDeveloperToolsTime" was not found in the plugin manager'