### PR TITLE
::class update and test update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,30 +31,30 @@ configuration for each of your entities namespaces:
 
 ```php
 <?php
-return array(
-    'doctrine' => array(
-        'driver' => array(
+return [
+    'doctrine' => [
+        'driver' => [
             // defines an annotation driver with two paths, and names it `my_annotation_driver`
-            'my_annotation_driver' => array(
-                'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
+            'my_annotation_driver' => [
+                'class' => \Doctrine\ORM\Mapping\Driver\AnnotationDriver::class,
                 'cache' => 'array',
-                'paths' => array(
+                'paths' => [
                     'path/to/my/entities',
                     'another/path'
-                ),
-            ),
+                ],
+            ],
 
             // default metadata driver, aggregates all other drivers into a single one.
             // Override `orm_default` only if you know what you're doing
-            'orm_default' => array(
-                'drivers' => array(
+            'orm_default' => [
+                'drivers' => [
                     // register `my_annotation_driver` for any entity under namespace `My\Namespace`
                     'My\Namespace' => 'my_annotation_driver'
-                )
-            )
-        )
-    )
-);
+                ],
+            ],
+        ],
+    ],
+];
 ```
 
 ## Connection settings
@@ -63,23 +63,23 @@ Connection parameters can be defined in the application configuration:
 
 ```php
 <?php
-return array(
-    'doctrine' => array(
-        'connection' => array(
+return [
+    'doctrine' => [
+        'connection' => [
             // default connection name
-            'orm_default' => array(
-                'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
-                'params' => array(
+            'orm_default' => [
+                'driverClass' => \Doctrine\DBAL\Driver\PDOMySql\Driver::class,
+                'params' => [
                     'host'     => 'localhost',
                     'port'     => '3306',
                     'user'     => 'username',
                     'password' => 'password',
                     'dbname'   => 'database',
-                )
-            )
-        )
-    ),
-);
+                ]
+            ]
+        ]
+    ],
+];
 ```
 
 #### Full configuration options
@@ -117,5 +117,5 @@ To access the entity manager, use the main service locator:
 ```php
 // for example, in a controller:
 $em = $this->getServiceLocator()->get('doctrine.entitymanager.orm_default');
-$em = $this->getServiceLocator()->get('Doctrine\ORM\EntityManager');
+$em = $this->getServiceLocator()->get(\Doctrine\ORM\EntityManager::class);
 ```

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -18,6 +18,7 @@
  */
 
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\DBAL\Tools\Console;
 use Doctrine\ORM\Tools\Console\Command;
 use DoctrineModule\Form\Element;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
@@ -198,8 +199,8 @@ return array(
         ),
         'invokables' => array(
             // DBAL commands
-            'doctrine.dbal_cmd.runsql' => \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand::class,
-            'doctrine.dbal_cmd.import' => \Doctrine\DBAL\Tools\Console\Command\ImportCommand::class,
+            'doctrine.dbal_cmd.runsql' => Console\Command\RunSqlCommand::class,
+            'doctrine.dbal_cmd.import' => Console\Command\ImportCommand::class,
             // ORM Commands
             'doctrine.orm_cmd.clear_cache_metadata' => Command\ClearCache\MetadataCommand::class,
             'doctrine.orm_cmd.clear_cache_result' => Command\ClearCache\ResultCommand::class,

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -17,6 +17,13 @@
  * <http://www.doctrine-project.org>.
  */
 
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\ORM\Tools\Console\Command;
+use DoctrineModule\Form\Element;
+use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
+use DoctrineORMModule\Service;
+use DoctrineORMModule\Yuml;
+
 return array(
     'doctrine' => array(
         'connection' => array(
@@ -99,7 +106,7 @@ return array(
             'orm_default' => array(
                 // By default, the ORM module uses a driver chain. This allows multiple
                 // modules to define their own entities
-                'class'   => 'Doctrine\ORM\Mapping\Driver\DriverChain',
+                'class'   => MappingDriverChain::class,
 
                 // Map of driver names to be used within this driver chain, indexed by
                 // entity namespace
@@ -187,64 +194,62 @@ return array(
 
     'service_manager' => array(
         'factories' => array(
-            'Doctrine\ORM\EntityManager' => 'DoctrineORMModule\Service\EntityManagerAliasCompatFactory',
+            'Doctrine\ORM\EntityManager' => Service\EntityManagerAliasCompatFactory::class,
         ),
         'invokables' => array(
             // DBAL commands
-            'doctrine.dbal_cmd.runsql' => '\Doctrine\DBAL\Tools\Console\Command\RunSqlCommand',
-            'doctrine.dbal_cmd.import' => '\Doctrine\DBAL\Tools\Console\Command\ImportCommand',
+            'doctrine.dbal_cmd.runsql' => \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand::class,
+            'doctrine.dbal_cmd.import' => \Doctrine\DBAL\Tools\Console\Command\ImportCommand::class,
             // ORM Commands
-            'doctrine.orm_cmd.clear_cache_metadata' => '\Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand',
-            'doctrine.orm_cmd.clear_cache_result' => '\Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand',
-            'doctrine.orm_cmd.clear_cache_query' => '\Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand',
-            'doctrine.orm_cmd.schema_tool_create' => '\Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand',
-            'doctrine.orm_cmd.schema_tool_update' => '\Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand',
-            'doctrine.orm_cmd.schema_tool_drop' => '\Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand',
-            'doctrine.orm_cmd.convert_d1_schema' => '\Doctrine\ORM\Tools\Console\Command\ConvertDoctrine1SchemaCommand',
-            'doctrine.orm_cmd.generate_entities' => '\Doctrine\ORM\Tools\Console\Command\GenerateEntitiesCommand',
-            'doctrine.orm_cmd.generate_proxies' => '\Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand',
-            'doctrine.orm_cmd.convert_mapping' => '\Doctrine\ORM\Tools\Console\Command\ConvertMappingCommand',
-            'doctrine.orm_cmd.run_dql' => '\Doctrine\ORM\Tools\Console\Command\RunDqlCommand',
-            'doctrine.orm_cmd.validate_schema' => '\Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand',
-            'doctrine.orm_cmd.info' => '\Doctrine\ORM\Tools\Console\Command\InfoCommand',
-            'doctrine.orm_cmd.ensure_production_settings'
-                => '\Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand',
-            'doctrine.orm_cmd.generate_repositories'
-                => '\Doctrine\ORM\Tools\Console\Command\GenerateRepositoriesCommand',
+            'doctrine.orm_cmd.clear_cache_metadata' => Command\ClearCache\MetadataCommand::class,
+            'doctrine.orm_cmd.clear_cache_result' => Command\ClearCache\ResultCommand::class,
+            'doctrine.orm_cmd.clear_cache_query' => Command\ClearCache\QueryCommand::class,
+            'doctrine.orm_cmd.schema_tool_create' => Command\SchemaTool\CreateCommand::class,
+            'doctrine.orm_cmd.schema_tool_update' => Command\SchemaTool\UpdateCommand::class,
+            'doctrine.orm_cmd.schema_tool_drop' => Command\SchemaTool\DropCommand::class,
+            'doctrine.orm_cmd.convert_d1_schema' => Command\ConvertDoctrine1SchemaCommand::class,
+            'doctrine.orm_cmd.generate_entities' => Command\GenerateEntitiesCommand::class,
+            'doctrine.orm_cmd.generate_proxies' => Command\GenerateProxiesCommand::class,
+            'doctrine.orm_cmd.convert_mapping' => Command\ConvertMappingCommand::class,
+            'doctrine.orm_cmd.run_dql' => Command\RunDqlCommand::class,
+            'doctrine.orm_cmd.validate_schema' => Command\ValidateSchemaCommand::class,
+            'doctrine.orm_cmd.info' => Command\InfoCommand::class,
+            'doctrine.orm_cmd.ensure_production_settings' => Command\EnsureProductionSettingsCommand::class,
+            'doctrine.orm_cmd.generate_repositories' => Command\GenerateRepositoriesCommand::class,
         ),
     ),
 
     // Factory mappings - used to define which factory to use to instantiate a particular doctrine
     // service type
     'doctrine_factories' => array(
-        'connection'               => 'DoctrineORMModule\Service\DBALConnectionFactory',
-        'configuration'            => 'DoctrineORMModule\Service\ConfigurationFactory',
-        'entitymanager'            => 'DoctrineORMModule\Service\EntityManagerFactory',
-        'entity_resolver'          => 'DoctrineORMModule\Service\EntityResolverFactory',
-        'sql_logger_collector'     => 'DoctrineORMModule\Service\SQLLoggerCollectorFactory',
-        'mapping_collector'        => 'DoctrineORMModule\Service\MappingCollectorFactory',
-        'formannotationbuilder'    => 'DoctrineORMModule\Service\FormAnnotationBuilderFactory',
-        'migrations_configuration' => 'DoctrineORMModule\Service\MigrationsConfigurationFactory',
-        'migrations_cmd'           => 'DoctrineORMModule\Service\MigrationsCommandFactory',
+        'connection'               => Service\DBALConnectionFactory::class,
+        'configuration'            => Service\ConfigurationFactory::class,
+        'entitymanager'            => Service\EntityManagerFactory::class,
+        'entity_resolver'          => Service\EntityResolverFactory::class,
+        'sql_logger_collector'     => Service\SQLLoggerCollectorFactory::class,
+        'mapping_collector'        => Service\MappingCollectorFactory::class,
+        'formannotationbuilder'    => Service\FormAnnotationBuilderFactory::class,
+        'migrations_configuration' => Service\MigrationsConfigurationFactory::class,
+        'migrations_cmd'           => Service\MigrationsCommandFactory::class,
     ),
 
     // Zend\Form\FormElementManager configuration
     'form_elements' => array(
         'aliases' => array(
-            'objectselect'        => 'DoctrineModule\Form\Element\ObjectSelect',
-            'objectradio'         => 'DoctrineModule\Form\Element\ObjectRadio',
-            'objectmulticheckbox' => 'DoctrineModule\Form\Element\ObjectMultiCheckbox',
+            'objectselect'        => Element\ObjectSelect::class,
+            'objectradio'         => Element\ObjectRadio::class,
+            'objectmulticheckbox' => Element\ObjectMultiCheckbox::class,
         ),
         'factories' => array(
-            'DoctrineModule\Form\Element\ObjectSelect'        => 'DoctrineORMModule\Service\ObjectSelectFactory',
-            'DoctrineModule\Form\Element\ObjectRadio'         => 'DoctrineORMModule\Service\ObjectRadioFactory',
-            'DoctrineModule\Form\Element\ObjectMultiCheckbox' => 'DoctrineORMModule\Service\ObjectMultiCheckboxFactory',
+            Element\ObjectSelect::class        => Service\ObjectSelectFactory::class,
+            Element\ObjectRadio::class         => Service\ObjectRadioFactory::class,
+            Element\ObjectMultiCheckbox::class => Service\ObjectMultiCheckboxFactory::class,
         ),
     ),
 
     'hydrators' => array(
         'factories' => array(
-            'DoctrineModule\Stdlib\Hydrator\DoctrineObject' => 'DoctrineORMModule\Service\DoctrineObjectHydratorFactory'
+            DoctrineObject::class => Service\DoctrineObjectHydratorFactory::class
         )
     ),
 
@@ -261,7 +266,7 @@ return array(
                 'options' => array(
                     'route' => '/ocra_service_manager_yuml',
                     'defaults' => array(
-                        'controller' => 'DoctrineORMModule\\Yuml\\YumlController',
+                        'controller' => Yuml\YumlController::class,
                         'action'     => 'index',
                     ),
                 ),

--- a/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
+++ b/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
@@ -21,6 +21,7 @@ namespace DoctrineORMModule\Form\Annotation;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
+use DoctrineModule\Form\Element;
 use Zend\EventManager\EventManagerInterface;
 use Zend\Form\Annotation\AnnotationBuilder as ZendAnnotationBuilder;
 
@@ -77,9 +78,9 @@ class AnnotationBuilder extends ZendAnnotationBuilder
         $inputFilter  = $formSpec['input_filter'];
 
         $formElements = array(
-            'DoctrineModule\Form\Element\ObjectSelect',
-            'DoctrineModule\Form\Element\ObjectMultiCheckbox',
-            'DoctrineModule\Form\Element\ObjectRadio',
+            Element\ObjectSelect::class,
+            Element\ObjectMultiCheckbox::class,
+            Element\ObjectRadio::class,
         );
 
         foreach ($formSpec['elements'] as $key => $elementSpec) {

--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -22,10 +22,11 @@ namespace DoctrineORMModule\Form\Annotation;
 use ArrayObject;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
-use DoctrineModule\Form\Element;
+use DoctrineORMModule\Form\Element\EntitySelect;
 use Zend\EventManager\AbstractListenerAggregate;
 use Zend\EventManager\EventInterface;
 use Zend\EventManager\EventManagerInterface;
+use Zend\Form\Element as ZendFormElement;
 
 /**
  * @author Kyle Spraggs <theman@spiffyjr.me>
@@ -283,27 +284,27 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
             case 'bigint':
             case 'integer':
             case 'smallint':
-                $type = 'Zend\Form\Element\Number';
+                $type = ZendFormElement\Number::class;
                 break;
             case 'bool':
             case 'boolean':
-                $type = 'Zend\Form\Element\Checkbox';
+                $type = ZendFormElement\Checkbox::class;
                 break;
             case 'date':
-                $type = 'Zend\Form\Element\Date';
+                $type = ZendFormElement\Date::class;
                 break;
             case 'datetimetz':
             case 'datetime':
-                $type = 'Zend\Form\Element\DateTime';
+                $type = ZendFormElement\DateTime::class;
                 break;
             case 'time':
-                $type = 'Zend\Form\Element\Time';
+                $type = ZendFormElement\Time::class;
                 break;
             case 'text':
-                $type = 'Zend\Form\Element\Textarea';
+                $type = ZendFormElement\Textarea::class;
                 break;
             default:
-                $type = 'Zend\Form\Element';
+                $type = ZendFormElement::class;
                 break;
         }
 
@@ -408,7 +409,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
 
         $elementSpec['spec']['options'] = $options;
         if (!isset($elementSpec['spec']['type'])) {
-            $elementSpec['spec']['type'] = 'DoctrineORMModule\Form\Element\EntitySelect';
+            $elementSpec['spec']['type'] = EntitySelect::class;
         }
     }
 

--- a/src/DoctrineORMModule/Options/DBALConnection.php
+++ b/src/DoctrineORMModule/Options/DBALConnection.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModule\Options;
 
+use Doctrine\DBAL\Driver\PDOMySql\Driver;
 use Zend\Stdlib\AbstractOptions;
 
 /**
@@ -62,7 +63,7 @@ class DBALConnection extends AbstractOptions
      *
      * @var string
      */
-    protected $driverClass = 'Doctrine\DBAL\Driver\PDOMySql\Driver';
+    protected $driverClass = Driver::class;
 
     /**
      * Set the wrapper class for the driver. In general, this should not

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -23,6 +23,7 @@ use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Cache\RegionsConfiguration;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
+use DoctrineORMModule\Options\Configuration as DoctrineORMModuleConfiguration;
 use DoctrineORMModule\Service\DBALConfigurationFactory as DoctrineConfigurationFactory;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -38,7 +39,7 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /** @var $options \DoctrineORMModule\Options\Configuration */
+        /** @var $options DoctrineORMModuleConfiguration */
         $options = $this->getOptions($container);
         $config  = new Configuration();
 
@@ -166,8 +167,11 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
         return $this($container, Configuration::class);
     }
 
+    /**
+     * @return string
+     */
     protected function getOptionsClass()
     {
-        return 'DoctrineORMModule\Options\Configuration';
+        return DoctrineORMModuleConfiguration::class;
     }
 }

--- a/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModule\Service;
 
+use DoctrineORMModule\Options\Configuration as DoctrineORMModuleConfiguration;
 use Interop\Container\ContainerInterface;
 use RuntimeException;
 use Doctrine\DBAL\Configuration;
@@ -124,6 +125,6 @@ class DBALConfigurationFactory implements FactoryInterface
      */
     protected function getOptionsClass()
     {
-        return 'DoctrineModule\Options\Configuration';
+        return DoctrineORMModuleConfiguration::class;
     }
 }

--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -19,9 +19,11 @@
 
 namespace DoctrineORMModule\Service;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Types\Type;
 use DoctrineModule\Service\AbstractFactory;
+use DoctrineORMModule\Options\DBALConnection;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -37,11 +39,11 @@ class DBALConnectionFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
-     * @return \Doctrine\DBAL\Connection
+     * @return Connection
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /** @var $options \DoctrineORMModule\Options\DBALConnection */
+        /** @var $options DBALConnection */
         $options = $this->getOptions($container, 'connection');
         $pdo     = $options->getPdo();
 
@@ -74,11 +76,11 @@ class DBALConnectionFactory extends AbstractFactory
 
     /**
      * {@inheritDoc}
-     * @return \Doctrine\DBAL\Connection
+     * @return Connection
      */
     public function createService(ServiceLocatorInterface $container)
     {
-        return $this($container, \Doctrine\DBAL\Connection::class);
+        return $this($container, Connection::class);
     }
 
     /**
@@ -88,6 +90,6 @@ class DBALConnectionFactory extends AbstractFactory
      */
     public function getOptionsClass()
     {
-        return 'DoctrineORMModule\Options\DBALConnection';
+        return DBALConnection::class;
     }
 }

--- a/src/DoctrineORMModule/Service/EntityManagerFactory.php
+++ b/src/DoctrineORMModule/Service/EntityManagerFactory.php
@@ -21,6 +21,7 @@ namespace DoctrineORMModule\Service;
 
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Service\AbstractFactory;
+use DoctrineORMModule\Options\EntityManager as DoctrineORMModuleEntityManager;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -33,7 +34,7 @@ class EntityManagerFactory extends AbstractFactory
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /* @var $options \DoctrineORMModule\Options\EntityManager */
+        /* @var $options DoctrineORMModuleEntityManager */
         $options    = $this->getOptions($container, 'entitymanager');
         $connection = $container->get($options->getConnection());
         $config     = $container->get($options->getConfiguration());
@@ -60,6 +61,6 @@ class EntityManagerFactory extends AbstractFactory
      */
     public function getOptionsClass()
     {
-        return 'DoctrineORMModule\Options\EntityManager';
+        return DoctrineORMModuleEntityManager::class;
     }
 }

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -23,7 +23,9 @@ use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
 use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use DoctrineModule\Service\AbstractFactory;
+use DoctrineORMModule\Options\EntityResolver;
 use Interop\Container\ContainerInterface;
+use Zend\EventManager\EventManager;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class EntityResolverFactory extends AbstractFactory
@@ -33,7 +35,7 @@ class EntityResolverFactory extends AbstractFactory
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /* @var $options \DoctrineORMModule\Options\EntityResolver */
+        /* @var $options EntityResolver */
         $options      = $this->getOptions($container, 'entity_resolver');
         $eventManager = $container->get($options->getEventManager());
         $resolvers    = $options->getResolvers();
@@ -59,7 +61,7 @@ class EntityResolverFactory extends AbstractFactory
      */
     public function createService(ServiceLocatorInterface $container)
     {
-        return $this($container, \Zend\EventManager\EventManager::class);
+        return $this($container, EventManager::class);
     }
 
     /**
@@ -69,6 +71,6 @@ class EntityResolverFactory extends AbstractFactory
      */
     public function getOptionsClass()
     {
-        return 'DoctrineORMModule\Options\EntityResolver';
+        return EntityResolver::class;
     }
 }

--- a/src/DoctrineORMModule/Service/ObjectMultiCheckboxFactory.php
+++ b/src/DoctrineORMModule/Service/ObjectMultiCheckboxFactory.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModule\Service;
 
+use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectMultiCheckbox;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -40,7 +41,7 @@ class ObjectMultiCheckboxFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $entityManager = $container->get('Doctrine\ORM\EntityManager');
+        $entityManager = $container->get(EntityManager::class);
         $element       = new ObjectMultiCheckbox;
 
         $element->getProxy()->setObjectManager($entityManager);

--- a/src/DoctrineORMModule/Service/ObjectRadioFactory.php
+++ b/src/DoctrineORMModule/Service/ObjectRadioFactory.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModule\Service;
 
+use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectRadio;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -40,7 +41,7 @@ class ObjectRadioFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $entityManager = $container->get('Doctrine\ORM\EntityManager');
+        $entityManager = $container->get(EntityManager::class);
         $element       = new ObjectRadio;
 
         $element->getProxy()->setObjectManager($entityManager);

--- a/src/DoctrineORMModule/Service/ObjectSelectFactory.php
+++ b/src/DoctrineORMModule/Service/ObjectSelectFactory.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModule\Service;
 
+use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectSelect;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -40,7 +41,7 @@ class ObjectSelectFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $entityManager = $container->get('Doctrine\ORM\EntityManager');
+        $entityManager = $container->get(EntityManager::class);
         $element       = new ObjectSelect;
 
         $element->getProxy()->setObjectManager($entityManager);

--- a/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
@@ -19,6 +19,7 @@
 
 namespace DoctrineORMModule\Service;
 
+use DoctrineORMModule\Options\SQLLoggerCollectorOptions;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -54,7 +55,7 @@ class SQLLoggerCollectorFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /** @var $options \DoctrineORMModule\Options\SQLLoggerCollectorOptions */
+        /** @var $options SQLLoggerCollectorOptions */
         $options = $this->getOptions($container);
 
         // @todo always ask the serviceLocator instead? (add a factory?)
@@ -119,6 +120,6 @@ class SQLLoggerCollectorFactory implements FactoryInterface
      */
     protected function getOptionsClass()
     {
-        return 'DoctrineORMModule\Options\SQLLoggerCollectorOptions';
+        return SQLLoggerCollectorOptions::class;
     }
 }

--- a/tests/DoctrineORMModuleTest/CliTest.php
+++ b/tests/DoctrineORMModuleTest/CliTest.php
@@ -72,73 +72,73 @@ class CliTest extends PHPUnit_Framework_TestCase
 
         /* @var $emHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
         $emHelper = $helperSet->get('em');
-        $this->assertInstanceOf('Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper', $emHelper);
+        $this->assertInstanceOf(\Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper::class, $emHelper);
         $this->assertSame($this->entityManager, $emHelper->getEntityManager());
 
         /* @var $dbHelper \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper */
         $dbHelper = $helperSet->get('db');
-        $this->assertInstanceOf('Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper', $dbHelper);
+        $this->assertInstanceOf(\Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper::class, $dbHelper);
         $this->assertSame($this->entityManager->getConnection(), $dbHelper->getConnection());
     }
 
     public function testValidCommands()
     {
-        $this->assertInstanceOf('Doctrine\DBAL\Tools\Console\Command\ImportCommand', $this->cli->get('dbal:import'));
-        $this->assertInstanceOf('Doctrine\DBAL\Tools\Console\Command\RunSqlCommand', $this->cli->get('dbal:run-sql'));
+        $this->assertInstanceOf(\Doctrine\DBAL\Tools\Console\Command\ImportCommand::class, $this->cli->get('dbal:import'));
+        $this->assertInstanceOf(\Doctrine\DBAL\Tools\Console\Command\RunSqlCommand::class, $this->cli->get('dbal:run-sql'));
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand',
+            \Doctrine\ORM\Tools\Console\Command\ClearCache\MetadataCommand::class,
             $this->cli->get('orm:clear-cache:metadata')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand',
+            \Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand::class,
             $this->cli->get('orm:clear-cache:query')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand',
+            \Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand::class,
             $this->cli->get('orm:clear-cache:result')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand',
+            \Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand::class,
             $this->cli->get('orm:generate-proxies')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand',
+            \Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand::class,
             $this->cli->get('orm:ensure-production-settings')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\InfoCommand',
+            \Doctrine\ORM\Tools\Console\Command\InfoCommand::class,
             $this->cli->get('orm:info')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand',
+            \Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand::class,
             $this->cli->get('orm:schema-tool:create')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand',
+            \Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand::class,
             $this->cli->get('orm:schema-tool:update')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand',
+            \Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand::class,
             $this->cli->get('orm:schema-tool:drop')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand',
+            \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand::class,
             $this->cli->get('orm:validate-schema')
         );
         $this->assertInstanceOf(
-            'Doctrine\ORM\Tools\Console\Command\RunDqlCommand',
+            \Doctrine\ORM\Tools\Console\Command\RunDqlCommand::class,
             $this->cli->get('orm:run-dql')
         );
         $this->assertInstanceOf(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand',
+            \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand::class,
             $this->cli->get('migrations:generate')
         );
         $this->assertInstanceOf(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand',
+            \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::class,
             $this->cli->get('migrations:diff')
         );
         $this->assertInstanceOf(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand',
+            \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand::class,
             $this->cli->get('migrations:execute')
         );
     }

--- a/tests/DoctrineORMModuleTest/CliTest.php
+++ b/tests/DoctrineORMModuleTest/CliTest.php
@@ -100,7 +100,7 @@ class CliTest extends PHPUnit_Framework_TestCase
 
         /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
         $entityManagerHelper = $application->getHelperSet()->get('entityManager');
-        $this->assertInstanceOf('Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper', $entityManagerHelper);
+        $this->assertInstanceOf(\Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper::class, $entityManagerHelper);
         $this->assertSame($this->objectManager, $entityManagerHelper->getEntityManager());
     }
 
@@ -109,11 +109,11 @@ class CliTest extends PHPUnit_Framework_TestCase
      */
     public function testEntityManagerUsedCanBeSpecifiedInCommandLineArgument()
     {
-        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+        $connection = $this->getMockBuilder(\Doctrine\DBAL\Connection::class)
             ->disableOriginalConstructor()
             ->getMock();
 
-        $entityManager = $this->getMockbuilder('Doctrine\ORM\EntityManager')
+        $entityManager = $this->getMockbuilder(\Doctrine\ORM\EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -134,7 +134,7 @@ class CliTest extends PHPUnit_Framework_TestCase
 
         /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
         $entityManagerHelper = $application->getHelperSet()->get('entityManager');
-        $this->assertInstanceOf('Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper', $entityManagerHelper);
+        $this->assertInstanceOf(\Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper::class, $entityManagerHelper);
         $this->assertSame($entityManager, $entityManagerHelper->getEntityManager());
     }
 
@@ -171,63 +171,63 @@ class CliTest extends PHPUnit_Framework_TestCase
         return [
             [
                 'dbal:import',
-                'Doctrine\DBAL\Tools\Console\Command\ImportCommand',
+                \Doctrine\DBAL\Tools\Console\Command\ImportCommand::class,
             ],
             [
                 'dbal:run-sql',
-                'Doctrine\DBAL\Tools\Console\Command\RunSqlCommand',
+                \Doctrine\DBAL\Tools\Console\Command\RunSqlCommand::class,
             ],
             [
                 'orm:clear-cache:query',
-                'Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand',
+                \Doctrine\ORM\Tools\Console\Command\ClearCache\QueryCommand::class,
             ],
             [
                 'orm:clear-cache:result',
-                'Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand',
+                \Doctrine\ORM\Tools\Console\Command\ClearCache\ResultCommand::class,
             ],
             [
                 'orm:generate-proxies',
-                'Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand',
+                \Doctrine\ORM\Tools\Console\Command\GenerateProxiesCommand::class,
             ],
             [
                 'orm:ensure-production-settings',
-                'Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand',
+                \Doctrine\ORM\Tools\Console\Command\EnsureProductionSettingsCommand::class,
             ],
             [
                 'orm:info',
-                'Doctrine\ORM\Tools\Console\Command\InfoCommand',
+                \Doctrine\ORM\Tools\Console\Command\InfoCommand::class,
             ],
             [
                 'orm:schema-tool:create',
-                'Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand',
+                \Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand::class,
             ],
             [
                 'orm:schema-tool:update',
-                'Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand',
+                \Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand::class,
             ],
             [
                 'orm:schema-tool:drop',
-                'Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand',
+                \Doctrine\ORM\Tools\Console\Command\SchemaTool\DropCommand::class,
             ],
             [
                 'orm:validate-schema',
-                'Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand',
+                \Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand::class,
             ],
             [
                 'orm:run-dql',
-                'Doctrine\ORM\Tools\Console\Command\RunDqlCommand',
+                \Doctrine\ORM\Tools\Console\Command\RunDqlCommand::class,
             ],
             [
                 'migrations:generate',
-                'Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand',
+                \Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand::class,
             ],
             [
                 'migrations:diff',
-                'Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand',
+                \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::class,
             ],
             [
                 'migrations:execute',
-                'Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand',
+                \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand::class,
             ],
         ];
     }

--- a/tests/DoctrineORMModuleTest/Collector/MappingCollectorTest.php
+++ b/tests/DoctrineORMModuleTest/Collector/MappingCollectorTest.php
@@ -47,8 +47,7 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->metadataFactory = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadataFactory')
-            ->getMock();
+        $this->metadataFactory = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadataFactory::class);
         $this->collector       = new MappingCollector($this->metadataFactory, 'test-collector');
     }
 
@@ -74,11 +73,9 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
      */
     public function testCollect()
     {
-        $m1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $m1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
-        $m2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $m2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $m2->expects($this->any())->method('getName')->will($this->returnValue('M2'));
         $this
             ->metadataFactory
@@ -86,7 +83,7 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
             ->method('getAllMetadata')
             ->will($this->returnValue([$m1, $m2]));
 
-        $this->collector->collect($this->getMockBuilder('Zend\\Mvc\\MvcEvent')->getMock());
+        $this->collector->collect($this->createMock(\Zend\Mvc\MvcEvent::class));
 
         $classes = $this->collector->getClasses();
 
@@ -102,12 +99,11 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->collector->canHide());
 
-        $m1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $m1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
         $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue([$m1]));
 
-        $this->collector->collect($this->getMockBuilder('Zend\\Mvc\\MvcEvent')->getMock());
+        $this->collector->collect($this->createMock(\Zend\Mvc\MvcEvent::class));
 
         $this->assertFalse($this->collector->canHide());
     }
@@ -119,12 +115,11 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
      */
     public function testSerializeUnserializeAndCollectWithNoMetadataFactory()
     {
-        $m1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $m1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
         $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue([$m1]));
 
-        $this->collector->collect($this->getMockBuilder('Zend\\Mvc\\MvcEvent')->getMock());
+        $this->collector->collect($this->createMock(\Zend\Mvc\MvcEvent::class));
 
         /* @var $collector MappingCollector */
         $collector = unserialize(serialize($this->collector));
@@ -134,7 +129,7 @@ class MappingCollectorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($m1, $classes['M1']);
         $this->assertSame('test-collector', $collector->getName());
 
-        $collector->collect($this->getMockBuilder('Zend\\Mvc\\MvcEvent')->getMock());
+        $collector->collect($this->createMock(\Zend\Mvc\MvcEvent::class));
 
         $classes = $collector->getClasses();
         $this->assertCount(1, $classes);

--- a/tests/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
+++ b/tests/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
@@ -37,7 +37,7 @@ class AnnotationBuilderTest extends TestCase
      */
     public function testAnnotationBuilderSupportsClassNames()
     {
-        $spec = $this->builder->getFormSpecification('DoctrineORMModuleTest\\Assets\\Entity\\Issue237');
+        $spec = $this->builder->getFormSpecification(\DoctrineORMModuleTest\Assets\Entity\Issue237::class);
 
         $this->assertCount(0, $spec['elements'], 'Annotation builder allows also class names');
     }

--- a/tests/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
+++ b/tests/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
@@ -39,10 +39,10 @@ class ElementAnnotationsListenerTest extends TestCase
         $elementSpec = $event->getParam('elementSpec');
         $this->assertEquals($this->getEntityManager(), $elementSpec['spec']['options']['object_manager']);
         $this->assertEquals(
-            'DoctrineORMModuleTest\Assets\Entity\TargetEntity',
+            \DoctrineORMModuleTest\Assets\Entity\TargetEntity::class,
             $elementSpec['spec']['options']['target_class']
         );
-        $this->assertEquals('DoctrineORMModule\Form\Element\EntitySelect', $elementSpec['spec']['type']);
+        $this->assertEquals(\DoctrineORMModule\Form\Element\EntitySelect::class, $elementSpec['spec']['type']);
     }
 
     public function testToOneMergesOptions()
@@ -98,10 +98,10 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertTrue($elementSpec['spec']['attributes']['multiple']);
         $this->assertEquals($this->getEntityManager(), $elementSpec['spec']['options']['object_manager']);
         $this->assertEquals(
-            'DoctrineORMModuleTest\Assets\Entity\FormEntityTarget',
+            \DoctrineORMModuleTest\Assets\Entity\FormEntityTarget::class,
             $elementSpec['spec']['options']['target_class']
         );
-        $this->assertEquals('DoctrineORMModule\Form\Element\EntitySelect', $elementSpec['spec']['type']);
+        $this->assertEquals(\DoctrineORMModule\Form\Element\EntitySelect::class, $elementSpec['spec']['type']);
         $this->assertFalse($inputSpec['required']);
     }
 
@@ -289,17 +289,17 @@ class ElementAnnotationsListenerTest extends TestCase
     public function eventTypeProvider()
     {
         return [
-            ['bool', 'Zend\Form\Element\Checkbox'],
-            ['boolean', 'Zend\Form\Element\Checkbox'],
-            ['bigint', 'Zend\Form\Element\Number'],
-            ['integer', 'Zend\Form\Element\Number'],
-            ['smallint', 'Zend\Form\Element\Number'],
-            ['datetime', 'Zend\Form\Element\DateTime'],
-            ['datetimetz', 'Zend\Form\Element\DateTime'],
-            ['date', 'Zend\Form\Element\Date'],
-            ['time', 'Zend\Form\Element\Time'],
-            ['string', 'Zend\Form\Element'],
-            ['text', 'Zend\Form\Element\Textarea'],
+            ['bool', \Zend\Form\Element\Checkbox::class],
+            ['boolean', \Zend\Form\Element\Checkbox::class],
+            ['bigint', \Zend\Form\Element\Number::class],
+            ['integer', \Zend\Form\Element\Number::class],
+            ['smallint', \Zend\Form\Element\Number::class],
+            ['datetime', \Zend\Form\Element\DateTime::class],
+            ['datetimetz', \Zend\Form\Element\DateTime::class],
+            ['date', \Zend\Form\Element\Date::class],
+            ['time', \Zend\Form\Element\Time::class],
+            ['string', \Zend\Form\Element::class],
+            ['text', \Zend\Form\Element\Textarea::class],
         ];
     }
 
@@ -323,7 +323,7 @@ class ElementAnnotationsListenerTest extends TestCase
     protected function getMetadataEvent()
     {
         $event    = new Event();
-        $metadata = $this->getEntityManager()->getClassMetadata('DoctrineORMModuleTest\Assets\Entity\FormEntity');
+        $metadata = $this->getEntityManager()->getClassMetadata(\DoctrineORMModuleTest\Assets\Entity\FormEntity::class);
         $event->setParam('metadata', $metadata);
 
         return $event;

--- a/tests/DoctrineORMModuleTest/Options/ConfigurationOptionsTest.php
+++ b/tests/DoctrineORMModuleTest/Options/ConfigurationOptionsTest.php
@@ -34,12 +34,11 @@ class ConfigurationOptionsTest extends TestCase
         $options->setNamingStrategy('test');
         $this->assertSame('test', $options->getNamingStrategy());
 
-        $namingStrategy = $this->getMockBuilder('Doctrine\ORM\Mapping\NamingStrategy')
-            ->getMock();
+        $namingStrategy = $this->createMock(\Doctrine\ORM\Mapping\NamingStrategy::class);
         $options->setNamingStrategy($namingStrategy);
         $this->assertSame($namingStrategy, $options->getNamingStrategy());
 
-        $this->expectException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->expectException(\Zend\Stdlib\Exception\InvalidArgumentException::class);
         $options->setNamingStrategy(new \stdClass());
     }
 
@@ -52,12 +51,11 @@ class ConfigurationOptionsTest extends TestCase
         $options->setQuoteStrategy('test');
         $this->assertSame('test', $options->getQuoteStrategy());
 
-        $quoteStrategy = $this->getMockBuilder('Doctrine\ORM\Mapping\QuoteStrategy')
-            ->getMock();
+        $quoteStrategy = $this->createMock(\Doctrine\ORM\Mapping\QuoteStrategy::class);
         $options->setQuoteStrategy($quoteStrategy);
         $this->assertSame($quoteStrategy, $options->getQuoteStrategy());
 
-        $this->expectException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->expectException(\Zend\Stdlib\Exception\InvalidArgumentException::class);
         $options->setQuoteStrategy(new \stdClass());
     }
 
@@ -74,7 +72,7 @@ class ConfigurationOptionsTest extends TestCase
         $options->setRepositoryFactory($repositoryFactory);
         $this->assertSame($repositoryFactory, $options->getRepositoryFactory());
 
-        $this->expectException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->expectException(\Zend\Stdlib\Exception\InvalidArgumentException::class);
         $options->setRepositoryFactory(new \stdClass());
     }
 
@@ -88,13 +86,12 @@ class ConfigurationOptionsTest extends TestCase
         $options->setEntityListenerResolver('test');
         $this->assertSame('test', $options->getEntityListenerResolver());
 
-        $entityListenerResolver = $this->getMockBuilder('Doctrine\ORM\Mapping\EntityListenerResolver')
-            ->getMock();
+        $entityListenerResolver = $this->createMock(\Doctrine\ORM\Mapping\EntityListenerResolver::class);
 
         $options->setEntityListenerResolver($entityListenerResolver);
         $this->assertSame($entityListenerResolver, $options->getEntityListenerResolver());
 
-        $this->expectException('Zend\Stdlib\Exception\InvalidArgumentException');
+        $this->expectException(\Zend\Stdlib\Exception\InvalidArgumentException::class);
         $options->setEntityListenerResolver(new \stdClass());
     }
 }

--- a/tests/DoctrineORMModuleTest/Options/DefaultRepositoryTest.php
+++ b/tests/DoctrineORMModuleTest/Options/DefaultRepositoryTest.php
@@ -25,9 +25,9 @@ class DefaultRepositoryTest extends TestCase
 {
     public function testEntityHasDefaultRepositoryInstance()
     {
-        $entityWithDefaultRepository = 'DoctrineORMModuleTest\Assets\Entity\EntityWithoutRepository';
+        $entityWithDefaultRepository = \DoctrineORMModuleTest\Assets\Entity\EntityWithoutRepository::class;
 
         $repository = $this->getEntityManager()->getRepository($entityWithDefaultRepository);
-        $this->assertInstanceOf('DoctrineORMModuleTest\Assets\RepositoryClass', $repository);
+        $this->assertInstanceOf(\DoctrineORMModuleTest\Assets\RepositoryClass::class, $repository);
     }
 }

--- a/tests/DoctrineORMModuleTest/Paginator/AdapterTestIgnore.php
+++ b/tests/DoctrineORMModuleTest/Paginator/AdapterTestIgnore.php
@@ -62,7 +62,7 @@ class AdapterTestIgnore extends TestCase
             ->getEntityManager()
             ->createQueryBuilder()
             ->select('t')
-            ->from('DoctrineORMModuleTest\Assets\Entity\Test', 't')
+            ->from(\DoctrineORMModuleTest\Assets\Entity\Test::class, 't')
             ->orderBy('t.id', 'ASC');
 
         $this->paginator = new DoctrinePaginator($this->qb);

--- a/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/ConfigurationFactoryTest.php
@@ -45,7 +45,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         $this->serviceManager->setService('doctrine.cache.array', new ArrayCache());
         $this->serviceManager->setService(
             'doctrine.driver.orm_default',
-            $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver')->getMock()
+            $this->createMock(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriver::class)
         );
     }
 
@@ -60,13 +60,12 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $ormConfig = $this->factory->createService($this->serviceManager);
-        $this->assertInstanceOf('Doctrine\ORM\Mapping\NamingStrategy', $ormConfig->getNamingStrategy());
+        $this->assertInstanceOf(\Doctrine\ORM\Mapping\NamingStrategy::class, $ormConfig->getNamingStrategy());
     }
 
     public function testWillInstantiateConfigWithNamingStrategyObject()
     {
-        $namingStrategy = $this->getMockBuilder('Doctrine\ORM\Mapping\NamingStrategy')
-            ->getMock();
+        $namingStrategy = $this->createMock(\Doctrine\ORM\Mapping\NamingStrategy::class);
 
         $config = [
             'doctrine' => [
@@ -85,8 +84,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillInstantiateConfigWithNamingStrategyReference()
     {
-        $namingStrategy = $this->getMockBuilder('Doctrine\ORM\Mapping\NamingStrategy')
-            ->getMock();
+        $namingStrategy = $this->createMock(\Doctrine\ORM\Mapping\NamingStrategy::class);
         $config = [
             'doctrine' => [
                 'configuration' => [
@@ -114,14 +112,13 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ],
         ];
         $this->serviceManager->setService('config', $config);
-        $this->expectException('Zend\ServiceManager\Exception\InvalidArgumentException');
+        $this->expectException(\Zend\ServiceManager\Exception\InvalidArgumentException::class);
         $this->factory->createService($this->serviceManager);
     }
 
     public function testWillInstantiateConfigWithQuoteStrategyObject()
     {
-        $quoteStrategy = $this->getMockBuilder('Doctrine\ORM\Mapping\QuoteStrategy')
-            ->getMock();
+        $quoteStrategy = $this->createMock(\Doctrine\ORM\Mapping\QuoteStrategy::class);
 
         $config = [
             'doctrine' => [
@@ -140,8 +137,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillInstantiateConfigWithQuoteStrategyReference()
     {
-        $quoteStrategy = $this->getMockBuilder('Doctrine\ORM\Mapping\QuoteStrategy')
-            ->getMock();
+        $quoteStrategy = $this->createMock(\Doctrine\ORM\Mapping\QuoteStrategy::class);
         $config = [
             'doctrine' => [
                 'configuration' => [
@@ -169,7 +165,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
             ],
         ];
         $this->serviceManager->setService('config', $config);
-        $this->expectException('Zend\ServiceManager\Exception\InvalidArgumentException');
+        $this->expectException(\Zend\ServiceManager\Exception\InvalidArgumentException::class);
         $this->factory->createService($this->serviceManager);
     }
 
@@ -187,20 +183,18 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
-        $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $ormConfig->getHydrationCacheImpl());
+        $this->assertInstanceOf(\Doctrine\Common\Cache\ArrayCache::class, $ormConfig->getHydrationCacheImpl());
     }
 
     public function testCanSetDefaultRepositoryClass()
     {
-        $repositoryClass = 'DoctrineORMModuleTest\Assets\RepositoryClass';
-
         $config = [
             'doctrine' => [
                 'configuration' => [
                     'test_default' => [
 
                         'hydration_cache' => 'array',
-                        'default_repository_class_name' => $repositoryClass,
+                        'default_repository_class_name' => \DoctrineORMModuleTest\Assets\RepositoryClass::class,
                     ],
                 ],
             ],
@@ -209,7 +203,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
-        $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $ormConfig->getHydrationCacheImpl());
+        $this->assertInstanceOf(\Doctrine\Common\Cache\ArrayCache::class, $ormConfig->getHydrationCacheImpl());
     }
 
     public function testAcceptsMetadataFactory()
@@ -242,7 +236,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         $this->serviceManager->setService('config', $config);
         $factory = new ConfigurationFactory('test_default');
         $ormConfig = $factory->createService($this->serviceManager);
-        $this->assertEquals('Doctrine\ORM\Mapping\ClassMetadataFactory', $ormConfig->getClassMetadataFactoryName());
+        $this->assertEquals(\Doctrine\ORM\Mapping\ClassMetadataFactory::class, $ormConfig->getClassMetadataFactoryName());
     }
 
     public function testWillInstantiateConfigWithoutEntityListenerResolverSetting()
@@ -259,13 +253,12 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
         $ormConfig = $this->factory->createService($this->serviceManager);
 
-        $this->assertInstanceOf('Doctrine\ORM\Mapping\EntityListenerResolver', $ormConfig->getEntityListenerResolver());
+        $this->assertInstanceOf(\Doctrine\ORM\Mapping\EntityListenerResolver::class, $ormConfig->getEntityListenerResolver());
     }
 
     public function testWillInstantiateConfigWithEntityListenerResolverObject()
     {
-        $entityListenerResolver = $this->getMockBuilder('Doctrine\ORM\Mapping\EntityListenerResolver')
-            ->getMock();
+        $entityListenerResolver = $this->createMock(\Doctrine\ORM\Mapping\EntityListenerResolver::class);
 
         $config = [
             'doctrine' => [
@@ -286,8 +279,7 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
 
     public function testWillInstantiateConfigWithEntityListenerResolverReference()
     {
-        $entityListenerResolver = $this->getMockBuilder('Doctrine\ORM\Mapping\EntityListenerResolver')
-            ->getMock();
+        $entityListenerResolver = $this->createMock(\Doctrine\ORM\Mapping\EntityListenerResolver::class);
 
         $config = [
             'doctrine' => [
@@ -360,10 +352,10 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         $ormConfig        = $this->factory->createService($this->serviceManager);
         $secondLevelCache = $ormConfig->getSecondLevelCacheConfiguration();
         
-        $this->assertInstanceOf('Doctrine\ORM\Cache\CacheConfiguration', $secondLevelCache);
+        $this->assertInstanceOf(\Doctrine\ORM\Cache\CacheConfiguration::class, $secondLevelCache);
 
         $cacheFactory = $secondLevelCache->getCacheFactory();
-        $this->assertInstanceOf('Doctrine\ORM\Cache\DefaultCacheFactory', $cacheFactory);
+        $this->assertInstanceOf(\Doctrine\ORM\Cache\DefaultCacheFactory::class, $cacheFactory);
         $this->assertEquals('my_dir', $cacheFactory->getFileLockRegionDirectory());
 
         $regionsConfiguration = $secondLevelCache->getRegionsConfiguration();
@@ -380,6 +372,6 @@ class ConfigurationFactoryTest extends PHPUnit_Framework_TestCase
         // reflection here
         $reflProperty = new \ReflectionProperty($cacheFactory, 'cache');
         $reflProperty->setAccessible(true);
-        $this->assertInstanceOf('Doctrine\Common\Cache\ArrayCache', $reflProperty->getValue($cacheFactory));
+        $this->assertInstanceOf(\Doctrine\Common\Cache\ArrayCache::class, $reflProperty->getValue($cacheFactory));
     }
 }

--- a/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -59,7 +59,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
                         'params' => [
                             'memory' => true,
                         ],
@@ -67,7 +67,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-        $configurationMock = $this->getMockBuilder('Doctrine\ORM\Configuration')
+        $configurationMock = $this->getMockBuilder(\Doctrine\ORM\Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -59,7 +59,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
                         'params' => [
                             'memory' => true,
                         ],
@@ -70,7 +70,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
                 ],
             ],
         ];
-        $configurationMock = $this->getMockBuilder('Doctrine\ORM\Configuration')
+        $configurationMock = $this->getMockBuilder(\Doctrine\ORM\Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -89,7 +89,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
                         'params' => [
                             'memory' => true,
                         ],
@@ -104,7 +104,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
                 'configuration' => [
                     'orm_default' => [
                         'types' => [
-                            'money' => 'DoctrineORMModuleTest\Assets\Types\MoneyType',
+                            'money' => \DoctrineORMModuleTest\Assets\Types\MoneyType::class,
                         ],
                     ],
                 ],
@@ -114,7 +114,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
         $this->serviceManager->setService('Configuration', $config);
         $this->serviceManager->setService(
             'doctrine.driver.orm_default',
-            $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\Driver\MappingDriver')->getMock()
+            $this->createMock(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriver::class)
         );
         $configurationFactory = new ConfigurationFactory('orm_default');
         $this->serviceManager->setService(
@@ -125,7 +125,7 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
         $platform = $dbal->getDatabasePlatform();
         $type = Type::getType($platform->getDoctrineTypeMapping("money"));
 
-        $this->assertInstanceOf('DoctrineORMModuleTest\Assets\Types\MoneyType', $type);
+        $this->assertInstanceOf(\DoctrineORMModuleTest\Assets\Types\MoneyType::class, $type);
         $this->assertTrue($platform->isCommentedDoctrineType($type));
     }
 }

--- a/tests/DoctrineORMModuleTest/Service/EntityResolverFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/EntityResolverFactoryTest.php
@@ -27,10 +27,10 @@ class EntityResolverFactoryTest extends TestCase
     public function testCanResolveTargetEntity()
     {
         $em            = $this->getEntityManager();
-        $classMetadata = $em->getClassMetadata('DoctrineORMModuleTest\Assets\Entity\ResolveTarget');
+        $classMetadata = $em->getClassMetadata(\DoctrineORMModuleTest\Assets\Entity\ResolveTarget::class);
         $meta          = $classMetadata->associationMappings;
 
-        $this->assertSame('DoctrineORMModuleTest\Assets\Entity\TargetEntity', $meta['target']['targetEntity']);
+        $this->assertSame(\DoctrineORMModuleTest\Assets\Entity\TargetEntity::class, $meta['target']['targetEntity']);
     }
 
     public function testAssertSubscriberIsAdded()

--- a/tests/DoctrineORMModuleTest/Service/FormAnnotationBuilderFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/FormAnnotationBuilderFactoryTest.php
@@ -35,10 +35,10 @@ class FormAnnotationBuilderFactoryTest extends PHPUnit_Framework_TestCase
      */
     public function testFormElementManagerGetsInjected()
     {
-        $entityManager      = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+        $entityManager      = $this->getMockBuilder(\Doctrine\ORM\EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $formElementManager = $this->getMockBuilder('Zend\Form\FormElementManager')
+        $formElementManager = $this->getMockBuilder(\Zend\Form\FormElementManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/DoctrineORMModuleTest/Service/MigrationsCommandFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/MigrationsCommandFactoryTest.php
@@ -50,7 +50,7 @@ class MigrationsCommandFactoryTest extends TestCase
         $factory = new MigrationsCommandFactory('execute');
 
         $this->assertInstanceOf(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand',
+            \Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand::class,
             $factory->createService($this->serviceLocator)
         );
     }
@@ -60,7 +60,7 @@ class MigrationsCommandFactoryTest extends TestCase
         $factory = new MigrationsCommandFactory('diff');
 
         $this->assertInstanceOf(
-            'Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand',
+            \Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand::class,
             $factory->createService($this->serviceLocator)
         );
     }
@@ -69,7 +69,7 @@ class MigrationsCommandFactoryTest extends TestCase
     {
         $factory = new MigrationsCommandFactory('unknowncommand');
 
-        $this->expectException('InvalidArgumentException');
+        $this->expectException(\InvalidArgumentException::class);
         $factory->createService($this->serviceLocator);
     }
 }

--- a/tests/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
@@ -62,8 +62,8 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             ]
         );
         $service = $this->factory->createService($this->services);
-        $this->assertInstanceOf('DoctrineORMModule\Collector\SQLLoggerCollector', $service);
-        $this->assertInstanceOf('Doctrine\DBAL\Logging\SQLLogger', $configuration->getSQLLogger());
+        $this->assertInstanceOf(\DoctrineORMModule\Collector\SQLLoggerCollector::class, $service);
+        $this->assertInstanceOf(\Doctrine\DBAL\Logging\SQLLogger::class, $configuration->getSQLLogger());
     }
 
     public function testCreateSQLLoggerWithCustomConfiguration()
@@ -83,19 +83,17 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             ]
         );
         $this->factory->createService($this->services);
-        $this->assertInstanceOf('Doctrine\DBAL\Logging\SQLLogger', $configuration->getSQLLogger());
+        $this->assertInstanceOf(\Doctrine\DBAL\Logging\SQLLogger::class, $configuration->getSQLLogger());
     }
 
     public function testCreateSQLLoggerWithPreviousExistingLoggerChainsLoggers()
     {
-        $originalLogger = $this->getMockBuilder('Doctrine\DBAL\Logging\SQLLogger')
-            ->getMock();
+        $originalLogger = $this->createMock(\Doctrine\DBAL\Logging\SQLLogger::class);
         $originalLogger
             ->expects($this->once())
             ->method('startQuery')
             ->with($this->equalTo('test query'));
-        $injectedLogger = $this->getMockBuilder('Doctrine\DBAL\Logging\DebugStack')
-            ->getMock();
+        $injectedLogger = $this->createMock(\Doctrine\DBAL\Logging\DebugStack::class);
         $injectedLogger
             ->expects($this->once())
             ->method('startQuery')

--- a/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -51,8 +51,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawSimpleEntity()
     {
-        $class = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
         $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
@@ -65,8 +64,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawSimpleEntityWithFields()
     {
-        $class = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(['a', 'b', 'c']));
         $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
@@ -86,8 +84,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawOneToOneUniDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -95,8 +92,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
@@ -109,8 +105,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawOneToOneBiDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -118,8 +113,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -136,8 +130,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawOneToOneBiDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -146,8 +139,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -163,8 +155,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawOneToManyBiDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -172,8 +163,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -190,8 +180,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawOneToManyBiDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -199,8 +188,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -217,8 +205,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawManyToManyUniDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -226,8 +213,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
@@ -240,14 +226,12 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawManyToManyUniDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -263,8 +247,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawManyToManyBiDirectionalAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -272,8 +255,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -290,8 +272,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawManyToManyBiDirectionalInverseAssociation()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -300,8 +281,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -317,8 +297,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawManyToManyAssociationWithoutKnownInverseSide()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -334,11 +313,9 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawInheritance()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $child  = get_class($this->getMockBuilder('stdClass')->getMock());
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $child  = get_class($this->createMock('stdClass'));
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
@@ -357,11 +334,9 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawInheritedFields()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $child  = get_class($this->getMockBuilder('stdClass')->getMock());
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $child  = get_class($this->createMock('stdClass'));
 
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
@@ -382,15 +357,11 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function testDrawInheritedAssociations()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $class3 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $class4 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
-        $child  = get_class($this->getMockBuilder('stdClass')->getMock());
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class3 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class4 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $child  = get_class($this->createMock('stdClass'));
 
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
@@ -450,8 +421,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
      */
     public function injectMultipleRelationsWithBothBiAndMonoDirectional()
     {
-        $class1 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['c']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
@@ -459,8 +429,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['c']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
@@ -468,8 +437,7 @@ class MetadataGrapherTest extends PHPUnit_Framework_TestCase
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class3 = $this->getMockBuilder('Doctrine\\Common\\Persistence\\Mapping\\ClassMetadata')
-            ->getMock();
+        $class3 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
         $class3->expects($this->any())->method('getName')->will($this->returnValue('C'));
         $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class3

--- a/tests/DoctrineORMModuleTest/Yuml/YumlControllerFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/YumlControllerFactoryTest.php
@@ -37,8 +37,7 @@ class YumlControllerFactoryTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
-            ->getMock();
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -62,8 +61,7 @@ class YumlControllerFactoryTest extends PHPUnit_Framework_TestCase
             ],
         ];
 
-        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
-            ->getMock();
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -83,8 +81,7 @@ class YumlControllerFactoryTest extends PHPUnit_Framework_TestCase
             'zenddevelopertools' => [],
         ];
 
-        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
-            ->getMock();
+        $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
         $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/DoctrineORMModuleTest/Yuml/YumlControllerTest.php
+++ b/tests/DoctrineORMModuleTest/Yuml/YumlControllerTest.php
@@ -52,10 +52,9 @@ class YumlControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->httpClient     = $this->getMockBuilder('Zend\\Http\\Client')
-            ->getMock();
+        $this->httpClient     = $this->createMock(\Zend\Http\Client::class);
         $this->controller     = new YumlController($this->httpClient);
-        $this->pluginManager  = $this->getMockBuilder('Zend\\Mvc\\Controller\\PluginManager')
+        $this->pluginManager  = $this->getMockBuilder(\Zend\Mvc\Controller\PluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller->setPluginManager($this->pluginManager);
@@ -66,12 +65,9 @@ class YumlControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testIndexActionWillRedirectToYuml()
     {
-        $response = $this->getMockBuilder('Zend\\Http\\Response')
-            ->getMock();
-        $controllerResponse = $this->getMockBuilder('Zend\\Http\\Response')
-            ->getMock();
-        $redirect = $this->getMockBuilder('Zend\\Mvc\\Controller\\Plugin\\Redirect')
-            ->getMock();
+        $response = $this->createMock(\Zend\Http\Response::class);
+        $controllerResponse = $this->createMock(\Zend\Http\Response::class);
+        $redirect = $this->createMock(\Zend\Mvc\Controller\Plugin\Redirect::class);
         $this->httpClient->expects($this->any())->method('send')->will($this->returnValue($response));
         $response->expects($this->any())->method('isSuccess')->will($this->returnValue(true));
         $response->expects($this->any())->method('getBody')->will($this->returnValue('short-url'));
@@ -94,12 +90,11 @@ class YumlControllerTest extends \PHPUnit_Framework_TestCase
      */
     public function testIndexActionWillFailOnMalformedResponse()
     {
-        $response = $this->getMockBuilder('Zend\\Http\\Response')
-            ->getMock();
+        $response = $this->createMock(\Zend\Http\Response::class);
         $this->httpClient->expects($this->any())->method('send')->will($this->returnValue($response));
         $response->expects($this->any())->method('isSuccess')->will($this->returnValue(false));
 
-        $this->expectException('UnexpectedValueException');
+        $this->expectException(\UnexpectedValueException::class);
         $this->controller->indexAction();
     }
 }

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -20,12 +20,12 @@ return [
     'doctrine' => [
         'configuration' => [
             'orm_default' => [
-                'default_repository_class_name' => 'DoctrineORMModuleTest\Assets\RepositoryClass',
+                'default_repository_class_name' => \DoctrineORMModuleTest\Assets\RepositoryClass::class,
             ],
         ],
         'driver' => [
             'DoctrineORMModuleTest\Assets\Entity' => [
-                'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
+                'class' => \Doctrine\ORM\Mapping\Driver\AnnotationDriver::class,
                 'cache' => 'array',
                 'paths' => [
                     __DIR__ . '/DoctrineORMModuleTest/Assets/Entity'
@@ -40,8 +40,8 @@ return [
         'entity_resolver' => [
             'orm_default' => [
                 'resolvers' => [
-                    'DoctrineORMModuleTest\Assets\Entity\TargetInterface'
-                        => 'DoctrineORMModuleTest\Assets\Entity\TargetEntity',
+                    \DoctrineORMModuleTest\Assets\Entity\TargetInterface::class
+                        => \DoctrineORMModuleTest\Assets\Entity\TargetEntity::class,
                 ],
             ],
         ],
@@ -49,7 +49,7 @@ return [
             'orm_default' => [
                 'configuration' => 'orm_default',
                 'eventmanager'  => 'orm_default',
-                'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
                 'params' => [
                     'memory' => true,
                 ],


### PR DESCRIPTION
changed to `::class` in tests and readme
update to `createMock`, if we call only `getMockBuilder` + `getMock`

like in https://github.com/doctrine/DoctrineORMModule/pull/497 written
