### PR TITLE
drop hhvm from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,18 +54,8 @@ matrix:
     - php: nightly
       env:
         - DEPS=latest
-    - php: hhvm
-      env:
-        - DEPS=lowest
-    - php: hhvm
-      env:
-        - DEPS=locked
-    - php: hhvm
-      env:
-        - DEPS=latest
   allow_failures:
     - php: nightly
-    - php: hhvm
 
 before_install:
   - travis_retry composer self-update


### PR DESCRIPTION
like in [zf-blog](https://framework.zend.com/blog/2017-06-06-zf-php-7-1.html) written removed hhvm

also the current hhvm tests go to a vm error, so it was not realy testet