### PR TITLE
Allow retrieving platform from container

### DIFF
--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -58,6 +58,14 @@ class DBALConnectionFactory extends AbstractFactory
         ];
         $params = array_merge($params, $options->getParams());
 
+        if (
+            array_key_exists('platform', $params)
+            && is_string($params['platform'])
+            && $container->has($params['platform'])
+        ) {
+            $params['platform'] = $container->get($params['platform']);
+        }
+
         $configuration = $container->get($options->getConfiguration());
         $eventManager  = $container->get($options->getEventManager());
 

--- a/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/tests/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -19,9 +19,12 @@
 
 namespace DoctrineORMModuleTest\Service;
 
+use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
+use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use PHPUnit\Framework\TestCase;
+use Doctrine\ORM\Configuration;
 use DoctrineORMModuleTest\Assets\Types\MoneyType;
+use PHPUnit\Framework\TestCase;
 use DoctrineORMModule\Service\DBALConnectionFactory;
 use Doctrine\DBAL\Types\Type;
 use Doctrine\Common\Cache\ArrayCache;
@@ -60,7 +63,7 @@ class DBALConnectionFactoryTest extends TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+                        'driverClass'   => PDOSqliteDriver::class,
                         'params' => [
                             'memory' => true,
                         ],
@@ -68,7 +71,7 @@ class DBALConnectionFactoryTest extends TestCase
                 ],
             ],
         ];
-        $configurationMock = $this->getMockBuilder(\Doctrine\ORM\Configuration::class)
+        $configurationMock = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -86,7 +89,7 @@ class DBALConnectionFactoryTest extends TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+                        'driverClass'   => PDOSqliteDriver::class,
                         'params' => [
                             'memory' => true,
                         ],
@@ -97,7 +100,7 @@ class DBALConnectionFactoryTest extends TestCase
                 ],
             ],
         ];
-        $configurationMock = $this->getMockBuilder(\Doctrine\ORM\Configuration::class)
+        $configurationMock = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -116,7 +119,7 @@ class DBALConnectionFactoryTest extends TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+                        'driverClass'   => PDOSqliteDriver::class,
                         'params' => [
                             'memory' => true,
                         ],
@@ -131,7 +134,7 @@ class DBALConnectionFactoryTest extends TestCase
                 'configuration' => [
                     'orm_default' => [
                         'types' => [
-                            'money' => \DoctrineORMModuleTest\Assets\Types\MoneyType::class,
+                            'money' => MoneyType::class,
                         ],
                     ],
                 ],
@@ -141,7 +144,7 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('Configuration', $config);
         $this->serviceManager->setService(
             'doctrine.driver.orm_default',
-            $this->createMock(\Doctrine\Common\Persistence\Mapping\Driver\MappingDriver::class)
+            $this->createMock(MappingDriver::class)
         );
         $configurationFactory = new ConfigurationFactory('orm_default');
         $this->serviceManager->setService(
@@ -152,7 +155,7 @@ class DBALConnectionFactoryTest extends TestCase
         $platform = $dbal->getDatabasePlatform();
         $type = Type::getType($platform->getDoctrineTypeMapping("money"));
 
-        $this->assertInstanceOf(\DoctrineORMModuleTest\Assets\Types\MoneyType::class, $type);
+        $this->assertInstanceOf(MoneyType::class, $type);
         $this->assertTrue($platform->isCommentedDoctrineType($type));
     }
 
@@ -162,7 +165,7 @@ class DBALConnectionFactoryTest extends TestCase
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
-                        'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
+                        'driverClass'   => PDOSqliteDriver::class,
                         'params' => [
                             'platform' => 'platform_service',
                         ],
@@ -170,7 +173,7 @@ class DBALConnectionFactoryTest extends TestCase
                 ],
             ],
         ];
-        $configurationMock = $this->getMockBuilder(\Doctrine\ORM\Configuration::class)
+        $configurationMock = $this->getMockBuilder(Configuration::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
This PR allows to retrieve platform from container.

The `platform` param must be an instance, but it's impossible to set an instance in the configuration (if we want to cache it). So, if we provide a string, we should check if can be retrieved from the service container.