### PR TITLE
Added a option to use a different entity-manager on cli

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -143,7 +143,7 @@ class Module implements
                 'object-manager',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The name of the object-manager to use.',
+                'The name of the object manager to use.',
                 'doctrine.entitymanager.orm_default'
             ));
 
@@ -151,11 +151,11 @@ class Module implements
         }
 
         $arguments = new ArgvInput();
-        $objectManagerName = $arguments->getParameterOption('--object-manager');
-        $objectManagerName = !empty($objectManagerName) ? $objectManagerName : 'doctrine.entitymanager.orm_default';
+        $objectManagerName = ($arguments->getParameterOption('--object-manager')) ?:
+            'doctrine.entitymanager.orm_default';
 
-        /* @var $entityManager \Doctrine\ORM\EntityManagerInterface */
-        $entityManager = $serviceLocator->get($objectManagerName);
+        /* @var $objectManager \Doctrine\ORM\EntityManagerInterface */
+        $objectManager = $serviceLocator->get($objectManagerName);
         $helperSet     = $cli->getHelperSet();
 
         if (class_exists('Symfony\Component\Console\Helper\QuestionHelper')) {
@@ -164,7 +164,7 @@ class Module implements
             $helperSet->set(new DialogHelper(), 'dialog');
         }
 
-        $helperSet->set(new ConnectionHelper($entityManager->getConnection()), 'db');
-        $helperSet->set(new EntityManagerHelper($entityManager), 'em');
+        $helperSet->set(new ConnectionHelper($objectManager->getConnection()), 'db');
+        $helperSet->set(new EntityManagerHelper($objectManager), 'em');
     }
 }

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -140,21 +140,22 @@ class Module implements
             /* @var $command \Symfony\Component\Console\Command\Command */
             $command = $serviceLocator->get($commandName);
             $command->getDefinition()->addOption(new InputOption(
-                'entitymanager',
+                'object-manager',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'The name of the entitymanager to use. If none is provided, it will use orm_default.'
+                'The name of the object-manager to use.',
+                'doctrine.entitymanager.orm_default'
             ));
 
             $cli->add($command);
         }
 
         $arguments = new ArgvInput();
-        $entityManagerName = $arguments->getParameterOption('--entitymanager');
-        $entityManagerName = !empty($entityManagerName) ? $entityManagerName : 'orm_default';
+        $objectManagerName = $arguments->getParameterOption('--object-manager');
+        $objectManagerName = !empty($objectManagerName) ? $objectManagerName : 'doctrine.entitymanager.orm_default';
 
-        /* @var $entityManager \Doctrine\ORM\EntityManager */
-        $entityManager = $serviceLocator->get('doctrine.entitymanager.' . $entityManagerName);
+        /* @var $entityManager \Doctrine\ORM\EntityManagerInterface */
+        $entityManager = $serviceLocator->get($objectManagerName);
         $helperSet     = $cli->getHelperSet();
 
         if (class_exists('Symfony\Component\Console\Helper\QuestionHelper')) {

--- a/tests/DoctrineORMModuleTest/CliTest.php
+++ b/tests/DoctrineORMModuleTest/CliTest.php
@@ -127,7 +127,7 @@ class CliTest extends PHPUnit_Framework_TestCase
         $application = new Application();
         $event = new Event('loadCli.post', $application, ['ServiceManager' => $this->serviceManager]);
 
-        $_SERVER['argv'][] = '--entitymanager=some_other_name';
+        $_SERVER['argv'][] = '--object-manager=doctrine.entitymanager.some_other_name';
 
         $module = new Module();
         $module->initializeConsole($event);
@@ -151,18 +151,16 @@ class CliTest extends PHPUnit_Framework_TestCase
         $this->assertInstanceOf($className, $command);
 
         // check for the entity-manager option
-        $this->assertTrue($command->getDefinition()->hasOption('entitymanager'));
+        $this->assertTrue($command->getDefinition()->hasOption('object-manager'));
 
-        $entityManagerOption = $command->getDefinition()->getOption('entitymanager');
+        $entityManagerOption = $command->getDefinition()->getOption('object-manager');
 
         $this->assertTrue($entityManagerOption->isValueOptional());
         $this->assertFalse($entityManagerOption->isValueRequired());
         $this->assertFalse($entityManagerOption->isArray());
         $this->assertNull($entityManagerOption->getShortcut());
-        $this->assertSame(
-            'The name of the entitymanager to use. If none is provided, it will use orm_default.',
-            $entityManagerOption->getDescription()
-        );
+        $this->assertSame('doctrine.entitymanager.orm_default', $entityManagerOption->getDefault());
+        $this->assertSame('The name of the object-manager to use.', $entityManagerOption->getDescription());
     }
 
     /**

--- a/tests/DoctrineORMModuleTest/CliTest.php
+++ b/tests/DoctrineORMModuleTest/CliTest.php
@@ -46,7 +46,7 @@ class CliTest extends PHPUnit_Framework_TestCase
     /**
      * @var \Doctrine\ORM\EntityManager
      */
-    protected $entityManager;
+    protected $objectManager;
 
     /**
      * {@inheritDoc}
@@ -70,7 +70,7 @@ class CliTest extends PHPUnit_Framework_TestCase
 
         $application->bootstrap();
         $this->serviceManager = $serviceManager;
-        $this->entityManager  = $serviceManager->get('doctrine.entitymanager.orm_default');
+        $this->objectManager  = $serviceManager->get('doctrine.entitymanager.orm_default');
         $this->cli            = $serviceManager->get('doctrine.cli');
         $this->assertSame(1, $invocations);
     }
@@ -82,12 +82,12 @@ class CliTest extends PHPUnit_Framework_TestCase
         /* @var $emHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
         $emHelper = $helperSet->get('em');
         $this->assertInstanceOf('Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper', $emHelper);
-        $this->assertSame($this->entityManager, $emHelper->getEntityManager());
+        $this->assertSame($this->objectManager, $emHelper->getEntityManager());
 
         /* @var $dbHelper \Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper */
         $dbHelper = $helperSet->get('db');
         $this->assertInstanceOf('Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper', $dbHelper);
-        $this->assertSame($this->entityManager->getConnection(), $dbHelper->getConnection());
+        $this->assertSame($this->objectManager->getConnection(), $dbHelper->getConnection());
     }
 
     public function testOrmDefaultIsUsedAsTheEntityManagerIfNoneIsProvided()
@@ -101,7 +101,7 @@ class CliTest extends PHPUnit_Framework_TestCase
         /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
         $entityManagerHelper = $application->getHelperSet()->get('entityManager');
         $this->assertInstanceOf('Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper', $entityManagerHelper);
-        $this->assertSame($this->entityManager, $entityManagerHelper->getEntityManager());
+        $this->assertSame($this->objectManager, $entityManagerHelper->getEntityManager());
     }
 
     /**
@@ -160,7 +160,7 @@ class CliTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($entityManagerOption->isArray());
         $this->assertNull($entityManagerOption->getShortcut());
         $this->assertSame('doctrine.entitymanager.orm_default', $entityManagerOption->getDefault());
-        $this->assertSame('The name of the object-manager to use.', $entityManagerOption->getDescription());
+        $this->assertSame('The name of the object manager to use.', $entityManagerOption->getDescription());
     }
 
     /**


### PR DESCRIPTION
Added a option to use a different entity-manager on cli.

Name: **doctrine.entitymanager.orm_default**
`php public/index.php orm:schema-tool:update --dump-sql `

Name: **doctrine.entitymanager.some_other**
`php public/index.php orm:schema-tool:update --dump-sql --entitymanager=some_other`

Inspired by the "doctrine/doctrine-mongo-odm-module" --documentmanager option.