### PR TITLE
[DOCS] Fix the documentation for using multiple connections

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,8 +114,9 @@ return [
     'doctrine' => [
         'connection' => [
             'orm_crawler' => [
-                'driverClass' => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
-                'params' => [
+                'driverClass'   => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+                'configuration' => 'orm_crawler',
+                'params'        => [
                     'host'     => 'localhost',
                     'port'     => '3306',
                     'user'     => 'root',

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,28 +180,16 @@ return [
 ];
 ```
 
-Module.php
-```php
-public function getServiceConfig()
-{
-    return [
-        'factories' => [
-            'doctrine.connection.orm_crawler'           => new \DoctrineORMModule\Service\DBALConnectionFactory('orm_crawler'),
-            'doctrine.configuration.orm_crawler'        => new \DoctrineORMModule\Service\ConfigurationFactory('orm_crawler'),
-            'doctrine.entitymanager.orm_crawler'        => new \DoctrineORMModule\Service\EntityManagerFactory('orm_crawler'),
+The `DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory` will create the following objects as needed:
+* 'doctrine.connection.orm_crawler'
+* 'doctrine.configuration.orm_crawler'
+* 'doctrine.entitymanager.orm_crawler'
+* 'doctrine.driver.orm_crawler'
+* 'doctrine.eventmanager.orm_crawler'
+* 'doctrine.entity_resolver.orm_crawler'
+* 'doctrine.sql_logger_collector.orm_crawler'
 
-            'doctrine.driver.orm_crawler'               => new \DoctrineModule\Service\DriverFactory('orm_crawler'),
-            'doctrine.eventmanager.orm_crawler'         => new \DoctrineModule\Service\EventManagerFactory('orm_crawler'),
-            'doctrine.entity_resolver.orm_crawler'      => new \DoctrineORMModule\Service\EntityResolverFactory('orm_crawler'),
-            'doctrine.sql_logger_collector.orm_crawler' => new \DoctrineORMModule\Service\SQLLoggerCollectorFactory('orm_crawler'),
-
-            'DoctrineORMModule\Form\Annotation\AnnotationBuilder' => function(\Zend\ServiceManager\ServiceLocatorInterface $sl) {
-                return new \DoctrineORMModule\Form\Annotation\AnnotationBuilder($sl->get('doctrine.entitymanager.orm_crawler'));
-            },
-        ],
-    ];
-}
-```
+You can retrieve them from the service manager via their keys.
 
 ### How to Use Naming Strategy
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,6 +115,7 @@ return [
         'connection' => [
             'orm_crawler' => [
                 'driverClass'   => 'Doctrine\DBAL\Driver\PDOMySql\Driver',
+                'eventmanager'  => 'orm_crawler',
                 'configuration' => 'orm_crawler',
                 'params'        => [
                     'host'     => 'localhost',
@@ -135,7 +136,7 @@ return [
                 'query_cache'       => 'array',
                 'result_cache'      => 'array',
                 'hydration_cache'   => 'array',
-                'driver'            => 'orm_crawler',
+                'driver'            => 'orm_crawler_chain',
                 'generate_proxies'  => true,
                 'proxy_dir'         => 'data/DoctrineORMModule/Proxy',
                 'proxy_namespace'   => 'DoctrineORMModule\Proxy',
@@ -144,17 +145,17 @@ return [
         ],
 
         'driver' => [
-            'Crawler_Driver' => [
+            'orm_crawler_annotation' => [
                 'class' => 'Doctrine\ORM\Mapping\Driver\AnnotationDriver',
                 'cache' => 'array',
                 'paths' => [
                     __DIR__ . '/../src/Crawler/Entity',
                 ],
             ],
-            'orm_crawler' => [
+            'orm_crawler_chain' => [
                 'class'   => 'Doctrine\ORM\Mapping\Driver\DriverChain',
                 'drivers' => [
-                    'Crawler\Entity' =>  'Crawler_Driver',
+                    'Crawler\Entity' =>  'orm_crawler_annotation',
                 ],
             ],
         ],


### PR DESCRIPTION
In the documentation for using multiple connection is written that we should register 8 factories to make the new connection, Entity-Manager, etc ... work. See https://github.com/doctrine/DoctrineORMModule/blob/master/docs/configuration.md#how-to-use-two-connections
This worked well in dev, but fails everywhere else! 
```
Error: Call to undefined method DoctrineORMModule\Service\DBALConnectionFactory::__set_state() in /x/data/module-config-cache.php:187
Stack trace:
#0 /x/vendor/zendframework/zend-modulemanager/src/Listener/ConfigListener.php(392): include()
#1 /x/vendor/zendframework/zend-modulemanager/src/Listener/ConfigListener.php(70): Zend\ModuleManager\Listener\ConfigListener->getCachedConfig()
#2 /x/vendor/zendframework/zend-modulemanager/src/Listener/DefaultListenerAggregate.php(112): Zend\ModuleManager\Listener\ConfigListener->__construct(Object(Zend\ModuleManager\Listener\ListenerOptions))
#3 /x/vendor/zendframework/zend-modulemanager/src/Listener/DefaultListenerAggregate.php(42): Zend\ModuleManager\Listener\DefaultListenerAggregate->getConfigListener()
#4 /x/vendor/zendframework/zend-mvc/src/Service/ModuleManagerFactory.php(77): Zend\ModuleManager\Listener\DefaultListenerAggregate->attach(Object(Zend\EventManager\EventManager))
#5 /x/vendor/zendframework/zend-servicemanager/src/ServiceManager.php(758): Zend\Mvc\Service\ModuleManagerFactory->__invoke(Object(Zend\ServiceManager\ServiceManager), 'ModuleManager', NULL)
#6 /x/vendor/zendframework/zend-servicemanager/src/ServiceManager.php(200): Zend\ServiceManager\ServiceManager->doCreate('ModuleManager')
#7 /x/vendor/zendframework/zend-mvc/src/Application.php(264): Zend\ServiceManager\ServiceManager->get('ModuleManager')
#8 /x/bin/doctrine-x.php(14): Zend\Mvc\Application::init(Array)
#9 {main}
```
Because the config cache is enabled (except in dev) and these factories do not implement the necessary method. This means we cant use these factories directly. There is an AbstractFactory that manages all that and is cache-able: `DoctrineModule\ServiceFactory\AbstractDoctrineServiceFactory`. 

So this PR removes every mention of these factories so we can cache this config.