### PR TITLE
Fix fatal error

### DIFF
--- a/src/DoctrineORMModule/Service/MappingCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/MappingCollectorFactory.php
@@ -37,9 +37,6 @@ class MappingCollectorFactory extends AbstractFactory
         return $this($container, MappingCollector::class);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function getOptionsClass() : string
     {
     }

--- a/src/DoctrineORMModule/Service/MappingCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/MappingCollectorFactory.php
@@ -40,7 +40,7 @@ class MappingCollectorFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      */
-    public function getOptionsClass()
+    public function getOptionsClass() : string
     {
     }
 }


### PR DESCRIPTION
Fixes `Fatal Error (E_COMPILE_ERROR): Declaration of DoctrineORMModule\Service\MappingCollectorFactory::getOptionsClass() must be compatible with DoctrineModule\Service\AbstractFactory::getOptionsClass(): string`