### PR TITLE
Allow for measurable time to pass when testing SQLLogger GetQueryTime

### DIFF
--- a/tests/DoctrineORMModuleTest/Collector/SQLLoggerCollectorTest.php
+++ b/tests/DoctrineORMModuleTest/Collector/SQLLoggerCollectorTest.php
@@ -69,6 +69,7 @@ class SQLLoggerCollectorTest extends TestCase
         $this->assertEquals(0, $this->collector->getQueryTime());
 
         $this->logger->startQuery('some sql');
+        sleep(1);
         $this->logger->stopQuery();
         $time = microtime(true) - $start;
         $time1 = $this->collector->getQueryTime();


### PR DESCRIPTION
I received this error when testing:

```
1) DoctrineORMModuleTest\Collector\SQLLoggerCollectorTest::testGetQueryTime
Failed asserting that 1.9073486328125E-6 is greater than 1.9073486328125E-6.
```

To allow measurable time to pass I added a sleep(1) to this test