### PR TITLE
Updated invalid namespace reference

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,6 +1,6 @@
 <?php
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\DBAL\Tools\Console;
 use Doctrine\ORM\Tools\Console\Command;
 use DoctrineModule\Form\Element;


### PR DESCRIPTION
I noticed that the default used config uses an invalid reference towards doctrine itself. It is reference towards the Doctrine\Common where it does not exists anymore.

Ofcourse i am able to extend it however on default Laminas/Zend will do a config merge and therefor fails