### PR TITLE
Update namespace for MappingDriverChain

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,6 +1,6 @@
 <?php
 
-use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\DBAL\Tools\Console;
 use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Doctrine\ORM\Tools\Console\Command;


### PR DESCRIPTION
Following update of doctrine module where MappingDriverChain moved from Common module to Persistence module, the namespace for the MappingDriverChain changed but was not updated here.