### PR TITLE
Removed direct interface implementations

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -21,10 +21,6 @@ namespace DoctrineORMModule;
 
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
-use Zend\ModuleManager\Feature\ControllerProviderInterface;
-use Zend\ModuleManager\Feature\ConfigProviderInterface;
-use Zend\ModuleManager\Feature\InitProviderInterface;
-use Zend\ModuleManager\Feature\DependencyIndicatorInterface;
 use Zend\ModuleManager\ModuleManagerInterface;
 use Zend\EventManager\EventInterface;
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
@@ -39,11 +35,7 @@ use Zend\Stdlib\ArrayUtils;
  * @author  Kyle Spraggs <theman@spiffyjr.me>
  * @author  Marco Pivetta <ocramius@gmail.com>
  */
-class Module implements
-    ControllerProviderInterface,
-    ConfigProviderInterface,
-    InitProviderInterface,
-    DependencyIndicatorInterface
+class Module
 {
     /**
      * {@inheritDoc}


### PR DESCRIPTION
These will be phased out of ModuleManager and pushed to the appropriate components in the near future.

Module Manager checks if interface is implemented or method exists.
This direct implementation of interfaces is removed in all ZF and Apigility modules so it should be removed also here for future compatibility. **No BC Break!**