### PR TITLE
Added ConfigProvider in line with ZF components

### DIFF
--- a/src/DoctrineORMModule/ConfigProvider.php
+++ b/src/DoctrineORMModule/ConfigProvider.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModule;
+
+/**
+ * Config provider for DoctrineORMModule config
+ *
+ * @license MIT
+ * @link    www.doctrine-project.org
+ * @author  James Titcumb <james@asgrim.com>
+ */
+class ConfigProvider
+{
+    /**
+     * @return array
+     */
+    public function __invoke()
+    {
+        $config = include __DIR__ . '/../../config/module.config.php';
+        $config['dependencies'] = $config['service_manager'];
+        unset($config['service_manager']);
+        return $config;
+    }
+}

--- a/tests/DoctrineORMModuleTest/ConfigProviderTest.php
+++ b/tests/DoctrineORMModuleTest/ConfigProviderTest.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModuleTest;
+
+use DoctrineORMModule\ConfigProvider;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests used to ensure ConfigProvider operates as expected
+ *
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  James Titcumb <james@asgrim.com>
+ */
+class ConfigProviderTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeHasDependencyKeyAndNotServiceManager()
+    {
+        $config = (new ConfigProvider())->__invoke();
+
+        self::assertArrayHasKey('dependencies', $config, 'Expected config to have "dependencies" array key');
+        self::assertArrayNotHasKey('service_manager', $config, 'Config should not have "service_manager" array key');
+    }
+}


### PR DESCRIPTION
Many ZF components now use a `ConfigProvider` to assist in config merging and allow components to be used e.g. in Expressive.

I took the strategy of least interference with existing config loading, so I did not move config here, nor make `Module.php` load config using the `ConfigProvider`. If desired, however, I can add this functionality into this PR. Feedback welcome, thanks!