### PR TITLE
Support for FilterSchemaAssetsExpression

### DIFF
--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -201,7 +201,7 @@ class Configuration extends DBALConfiguration
      * @var SecondLevelCacheConfiguration|null
      */
     protected $secondLevelCache;
-    
+
     /**
      * Configuration for schema filter
      *

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -35,7 +35,7 @@ class Configuration extends DBALConfiguration
      * @var string
      */
     protected $queryCache = 'array';
-    
+
     /**
      * Set the cache key for the result cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -203,11 +203,11 @@ class Configuration extends DBALConfiguration
     protected $secondLevelCache;
 
     /**
-     * Configuration for schema filter
+     * Configuration option for the filter schema expression
      *
      * @var string|null
      */
-    protected $schemaFilter;
+    protected $filterSchemaAssetsExpression;
 
     /**
      * @param  array $datetimeFunctions
@@ -684,20 +684,20 @@ class Configuration extends DBALConfiguration
     }
     
     /**
-     * @param  string $schemaFilter
+     * @param  string $filterSchemaAssetsExpression
      * @return void
      */
-    public function setSchemaFilter($schemaFilter)
+    public function setFilterSchemaAssetsExpression($filterSchemaAssetsExpression)
     {
-        $this->schemaFilter = $schemaFilter;
+        $this->filterSchemaAssetsExpression = $filterSchemaAssetsExpression;
     }
 
     /**
      * @return string|null
      */
-    public function getSchemaFilter()
+    public function getFilterSchemaAssetsExpression()
     {
-        return $this->schemaFilter;
+        return $this->filterSchemaAssetsExpression;
     }
 
     /**

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -35,7 +35,7 @@ class Configuration extends DBALConfiguration
      * @var string
      */
     protected $queryCache = 'array';
-
+    
     /**
      * Set the cache key for the result cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
@@ -201,6 +201,13 @@ class Configuration extends DBALConfiguration
      * @var SecondLevelCacheConfiguration|null
      */
     protected $secondLevelCache;
+    
+    /**
+     * Configuration for schema filter
+     *
+     * @var string|null
+     */
+    protected $schemaFilter;
 
     /**
      * @param  array $datetimeFunctions
@@ -674,6 +681,23 @@ class Configuration extends DBALConfiguration
     public function getSecondLevelCache()
     {
         return $this->secondLevelCache ?: new SecondLevelCacheConfiguration();
+    }
+    
+    /**
+     * @param  string $schemaFilter
+     * @return void
+     */
+    public function setSchemaFilter($schemaFilter)
+    {
+        $this->schemaFilter = $schemaFilter;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSchemaFilter()
+    {
+        return $this->schemaFilter;
     }
 
     /**

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -153,8 +153,8 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
             $config->setSecondLevelCacheConfiguration($cacheConfiguration);
         }
         
-        if($schemaFilter = $options->getSchemaFilter()) {
-            $config->setFilterSchemaAssetsExpression($schemaFilter);
+        if($filterSchemaAssetsExpression = $options->getFilterSchemaAssetsExpression()) {
+            $config->setFilterSchemaAssetsExpression($filterSchemaAssetsExpression);
         }
 
         if ($className = $options->getDefaultRepositoryClassName()) {

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -152,6 +152,10 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
             $config->setSecondLevelCacheEnabled();
             $config->setSecondLevelCacheConfiguration($cacheConfiguration);
         }
+        
+        if($schemaFilter = $options->getSchemaFilter()) {
+            $config->setFilterSchemaAssetsExpression($schemaFilter);
+        }
 
         if ($className = $options->getDefaultRepositoryClassName()) {
             $config->setDefaultRepositoryClassName($className);


### PR DESCRIPTION
Added schema_filter (setFilterSchemaAssetsExpression) support for Zend in the configuration file like in symfony, described here: https://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html#manual-tables