### PR TITLE
Only include migrations commands if compatible

### DIFF
--- a/src/DoctrineORMModule/CliConfigurator.php
+++ b/src/DoctrineORMModule/CliConfigurator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineORMModule;
 
 use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -126,7 +127,7 @@ class CliConfigurator
      */
     private function getAvailableCommands() : array
     {
-        if (class_exists(VersionCommand::class)) {
+        if (class_exists(Configuration::class) && method_exists(Configuration::class, 'getOutputWriter')) {
             return ArrayUtils::merge($this->commands, $this->migrationCommands);
         }
 


### PR DESCRIPTION
This is a temporary fix for the error message when using the CLI tools with doctrine migrations 3.0 installed. This will only load the migrations commands if they're compatible with DoctrineORMModule. It does not provide support for migrations 3.0.

https://github.com/doctrine/DoctrineORMModule/issues/620