### PR TITLE
 Making 1.1.8 work with zendframework/zend-developer-tools 1.2.1

### DIFF
--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -52,8 +52,8 @@ class Module implements
                 ->getEventManager()
                 ->attach(
                     ProfilerEvent::EVENT_PROFILER_INIT,
-                    function ($event) {
-                        $container = $event->getTarget()->getParam('ServiceManager');
+                    function ($event) use ($manager) {
+                        $container = $manager->getEvent()->getParam('ServiceManager');
                         $container->get('doctrine.sql_logger_collector.orm_default');
                     }
                 );


### PR DESCRIPTION
Related to forgotten [doctrine/DoctrineORMModule#567](https://github.com/doctrine/DoctrineORMModule/issues/567).