### PR TITLE
DBALConnectionFactory opens db connection, even if its not necessary

### DIFF
--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -60,16 +60,12 @@ class DBALConnectionFactory extends AbstractFactory
         $eventManager  = $container->get($options->getEventManager());
 
         $connection = DriverManager::getConnection($params, $configuration, $eventManager);
+        foreach ($options->getDoctrineTypeMappings() as $dbType => $doctrineType) {
+            $connection->getDatabasePlatform()->registerDoctrineTypeMapping($dbType, $doctrineType);
+        }
 
-        if (count($options->getDoctrineTypeMappings()) > 0 || $options->getDoctrineCommentedTypes() > 0) {
-            $platform = $connection->getDatabasePlatform();
-            foreach ($options->getDoctrineTypeMappings() as $dbType => $doctrineType) {
-                $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
-            }
-
-            foreach ($options->getDoctrineCommentedTypes() as $type) {
-                $platform->markDoctrineTypeCommented(Type::getType($type));
-            }
+        foreach ($options->getDoctrineCommentedTypes() as $type) {
+            $connection->getDatabasePlatform()->markDoctrineTypeCommented(Type::getType($type));
         }
 
         return $connection;

--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -60,13 +60,16 @@ class DBALConnectionFactory extends AbstractFactory
         $eventManager  = $container->get($options->getEventManager());
 
         $connection = DriverManager::getConnection($params, $configuration, $eventManager);
-        $platform = $connection->getDatabasePlatform();
-        foreach ($options->getDoctrineTypeMappings() as $dbType => $doctrineType) {
-            $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
-        }
 
-        foreach ($options->getDoctrineCommentedTypes() as $type) {
-            $platform->markDoctrineTypeCommented(Type::getType($type));
+        if (count($options->getDoctrineTypeMappings()) > 0 || $options->getDoctrineCommentedTypes() > 0) {
+            $platform = $connection->getDatabasePlatform();
+            foreach ($options->getDoctrineTypeMappings() as $dbType => $doctrineType) {
+                $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
+            }
+
+            foreach ($options->getDoctrineCommentedTypes() as $type) {
+                $platform->markDoctrineTypeCommented(Type::getType($type));
+            }
         }
 
         return $connection;

--- a/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -53,6 +53,32 @@ class DBALConnectionFactoryTest extends PHPUnit_Framework_TestCase
         $this->serviceManager->setService('doctrine.eventmanager.orm_default', new EventManager());
     }
 
+    public function testNoConnectWithoutCustomMappingsAndCommentedTypes()
+    {
+        $config = [
+            'doctrine' => [
+                'connection' => [
+                    'orm_default' => [
+                        'driverClass'   => 'Doctrine\DBAL\Driver\PDOSqlite\Driver',
+                        'params' => [
+                            'memory' => true,
+                        ],
+                    ]
+                ],
+            ],
+        ];
+        $configurationMock = $this->getMockBuilder('Doctrine\ORM\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->serviceManager->setService('doctrine.configuration.orm_default', $configurationMock);
+        $this->serviceManager->setService('config', $config);
+        $this->serviceManager->setService('Configuration', $config);
+
+        $dbal = $this->factory->createService($this->serviceManager);
+        $this->assertFalse($dbal->isConnected());
+    }
+
     public function testDoctrineMappingTypeReturnCorrectParent()
     {
         $config = [


### PR DESCRIPTION
Hi guys,

We sometimes got the issue that our app can't connect to our database.
Right now we just get a "ServiceNotCreatedException", because the DBALConnectionFactory opens a db connection while creating the connection services.

This fix only opens a db connection, if needed.
That way we can catch the ConnectionException in our controller/business logic and return a proper response.