### PR TITLE
Expose to `zend-component-installer` as module `DoctrineORMModule`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,11 @@
             "email": "guilhermeblanco@hotmail.com"
         }
     ],
+    "extra": {
+        "zf": {
+            "module": "DoctrineORMModule"
+        }
+    },
     "require":           {
         "php":                               "^5.6 || ^7.0",
         "doctrine/doctrine-module":          "dev-master",


### PR DESCRIPTION
There is new library used with zend application skeleton and apigility skeleton to simplify installation of new modules: [`zend-component-installer`](https://github.com/zendframework/zend-component-installer).