### PR TITLE
Uses listener class to configure console application

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -22,8 +22,10 @@ use Doctrine\DBAL\Tools\Console;
 use Doctrine\ORM\Tools\Console\Command;
 use DoctrineModule\Form\Element;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
+use DoctrineORMModule\Listener\PostCliLoadListener;
 use DoctrineORMModule\Service;
 use DoctrineORMModule\Yuml;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'doctrine' => [
@@ -195,6 +197,7 @@ return [
 
     'service_manager' => [
         'factories' => [
+            PostCliLoadListener::class => InvokableFactory::class,
             'Doctrine\ORM\EntityManager' => Service\EntityManagerAliasCompatFactory::class,
         ],
         'invokables' => [

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -22,10 +22,10 @@ use Doctrine\DBAL\Tools\Console;
 use Doctrine\ORM\Tools\Console\Command;
 use DoctrineModule\Form\Element;
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
+use DoctrineORMModule\CliConfigurator;
 use DoctrineORMModule\Listener\PostCliLoadListener;
 use DoctrineORMModule\Service;
 use DoctrineORMModule\Yuml;
-use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'doctrine' => [
@@ -197,7 +197,8 @@ return [
 
     'service_manager' => [
         'factories' => [
-            PostCliLoadListener::class => InvokableFactory::class,
+            PostCliLoadListener::class => Service\PostCliLoadListenerFactory::class,
+            CliConfigurator::class => Service\CliConfiguratorFactory::class,
             'Doctrine\ORM\EntityManager' => Service\EntityManagerAliasCompatFactory::class,
         ],
         'invokables' => [

--- a/src/DoctrineORMModule/CliConfigurator.php
+++ b/src/DoctrineORMModule/CliConfigurator.php
@@ -1,0 +1,161 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModule;
+
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Interop\Container\ContainerInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputOption;
+use Zend\Stdlib\ArrayUtils;
+
+/**
+ * @license MIT
+ * @link    www.doctrine-project.org
+ * @author  Nicolas Eeckeloo <neeckeloo@gmail.com>
+ */
+class CliConfigurator
+{
+    private $defaultObjectManagerName = 'doctrine.entitymanager.orm_default';
+
+    private $commands = [
+        'doctrine.dbal_cmd.runsql',
+        'doctrine.dbal_cmd.import',
+        'doctrine.orm_cmd.clear_cache_metadata',
+        'doctrine.orm_cmd.clear_cache_result',
+        'doctrine.orm_cmd.clear_cache_query',
+        'doctrine.orm_cmd.schema_tool_create',
+        'doctrine.orm_cmd.schema_tool_update',
+        'doctrine.orm_cmd.schema_tool_drop',
+        'doctrine.orm_cmd.ensure_production_settings',
+        'doctrine.orm_cmd.convert_d1_schema',
+        'doctrine.orm_cmd.generate_repositories',
+        'doctrine.orm_cmd.generate_entities',
+        'doctrine.orm_cmd.generate_proxies',
+        'doctrine.orm_cmd.convert_mapping',
+        'doctrine.orm_cmd.run_dql',
+        'doctrine.orm_cmd.validate_schema',
+        'doctrine.orm_cmd.info',
+    ];
+
+    private $migrationCommands = [
+        'doctrine.migrations_cmd.execute',
+        'doctrine.migrations_cmd.generate',
+        'doctrine.migrations_cmd.migrate',
+        'doctrine.migrations_cmd.status',
+        'doctrine.migrations_cmd.version',
+        'doctrine.migrations_cmd.diff',
+        'doctrine.migrations_cmd.latest',
+    ];
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function configure(Application $cli)
+    {
+        $commands = $this->getAvailableCommands();
+        foreach ($commands as $commandName) {
+            /* @var $command \Symfony\Component\Console\Command\Command */
+            $command = $this->container->get($commandName);
+            $command->getDefinition()->addOption($this->createObjectManagerInputOption());
+
+            $cli->add($command);
+        }
+
+        /* @var $objectManager \Doctrine\ORM\EntityManagerInterface */
+        $objectManager = $this->container->get($this->getObjectManagerName());
+
+        $helpers = $this->getHelpers($objectManager);
+        foreach ($helpers as $name => $instance) {
+            $cli->getHelperSet()->set($instance, $name);
+        }
+    }
+
+    /**
+     * @param EntityManagerInterface $objectManager
+     * @return array
+     */
+    private function getHelpers(EntityManagerInterface $objectManager)
+    {
+        $helpers = [];
+
+        if (class_exists('Symfony\Component\Console\Helper\QuestionHelper')) {
+            $helpers['dialog'] = new QuestionHelper();
+        } else {
+            $helpers['dialog'] = new DialogHelper();
+        }
+
+        $helpers['db'] = new ConnectionHelper($objectManager->getConnection());
+        $helpers['em'] = new EntityManagerHelper($objectManager);
+
+        return $helpers;
+    }
+
+    /**
+     * @return InputOption
+     */
+    private function createObjectManagerInputOption()
+    {
+        return new InputOption(
+            'object-manager',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'The name of the object manager to use.',
+            $this->defaultObjectManagerName
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getObjectManagerName()
+    {
+        $arguments = new ArgvInput();
+
+        if (!$arguments->hasParameterOption('--object-manager')) {
+            return $this->defaultObjectManagerName;
+        }
+
+        return $arguments->getParameterOption('--object-manager');
+    }
+
+    /**
+     * @return array
+     */
+    private function getAvailableCommands()
+    {
+        if (class_exists('Doctrine\\DBAL\\Migrations\\Version')) {
+            return ArrayUtils::merge($this->commands, $this->migrationCommands);
+        }
+
+        return $this->commands;
+    }
+}

--- a/src/DoctrineORMModule/Listener/PostCliLoadListener.php
+++ b/src/DoctrineORMModule/Listener/PostCliLoadListener.php
@@ -1,0 +1,163 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModule\Listener;
+
+use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use Symfony\Component\Console\Helper\DialogHelper;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputOption;
+use Zend\EventManager\AbstractListenerAggregate;
+use Zend\EventManager\EventInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\Stdlib\ArrayUtils;
+
+/**
+ * @license MIT
+ * @link    www.doctrine-project.org
+ * @author  Nicolas Eeckeloo <neeckeloo@gmail.com>
+ */
+class PostCliLoadListener extends AbstractListenerAggregate
+{
+    private $defaultObjectManagerName = 'doctrine.entitymanager.orm_default';
+
+    private $commands = [
+        'doctrine.dbal_cmd.runsql',
+        'doctrine.dbal_cmd.import',
+        'doctrine.orm_cmd.clear_cache_metadata',
+        'doctrine.orm_cmd.clear_cache_result',
+        'doctrine.orm_cmd.clear_cache_query',
+        'doctrine.orm_cmd.schema_tool_create',
+        'doctrine.orm_cmd.schema_tool_update',
+        'doctrine.orm_cmd.schema_tool_drop',
+        'doctrine.orm_cmd.ensure_production_settings',
+        'doctrine.orm_cmd.convert_d1_schema',
+        'doctrine.orm_cmd.generate_repositories',
+        'doctrine.orm_cmd.generate_entities',
+        'doctrine.orm_cmd.generate_proxies',
+        'doctrine.orm_cmd.convert_mapping',
+        'doctrine.orm_cmd.run_dql',
+        'doctrine.orm_cmd.validate_schema',
+        'doctrine.orm_cmd.info',
+    ];
+
+    private $migrationCommands = [
+        'doctrine.migrations_cmd.execute',
+        'doctrine.migrations_cmd.generate',
+        'doctrine.migrations_cmd.migrate',
+        'doctrine.migrations_cmd.status',
+        'doctrine.migrations_cmd.version',
+        'doctrine.migrations_cmd.diff',
+        'doctrine.migrations_cmd.latest',
+    ];
+
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->getSharedManager()->attach('doctrine', 'loadCli.post', $this, $priority);
+    }
+
+    public function __invoke(EventInterface $event)
+    {
+        /* @var $cli \Symfony\Component\Console\Application */
+        $cli            = $event->getTarget();
+        /* @var $serviceLocator \Zend\ServiceManager\ServiceLocatorInterface */
+        $serviceLocator = $event->getParam('ServiceManager');
+
+        $commands = $this->getAvailableCommands();
+        foreach ($commands as $commandName) {
+            /* @var $command \Symfony\Component\Console\Command\Command */
+            $command = $serviceLocator->get($commandName);
+            $command->getDefinition()->addOption($this->createObjectManagerInputOption());
+
+            $cli->add($command);
+        }
+
+        /* @var $objectManager \Doctrine\ORM\EntityManagerInterface */
+        $objectManager = $serviceLocator->get($this->getObjectManagerName());
+        $helperSet     = $cli->getHelperSet();
+
+        $helpers = $this->getHelpers($objectManager);
+        foreach ($helpers as $name => $instance) {
+            $helperSet->set($instance, $name);
+        }
+    }
+
+    /**
+     * @param EntityManagerInterface $objectManager
+     * @return array
+     */
+    private function getHelpers(EntityManagerInterface $objectManager)
+    {
+        $helpers = [];
+
+        if (class_exists('Symfony\Component\Console\Helper\QuestionHelper')) {
+            $helpers['dialog'] = new QuestionHelper();
+        } else {
+            $helpers['dialog'] = new DialogHelper();
+        }
+
+        $helpers['db'] = new ConnectionHelper($objectManager->getConnection());
+        $helpers['em'] = new EntityManagerHelper($objectManager);
+
+        return $helpers;
+    }
+
+    /**
+     * @return InputOption
+     */
+    private function createObjectManagerInputOption()
+    {
+        return new InputOption(
+            'object-manager',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'The name of the object manager to use.',
+            $this->defaultObjectManagerName
+        );
+    }
+
+    /**
+     * @return string
+     */
+    private function getObjectManagerName()
+    {
+        $arguments = new ArgvInput();
+
+        if (!$arguments->hasParameterOption('--object-manager')) {
+            return $this->defaultObjectManagerName;
+        }
+
+        return $arguments->getParameterOption('--object-manager');
+    }
+
+    /**
+     * @return array
+     */
+    private function getAvailableCommands()
+    {
+        if (class_exists('Doctrine\\DBAL\\Migrations\\Version')) {
+            return ArrayUtils::merge($this->commands, $this->migrationCommands);
+        }
+
+        return $this->commands;
+    }
+}

--- a/src/DoctrineORMModule/Service/CliConfiguratorFactory.php
+++ b/src/DoctrineORMModule/Service/CliConfiguratorFactory.php
@@ -17,33 +17,28 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace DoctrineORMModuleTest\Listener;
+namespace DoctrineORMModule\Service;
 
 use DoctrineORMModule\CliConfigurator;
-use DoctrineORMModule\Listener\PostCliLoadListener;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
-use Zend\EventManager\Event;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-/**
- * @license MIT
- * @link    http://www.doctrine-project.org/
- * @author  Nicolas Eeckeloo <neeckeloo@gmail.com>
- */
-class PostCliLoadListenerTest extends TestCase
+class CliConfiguratorFactory implements FactoryInterface
 {
-    public function testListenerConfigureConsoleApplication()
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $application = new Application();
-        $event = new Event('loadCli.post', $application);
+        return new CliConfigurator($container);
+    }
 
-        $cliConfigurator = $this->getMockBuilder(CliConfigurator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $cliConfigurator->expects($this->once())->method('configure')->with($application);
-
-        $listener = new PostCliLoadListener($cliConfigurator);
-        $listener($event);
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, CliConfigurator::class);
     }
 }

--- a/src/DoctrineORMModule/Service/PostCliLoadListenerFactory.php
+++ b/src/DoctrineORMModule/Service/PostCliLoadListenerFactory.php
@@ -17,33 +17,32 @@
  * <http://www.doctrine-project.org>.
  */
 
-namespace DoctrineORMModuleTest\Listener;
+namespace DoctrineORMModule\Service;
 
 use DoctrineORMModule\CliConfigurator;
 use DoctrineORMModule\Listener\PostCliLoadListener;
-use PHPUnit\Framework\TestCase;
-use Symfony\Component\Console\Application;
-use Zend\EventManager\Event;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-/**
- * @license MIT
- * @link    http://www.doctrine-project.org/
- * @author  Nicolas Eeckeloo <neeckeloo@gmail.com>
- */
-class PostCliLoadListenerTest extends TestCase
+class PostCliLoadListenerFactory implements FactoryInterface
 {
-    public function testListenerConfigureConsoleApplication()
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $application = new Application();
-        $event = new Event('loadCli.post', $application);
+        /* @var $cliConfigurator CliConfigurator */
+        $cliConfigurator = $container->get(CliConfigurator::class);
 
-        $cliConfigurator = $this->getMockBuilder(CliConfigurator::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        return new PostCliLoadListener($cliConfigurator);
+    }
 
-        $cliConfigurator->expects($this->once())->method('configure')->with($application);
-
-        $listener = new PostCliLoadListener($cliConfigurator);
-        $listener($event);
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, PostCliLoadListener::class);
     }
 }

--- a/tests/DoctrineORMModuleTest/CliConfiguratorTest.php
+++ b/tests/DoctrineORMModuleTest/CliConfiguratorTest.php
@@ -1,0 +1,105 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModuleTest\Listener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use DoctrineORMModule\CliConfigurator;
+use DoctrineORMModuleTest\ServiceManagerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+
+/**
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Nicolas Eeckeloo <neeckeloo@gmail.com>
+ */
+class CliConfiguratorTest extends TestCase
+{
+    /**
+     * @var \Zend\ServiceManager\ServiceManager
+     */
+    protected $serviceManager;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $objectManager;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->serviceManager = ServiceManagerFactory::getServiceManager();
+        $this->objectManager  = $this->serviceManager->get('doctrine.entitymanager.orm_default');
+    }
+
+    public function testOrmDefaultIsUsedAsTheEntityManagerIfNoneIsProvided()
+    {
+        $application = new Application();
+
+        $cliConfigurator = new CliConfigurator($this->serviceManager);
+        $cliConfigurator->configure($application);
+
+        /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
+        $entityManagerHelper = $application->getHelperSet()->get('entityManager');
+
+        $this->assertInstanceOf(EntityManagerHelper::class, $entityManagerHelper);
+        $this->assertSame($this->objectManager, $entityManagerHelper->getEntityManager());
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testEntityManagerUsedCanBeSpecifiedInCommandLineArgument()
+    {
+        $objectManagerName = 'doctrine.entitymanager.some_other_name';
+
+        $connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager = $this->getMockbuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager
+            ->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($connection);
+
+        $this->serviceManager->setService($objectManagerName, $entityManager);
+
+        $application = new Application();
+
+        $_SERVER['argv'][] = '--object-manager=' . $objectManagerName;
+
+        $cliConfigurator = new CliConfigurator($this->serviceManager);
+        $cliConfigurator->configure($application);
+
+        /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
+        $entityManagerHelper = $application->getHelperSet()->get('entityManager');
+
+        $this->assertInstanceOf(EntityManagerHelper::class, $entityManagerHelper);
+        $this->assertSame($entityManager, $entityManagerHelper->getEntityManager());
+    }
+}

--- a/tests/DoctrineORMModuleTest/CliTest.php
+++ b/tests/DoctrineORMModuleTest/CliTest.php
@@ -90,54 +90,6 @@ class CliTest extends TestCase
         $this->assertSame($this->objectManager->getConnection(), $dbHelper->getConnection());
     }
 
-    public function testOrmDefaultIsUsedAsTheEntityManagerIfNoneIsProvided()
-    {
-        $application = new Application();
-        $event = new Event('loadCli.post', $application, ['ServiceManager' => $this->serviceManager]);
-
-        $module = new Module();
-        $module->initializeConsole($event);
-
-        /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
-        $entityManagerHelper = $application->getHelperSet()->get('entityManager');
-        $this->assertInstanceOf(\Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper::class, $entityManagerHelper);
-        $this->assertSame($this->objectManager, $entityManagerHelper->getEntityManager());
-    }
-
-    /**
-     * @backupGlobals enabled
-     */
-    public function testEntityManagerUsedCanBeSpecifiedInCommandLineArgument()
-    {
-        $connection = $this->getMockBuilder(\Doctrine\DBAL\Connection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entityManager = $this->getMockbuilder(\Doctrine\ORM\EntityManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $entityManager
-            ->expects($this->atLeastOnce())
-            ->method('getConnection')
-            ->willReturn($connection);
-
-        $this->serviceManager->setService('doctrine.entitymanager.some_other_name', $entityManager);
-
-        $application = new Application();
-        $event = new Event('loadCli.post', $application, ['ServiceManager' => $this->serviceManager]);
-
-        $_SERVER['argv'][] = '--object-manager=doctrine.entitymanager.some_other_name';
-
-        $module = new Module();
-        $module->initializeConsole($event);
-
-        /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
-        $entityManagerHelper = $application->getHelperSet()->get('entityManager');
-        $this->assertInstanceOf(\Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper::class, $entityManagerHelper);
-        $this->assertSame($entityManager, $entityManagerHelper->getEntityManager());
-    }
-
     /**
      * @param string $commandName
      * @param string $className

--- a/tests/DoctrineORMModuleTest/Listener/PostCliLoadListenerTest.php
+++ b/tests/DoctrineORMModuleTest/Listener/PostCliLoadListenerTest.php
@@ -1,0 +1,108 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace DoctrineORMModuleTest\Listener;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
+use DoctrineORMModule\Listener\PostCliLoadListener;
+use DoctrineORMModuleTest\ServiceManagerFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Zend\EventManager\Event;
+
+/**
+ * @license MIT
+ * @link    http://www.doctrine-project.org/
+ * @author  Nicolas Eeckeloo <neeckeloo@gmail.com>
+ */
+class PostCliLoadListenerTest extends TestCase
+{
+    /**
+     * @var \Zend\ServiceManager\ServiceManager
+     */
+    protected $serviceManager;
+
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    protected $objectManager;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUp()
+    {
+        $this->serviceManager = ServiceManagerFactory::getServiceManager();
+        $this->objectManager  = $this->serviceManager->get('doctrine.entitymanager.orm_default');
+    }
+
+    public function testOrmDefaultIsUsedAsTheEntityManagerIfNoneIsProvided()
+    {
+        $application = new Application();
+        $event = new Event('loadCli.post', $application, ['ServiceManager' => $this->serviceManager]);
+
+        $listener = new PostCliLoadListener();
+        $listener($event);
+
+        /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
+        $entityManagerHelper = $application->getHelperSet()->get('entityManager');
+
+        $this->assertInstanceOf(EntityManagerHelper::class, $entityManagerHelper);
+        $this->assertSame($this->objectManager, $entityManagerHelper->getEntityManager());
+    }
+
+    /**
+     * @backupGlobals enabled
+     */
+    public function testEntityManagerUsedCanBeSpecifiedInCommandLineArgument()
+    {
+        $objectManagerName = 'doctrine.entitymanager.some_other_name';
+
+        $connection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager = $this->getMockbuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityManager
+            ->expects($this->atLeastOnce())
+            ->method('getConnection')
+            ->willReturn($connection);
+
+        $this->serviceManager->setService($objectManagerName, $entityManager);
+
+        $application = new Application();
+        $event = new Event('loadCli.post', $application, ['ServiceManager' => $this->serviceManager]);
+
+        $_SERVER['argv'][] = '--object-manager=' . $objectManagerName;
+
+        $listener = new PostCliLoadListener();
+        $listener($event);
+
+        /* @var $entityManagerHelper \Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper */
+        $entityManagerHelper = $application->getHelperSet()->get('entityManager');
+
+        $this->assertInstanceOf(EntityManagerHelper::class, $entityManagerHelper);
+        $this->assertSame($entityManager, $entityManagerHelper->getEntityManager());
+    }
+}

--- a/tests/TestConfigurationV2.php
+++ b/tests/TestConfigurationV2.php
@@ -16,6 +16,10 @@
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
+
+use DoctrineORMModule\Listener\PostCliLoadListener;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
 return [
     'modules' => [
         'DoctrineModule',
@@ -26,5 +30,10 @@ return [
             __DIR__ . '/testing.config.php',
         ],
         'module_paths' => [],
+    ],
+    'service_manager' => [
+        'factories' => [
+            PostCliLoadListener::class => InvokableFactory::class,
+        ],
     ],
 ];

--- a/tests/TestConfigurationV2.php
+++ b/tests/TestConfigurationV2.php
@@ -17,8 +17,10 @@
  * <http://www.doctrine-project.org>.
  */
 
+use DoctrineORMModule\CliConfigurator;
 use DoctrineORMModule\Listener\PostCliLoadListener;
-use Zend\ServiceManager\Factory\InvokableFactory;
+use DoctrineORMModule\Service\CliConfiguratorFactory;
+use DoctrineORMModule\Service\PostCliLoadListenerFactory;
 
 return [
     'modules' => [
@@ -33,7 +35,8 @@ return [
     ],
     'service_manager' => [
         'factories' => [
-            PostCliLoadListener::class => InvokableFactory::class,
+            PostCliLoadListener::class => PostCliLoadListenerFactory::class,
+            CliConfigurator::class => CliConfiguratorFactory::class,
         ],
     ],
 ];

--- a/tests/TestConfigurationV3.php
+++ b/tests/TestConfigurationV3.php
@@ -16,6 +16,10 @@
  * and is licensed under the MIT license. For more information, see
  * <http://www.doctrine-project.org>.
  */
+
+use DoctrineORMModule\Listener\PostCliLoadListener;
+use Zend\ServiceManager\Factory\InvokableFactory;
+
 return [
     'modules' => [
         'Zend\Cache',
@@ -33,5 +37,10 @@ return [
             __DIR__ . '/testing.config.php',
         ],
         'module_paths' => [],
+    ],
+    'service_manager' => [
+        'factories' => [
+            PostCliLoadListener::class => InvokableFactory::class,
+        ],
     ],
 ];

--- a/tests/TestConfigurationV3.php
+++ b/tests/TestConfigurationV3.php
@@ -17,8 +17,10 @@
  * <http://www.doctrine-project.org>.
  */
 
+use DoctrineORMModule\CliConfigurator;
 use DoctrineORMModule\Listener\PostCliLoadListener;
-use Zend\ServiceManager\Factory\InvokableFactory;
+use DoctrineORMModule\Service\CliConfiguratorFactory;
+use DoctrineORMModule\Service\PostCliLoadListenerFactory;
 
 return [
     'modules' => [
@@ -40,7 +42,8 @@ return [
     ],
     'service_manager' => [
         'factories' => [
-            PostCliLoadListener::class => InvokableFactory::class,
+            PostCliLoadListener::class => PostCliLoadListenerFactory::class,
+            CliConfigurator::class => CliConfiguratorFactory::class,
         ],
     ],
 ];


### PR DESCRIPTION
Hi!

This PR is not adding any features, it's merely the start of a refactoring in order to split responsibilities in some of the existing classes. The goal is to get out the logic that initializes the console application from the `DoctrineORMModule\Module` class.

 * the listener of `loadCli.post` event, that aims to initialize console application, is separated in it's own file and class:`DoctrineORMModule\Listener\PostCliLoadListener`
 * `DoctrineORMModule\CliConfigurator` class is used to configure console application in the previous listener. This class has been splitted into several methods that could lead to the creation of other classes to improve separation of concerns.
* consequently, unit tests have been updated and improved