### PR TITLE
switch to laminas

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,27 +43,27 @@
         "doctrine/orm":                      "^2.6.3",
         "doctrine/dbal":                     "^2.6.0",
         "symfony/console":                   "^3.3 || ^4.0 || ^5.0",
-        "zendframework/zend-stdlib":         "^3.2.1",
-        "zendframework/zend-hydrator":       "^2.3",
-        "zendframework/zend-mvc":            "^3.1",
-        "zendframework/zend-servicemanager": "^3.3"
+        "laminas/laminas-stdlib":         "^3.2.1",
+        "laminas/laminas-hydrator":       "^2.3",
+        "laminas/laminas-mvc":            "^3.1",
+        "laminas/laminas-servicemanager": "^3.3"
     },
     "require-dev":       {
         "phpunit/phpunit":                    "^7.0.3",
         "squizlabs/php_codesniffer":          "^2.7",
         "doctrine/data-fixtures":             "^1.2.1",
         "doctrine/migrations":                "^1.5 || ^2.0",
-        "zendframework/zend-console":         "^2.6",
-        "zendframework/zend-developer-tools": "^1.1",
-        "zendframework/zend-i18n":            "^2.7.3",
-        "zendframework/zend-log":             "^2.9",
-        "zendframework/zend-modulemanager":   "^2.7.2",
-        "zendframework/zend-mvc-console":     "^1.2",
-        "zendframework/zend-serializer":      "^2.8"
+        "laminas/laminas-console":         "^2.6",
+        "laminas/laminas-developer-tools": "^1.1",
+        "laminas/laminas-i18n":            "^2.7.3",
+        "laminas/laminas-log":             "^2.9",
+        "laminas/laminas-modulemanager":   "^2.7.2",
+        "laminas/laminas-mvc-console":     "^1.2",
+        "laminas/laminas-serializer":      "^2.8"
     },
     "suggest":           {
-        "zendframework/zend-form":            "if you want to use form elements backed by Doctrine",
-        "zendframework/zend-developer-tools": "zend-developer-tools if you want to profile operations executed by the ORM during development",
+        "laminas/laminas-form":            "if you want to use form elements backed by Doctrine",
+        "laminas/laminas-developer-tools": "zend-developer-tools if you want to profile operations executed by the ORM during development",
         "doctrine/migrations":                "doctrine migrations if you want to keep your schema definitions versioned"
     },
     "autoload":          {

--- a/src/DoctrineORMModule/CliConfigurator.php
+++ b/src/DoctrineORMModule/CliConfigurator.php
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
-use Zend\Stdlib\ArrayUtils;
+use Laminas\Stdlib\ArrayUtils;
 
 /**
  * @license MIT

--- a/src/DoctrineORMModule/Collector/MappingCollector.php
+++ b/src/DoctrineORMModule/Collector/MappingCollector.php
@@ -4,15 +4,15 @@ namespace DoctrineORMModule\Collector;
 
 use Serializable;
 
-use ZendDeveloperTools\Collector\CollectorInterface;
-use ZendDeveloperTools\Collector\AutoHideInterface;
+use Laminas\DeveloperTools\Collector\CollectorInterface;
+use Laminas\DeveloperTools\Collector\AutoHideInterface;
 
-use Zend\Mvc\MvcEvent;
+use Laminas\Mvc\MvcEvent;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 
 /**
- * Collector to be used in ZendDeveloperTools to record and display mapping information
+ * Collector to be used in LaminasDeveloperTools to record and display mapping information
  *
  * @license MIT
  * @link    www.doctrine-project.org

--- a/src/DoctrineORMModule/Collector/SQLLoggerCollector.php
+++ b/src/DoctrineORMModule/Collector/SQLLoggerCollector.php
@@ -2,15 +2,15 @@
 
 namespace DoctrineORMModule\Collector;
 
-use ZendDeveloperTools\Collector\CollectorInterface;
-use ZendDeveloperTools\Collector\AutoHideInterface;
+use Laminas\DeveloperTools\Collector\CollectorInterface;
+use Laminas\DeveloperTools\Collector\AutoHideInterface;
 
-use Zend\Mvc\MvcEvent;
+use Laminas\Mvc\MvcEvent;
 
 use Doctrine\DBAL\Logging\DebugStack;
 
 /**
- * Collector to be used in ZendDeveloperTools to record and display SQL queries
+ * Collector to be used in LaminasDeveloperTools to record and display SQL queries
  *
  * @license MIT
  * @link    www.doctrine-project.org

--- a/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
+++ b/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
@@ -5,13 +5,13 @@ namespace DoctrineORMModule\Form\Annotation;
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Form\Element;
-use Zend\EventManager\EventManagerInterface;
-use Zend\Form\Annotation\AnnotationBuilder as ZendAnnotationBuilder;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\Form\Annotation\AnnotationBuilder as LaminasAnnotationBuilder;
 
 /**
  * @author Kyle Spraggs <theman@spiffyjr.me>
  */
-class AnnotationBuilder extends ZendAnnotationBuilder
+class AnnotationBuilder extends LaminasAnnotationBuilder
 {
     const EVENT_CONFIGURE_FIELD       = 'configureField';
     const EVENT_CONFIGURE_ASSOCIATION = 'configureAssociation';

--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -6,10 +6,10 @@ use ArrayObject;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use DoctrineORMModule\Form\Element\EntitySelect;
-use Zend\EventManager\AbstractListenerAggregate;
-use Zend\EventManager\EventInterface;
-use Zend\EventManager\EventManagerInterface;
-use Zend\Form\Element as ZendFormElement;
+use Laminas\EventManager\AbstractListenerAggregate;
+use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\Form\Element as LaminasFormElement;
 
 /**
  * @author Kyle Spraggs <theman@spiffyjr.me>
@@ -267,27 +267,27 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
             case 'bigint':
             case 'integer':
             case 'smallint':
-                $type = ZendFormElement\Number::class;
+                $type = LaminasFormElement\Number::class;
                 break;
             case 'bool':
             case 'boolean':
-                $type = ZendFormElement\Checkbox::class;
+                $type = LaminasFormElement\Checkbox::class;
                 break;
             case 'date':
-                $type = ZendFormElement\Date::class;
+                $type = LaminasFormElement\Date::class;
                 break;
             case 'datetimetz':
             case 'datetime':
-                $type = ZendFormElement\DateTime::class;
+                $type = LaminasFormElement\DateTime::class;
                 break;
             case 'time':
-                $type = ZendFormElement\Time::class;
+                $type = LaminasFormElement\Time::class;
                 break;
             case 'text':
-                $type = ZendFormElement\Textarea::class;
+                $type = LaminasFormElement\Textarea::class;
                 break;
             default:
-                $type = ZendFormElement::class;
+                $type = LaminasFormElement::class;
                 break;
         }
 
@@ -330,7 +330,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
             case 'string':
                 $elementSpec = $event->getParam('elementSpec');
                 if (isset($elementSpec['spec']['type']) &&
-                    in_array($elementSpec['spec']['type'], ['File', 'Zend\Form\Element\File'])
+                    in_array($elementSpec['spec']['type'], ['File', 'Laminas\Form\Element\File'])
                 ) {
                     return;
                 }

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -3,13 +3,13 @@
 namespace DoctrineORMModule;
 
 use Interop\Container\ContainerInterface;
-use Zend\EventManager\EventInterface;
-use Zend\ModuleManager\Feature\ControllerProviderInterface;
-use Zend\ModuleManager\Feature\ConfigProviderInterface;
-use Zend\ModuleManager\Feature\DependencyIndicatorInterface;
-use Zend\ModuleManager\ModuleManagerInterface;
+use Laminas\EventManager\EventInterface;
+use Laminas\ModuleManager\Feature\ControllerProviderInterface;
+use Laminas\ModuleManager\Feature\ConfigProviderInterface;
+use Laminas\ModuleManager\Feature\DependencyIndicatorInterface;
+use Laminas\ModuleManager\ModuleManagerInterface;
 use DoctrineORMModule\CliConfigurator;
-use ZendDeveloperTools\ProfilerEvent;
+use Laminas\DeveloperTools\ProfilerEvent;
 
 /**
  * Base module for Doctrine ORM.
@@ -46,7 +46,7 @@ class Module implements
                 1
             );
 
-        // Initialize logger collector in ZendDeveloperTools
+        // Initialize logger collector in LaminasDeveloperTools
         if (class_exists(ProfilerEvent::class)) {
             $manager
                 ->getEventManager()

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Repository\RepositoryFactory;
-use Zend\Stdlib\Exception\InvalidArgumentException;
+use Laminas\Stdlib\Exception\InvalidArgumentException;
 
 /**
  * Configuration options for an ORM Configuration

--- a/src/DoctrineORMModule/Options/DBALConfiguration.php
+++ b/src/DoctrineORMModule/Options/DBALConfiguration.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineORMModule\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Configuration options for a DBAL Connection

--- a/src/DoctrineORMModule/Options/DBALConnection.php
+++ b/src/DoctrineORMModule/Options/DBALConnection.php
@@ -3,7 +3,7 @@
 namespace DoctrineORMModule\Options;
 
 use Doctrine\DBAL\Driver\PDOMySql\Driver;
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * DBAL Connection options

--- a/src/DoctrineORMModule/Options/EntityManager.php
+++ b/src/DoctrineORMModule/Options/EntityManager.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineORMModule\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 class EntityManager extends AbstractOptions
 {

--- a/src/DoctrineORMModule/Options/EntityResolver.php
+++ b/src/DoctrineORMModule/Options/EntityResolver.php
@@ -3,7 +3,7 @@
 namespace DoctrineORMModule\Options;
 
 use InvalidArgumentException;
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 class EntityResolver extends AbstractOptions
 {

--- a/src/DoctrineORMModule/Options/SQLLoggerCollectorOptions.php
+++ b/src/DoctrineORMModule/Options/SQLLoggerCollectorOptions.php
@@ -2,7 +2,7 @@
 
 namespace DoctrineORMModule\Options;
 
-use Zend\Stdlib\AbstractOptions;
+use Laminas\Stdlib\AbstractOptions;
 
 /**
  * Configuration options for an collector

--- a/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
+++ b/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
@@ -6,8 +6,8 @@ use DoctrineORMModule\Options\DBALConfiguration;
 use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Repository\RepositoryFactory;
-use Zend\Stdlib\AbstractOptions;
-use Zend\Stdlib\Exception\InvalidArgumentException;
+use Laminas\Stdlib\AbstractOptions;
+use Laminas\Stdlib\Exception\InvalidArgumentException;
 
 /**
  * Configuration options for Second Level Cache

--- a/src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php
@@ -3,10 +3,10 @@
 namespace DoctrineORMModule\Paginator\Adapter;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
-use Zend\Paginator\Adapter\AdapterInterface;
+use Laminas\Paginator\Adapter\AdapterInterface;
 
 /**
- * Paginator adapter for the Zend\Paginator component
+ * Paginator adapter for the Laminas\Paginator component
  *
  * @license MIT
  * @link    http://www.doctrine-project.org/

--- a/src/DoctrineORMModule/Service/CliConfiguratorFactory.php
+++ b/src/DoctrineORMModule/Service/CliConfiguratorFactory.php
@@ -4,8 +4,8 @@ namespace DoctrineORMModule\Service;
 
 use DoctrineORMModule\CliConfigurator;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class CliConfiguratorFactory implements FactoryInterface
 {

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -9,8 +9,8 @@ use Doctrine\ORM\Mapping\EntityListenerResolver;
 use DoctrineORMModule\Options\Configuration as DoctrineORMModuleConfiguration;
 use DoctrineORMModule\Service\DBALConfigurationFactory as DoctrineConfigurationFactory;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\Exception\InvalidArgumentException;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Exception\InvalidArgumentException;
 use Doctrine\ORM\Configuration;
 
 class ConfigurationFactory extends DoctrineConfigurationFactory

--- a/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
@@ -7,8 +7,8 @@ use Interop\Container\ContainerInterface;
 use RuntimeException;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Types\Type;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * DBAL Configuration ServiceManager factory

--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -8,7 +8,7 @@ use Doctrine\DBAL\Types\Type;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\DBALConnection;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * DBAL Connection ServiceManager factory

--- a/src/DoctrineORMModule/Service/DoctrineObjectHydratorFactory.php
+++ b/src/DoctrineORMModule/Service/DoctrineObjectHydratorFactory.php
@@ -20,8 +20,8 @@ namespace DoctrineORMModule\Service;
 
 use DoctrineModule\Stdlib\Hydrator\DoctrineObject;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class DoctrineObjectHydratorFactory implements FactoryInterface
 {

--- a/src/DoctrineORMModule/Service/EntityManagerAliasCompatFactory.php
+++ b/src/DoctrineORMModule/Service/EntityManagerAliasCompatFactory.php
@@ -3,8 +3,8 @@
 namespace DoctrineORMModule\Service;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Factory that provides the `Doctrine\ORM\EntityManager` alias for `doctrine.entitymanager.orm_default`

--- a/src/DoctrineORMModule/Service/EntityManagerFactory.php
+++ b/src/DoctrineORMModule/Service/EntityManagerFactory.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\EntityManager;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\EntityManager as DoctrineORMModuleEntityManager;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class EntityManagerFactory extends AbstractFactory
 {

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -8,8 +8,8 @@ use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\EntityResolver;
 use Interop\Container\ContainerInterface;
-use Zend\EventManager\EventManager;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\EventManager\EventManager;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class EntityResolverFactory extends AbstractFactory
 {

--- a/src/DoctrineORMModule/Service/FormAnnotationBuilderFactory.php
+++ b/src/DoctrineORMModule/Service/FormAnnotationBuilderFactory.php
@@ -5,8 +5,8 @@ namespace DoctrineORMModule\Service;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Form\Annotation\AnnotationBuilder;
 use Interop\Container\ContainerInterface;
-use Zend\Form\Factory;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Form\Factory;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Service factory responsible for instantiating {@see \DoctrineORMModule\Form\Annotation\AnnotationBuilder}

--- a/src/DoctrineORMModule/Service/MappingCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/MappingCollectorFactory.php
@@ -5,7 +5,7 @@ namespace DoctrineORMModule\Service;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Collector\MappingCollector;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Service factory responsible for instantiating {@see \DoctrineORMModule\Collector\MappingCollector}

--- a/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
@@ -19,8 +19,8 @@
 namespace DoctrineORMModule\Service;
 
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Service factory for migrations command
@@ -69,7 +69,7 @@ class MigrationsCommandFactory implements FactoryInterface
     }
 
     /**
-     * @param \Zend\ServiceManager\ServiceLocatorInterface $container
+     * @param \Laminas\ServiceManager\ServiceLocatorInterface $container
      * @return \Doctrine\Migrations\Tools\Console\Command\AbstractCommand
      * @throws \InvalidArgumentException
      */

--- a/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
@@ -6,7 +6,7 @@ use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\OutputWriter;
 use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 /**

--- a/src/DoctrineORMModule/Service/ObjectMultiCheckboxFactory.php
+++ b/src/DoctrineORMModule/Service/ObjectMultiCheckboxFactory.php
@@ -5,8 +5,8 @@ namespace DoctrineORMModule\Service;
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectMultiCheckbox;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
 
 /**
  * Factory for {@see ObjectMultiCheckbox}

--- a/src/DoctrineORMModule/Service/ObjectRadioFactory.php
+++ b/src/DoctrineORMModule/Service/ObjectRadioFactory.php
@@ -5,8 +5,8 @@ namespace DoctrineORMModule\Service;
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectRadio;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
 
 /**
  * Factory for {@see ObjectRadio}

--- a/src/DoctrineORMModule/Service/ObjectSelectFactory.php
+++ b/src/DoctrineORMModule/Service/ObjectSelectFactory.php
@@ -5,8 +5,8 @@ namespace DoctrineORMModule\Service;
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectSelect;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
 
 /**
  * Factory for {@see ObjectSelect}

--- a/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
@@ -4,8 +4,8 @@ namespace DoctrineORMModule\Service;
 
 use DoctrineORMModule\Options\SQLLoggerCollectorOptions;
 use Interop\Container\ContainerInterface;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
 use DoctrineORMModule\Collector\SQLLoggerCollector;
 use Doctrine\DBAL\Logging\DebugStack;

--- a/src/DoctrineORMModule/Yuml/YumlController.php
+++ b/src/DoctrineORMModule/Yuml/YumlController.php
@@ -2,9 +2,9 @@
 
 namespace DoctrineORMModule\Yuml;
 
-use Zend\Http\Client;
-use Zend\Http\Request;
-use Zend\Mvc\Controller\AbstractActionController;
+use Laminas\Http\Client;
+use Laminas\Http\Request;
+use Laminas\Mvc\Controller\AbstractActionController;
 
 /**
  * Utility to generate Yuml compatible strings from metadata graphs
@@ -31,13 +31,13 @@ class YumlController extends AbstractActionController
     /**
      * Redirects the user to a YUML graph drawn with the provided `dsl_text`
      *
-     * @return \Zend\Http\Response
+     * @return \Laminas\Http\Response
      *
      * @throws \UnexpectedValueException if the YUML service answered incorrectly
      */
     public function indexAction()
     {
-        /* @var $request \Zend\Http\Request */
+        /* @var $request \Laminas\Http\Request */
         $request = $this->getRequest();
         $this->httpClient->setMethod(Request::METHOD_POST);
         $this->httpClient->setParameterPost(['dsl_text' => $request->getPost('dsl_text')]);
@@ -47,7 +47,7 @@ class YumlController extends AbstractActionController
             throw new \UnexpectedValueException('HTTP Request failed');
         }
 
-        /* @var $redirect \Zend\Mvc\Controller\Plugin\Redirect */
+        /* @var $redirect \Laminas\Mvc\Controller\Plugin\Redirect */
         $redirect = $this->plugin('redirect');
 
         return $redirect->toUrl('https://yuml.me/' . $response->getBody());

--- a/src/DoctrineORMModule/Yuml/YumlControllerFactory.php
+++ b/src/DoctrineORMModule/Yuml/YumlControllerFactory.php
@@ -4,11 +4,11 @@ namespace DoctrineORMModule\Yuml;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
-use Zend\Http\Client;
-use Zend\ServiceManager\AbstractPluginManager;
-use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use Zend\ServiceManager\FactoryInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
+use Laminas\Http\Client;
+use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
 
 class YumlControllerFactory implements FactoryInterface
 {
@@ -45,8 +45,8 @@ class YumlControllerFactory implements FactoryInterface
     {
         $config = $container->get('config');
 
-        if (! isset($config['zenddevelopertools']['toolbar']['enabled'])
-            || ! $config['zenddevelopertools']['toolbar']['enabled']
+        if (! isset($config['Laminasdevelopertools']['toolbar']['enabled'])
+            || ! $config['Laminasdevelopertools']['toolbar']['enabled']
         ) {
             throw new ServiceNotFoundException(
                 sprintf('Service %s could not be found', YumlController::class)


### PR DESCRIPTION
This pull request changes the dependencies to old zend framework components to the new laminas components.

Zend framework is abandoned as of 01/01/2020, and would not be supported any more. All active codes are moved to laminas.
