### PR TITLE
Upgrade packages to reach Composer 2 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ phpunit.xml
 .project/
 nbproject/
 composer.phar
-.phpcs-cache
+.php_cs.cache
 .phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "doctrine/annotations":            "^1.8",
         "doctrine/coding-standard":        "^8.0",
         "doctrine/data-fixtures":          "^1.2.1",
-        "doctrine/migrations":             "^1.5 || ^2.0",
+        "doctrine/migrations":             "^1.5 || ^2.0, < 2.3.0",
         "laminas/laminas-code":            "^3.3.2",
         "laminas/laminas-console":         "^2.6",
         "laminas/laminas-developer-tools": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
             "@cs-check",
             "@test"
         ],
-        "cs-check": "phpcs --standard=Doctrine src",
+        "cs-check": "phpcs",
         "cs-fix": "phpcbf",
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --coverage-clover build/clover.xml"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,12 @@
             "email": "tom.h.anderson@gmail.com"
         }
     ],
+    "config": {
+        "platform": {
+            "php": "7.2.15"
+        },
+        "sort-packages": true
+    },
     "extra": {
         "laminas": {
             "config-provider": "DoctrineORMModule\\ConfigProvider",
@@ -42,15 +48,16 @@
         }
     },
     "require":           {
-        "php":                               "^7.2",
-        "doctrine/dbal":                     "^2.10",
-        "doctrine/doctrine-module":          "^4.0",
-        "doctrine/orm":                      "^2.6.4",
-        "symfony/console":                   "^5.0"
+        "php":                                  "^7.2",
+        "composer/package-versions-deprecated": "^1.11",
+        "doctrine/dbal":                        "^2.10",
+        "doctrine/doctrine-module":             "^4.0",
+        "doctrine/orm":                         "^2.6.4",
+        "symfony/console":                      "^5.0"
     },
     "require-dev":       {
         "doctrine/annotations":            "^1.8",
-        "doctrine/coding-standard":        "^7.0.2",
+        "doctrine/coding-standard":        "^8.0",
         "doctrine/data-fixtures":          "^1.2.1",
         "doctrine/migrations":             "^1.5 || ^2.0",
         "laminas/laminas-code":            "^3.3.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,81 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd09fe81bc18280e1eded502006bd98b",
+    "content-hash": "954cb29c0fd1ed7e9ce4caa739fed39b",
     "packages": [
+        {
+            "name": "composer/package-versions-deprecated",
+            "version": "1.11.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/package-versions-deprecated.git",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/package-versions-deprecated/zipball/c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "reference": "c8c9aa8a14cc3d3bec86d0a8c3fa52ea79936855",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0",
+                "php": "^7 || ^8"
+            },
+            "replace": {
+                "ocramius/package-versions": "1.11.99"
+            },
+            "require-dev": {
+                "composer/composer": "^1.9.3 || ^2.0@dev",
+                "ext-zip": "^1.13",
+                "phpunit/phpunit": "^6.5 || ^7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "support": {
+                "issues": "https://github.com/composer/package-versions-deprecated/issues",
+                "source": "https://github.com/composer/package-versions-deprecated/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-25T05:50:16+00:00"
+        },
         {
             "name": "container-interop/container-interop",
             "version": "1.2.0",
@@ -2693,56 +2766,6 @@
             "time": "2020-05-20T16:45:56+00:00"
         },
         {
-            "name": "ocramius/package-versions",
-            "version": "1.4.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Ocramius/PackageVersions.git",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "reference": "44af6f3a2e2e04f2af46bcb302ad9600cba41c7d",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0.0",
-                "php": "^7.1.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.6.3",
-                "doctrine/coding-standard": "^5.0.1",
-                "ext-zip": "*",
-                "infection/infection": "^0.7.1",
-                "phpunit/phpunit": "^7.5.17"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "PackageVersions\\Installer",
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PackageVersions\\": "src/PackageVersions"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com"
-                }
-            ],
-            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
-            "time": "2019-11-15T16:17:10+00:00"
-        },
-        {
             "name": "psr/cache",
             "version": "1.0.1",
             "source": {
@@ -3583,22 +3606,22 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
+                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -3645,39 +3668,33 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-06-25T14:57:39+00:00"
         },
         {
             "name": "doctrine/coding-standard",
-            "version": "7.0.2",
+            "version": "8.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/coding-standard.git",
-                "reference": "d8a60ec4da68025c42795b714f66e277dd3e11de"
+                "reference": "529d385bb3790431080493c0fe7adaec39df368a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/d8a60ec4da68025c42795b714f66e277dd3e11de",
-                "reference": "d8a60ec4da68025c42795b714f66e277dd3e11de",
+                "url": "https://api.github.com/repos/doctrine/coding-standard/zipball/529d385bb3790431080493c0fe7adaec39df368a",
+                "reference": "529d385bb3790431080493c0fe7adaec39df368a",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-                "php": "^7.2",
-                "slevomat/coding-standard": "^6.0",
-                "squizlabs/php_codesniffer": "^3.5.3"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "slevomat/coding-standard": "^6.3.9",
+                "squizlabs/php_codesniffer": "^3.5.5"
             },
             "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "7.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Sniffs\\": "lib/Doctrine/Sniffs"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
@@ -3706,7 +3723,11 @@
                 "standard",
                 "style"
             ],
-            "time": "2019-12-11T07:59:21+00:00"
+            "support": {
+                "issues": "https://github.com/doctrine/coding-standard/issues",
+                "source": "https://github.com/doctrine/coding-standard/tree/8.2.0"
+            },
+            "time": "2020-10-25T14:56:19+00:00"
         },
         {
             "name": "doctrine/data-fixtures",
@@ -4821,20 +4842,20 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "0.4.4",
+            "version": "0.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "d8d9d4645379e677466d407034436bb155b11c65"
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/d8d9d4645379e677466d407034436bb155b11c65",
-                "reference": "d8d9d4645379e677466d407034436bb155b11c65",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/98a088b17966bdf6ee25c8a4b634df313d8aa531",
+                "reference": "98a088b17966bdf6ee25c8a4b634df313d8aa531",
                 "shasum": ""
             },
             "require": {
-                "php": "~7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "consistence/coding-standard": "^3.5",
@@ -4842,7 +4863,7 @@
                 "jakub-onderka/php-parallel-lint": "^0.9.2",
                 "phing/phing": "^2.16.0",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.19",
+                "phpstan/phpstan": "^0.12.26",
                 "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^6.3",
                 "slevomat/coding-standard": "^4.7.2",
@@ -4866,7 +4887,11 @@
                 "MIT"
             ],
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
-            "time": "2020-04-13T16:28:46+00:00"
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/master"
+            },
+            "time": "2020-08-03T20:32:43+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -5877,32 +5902,32 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "6.3.9",
+            "version": "6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "dd73c0f9c2207026aeda4b0fdff6e9b7ed2a83e5"
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/dd73c0f9c2207026aeda4b0fdff6e9b7ed2a83e5",
-                "reference": "dd73c0f9c2207026aeda4b0fdff6e9b7ed2a83e5",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/696dcca217d0c9da2c40d02731526c1e25b65346",
+                "reference": "696dcca217d0c9da2c40d02731526c1e25b65346",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1",
-                "phpstan/phpdoc-parser": "0.4.0 - 0.4.4",
-                "squizlabs/php_codesniffer": "^3.5.5"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.4.5 - 0.4.9",
+                "squizlabs/php_codesniffer": "^3.5.6"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "0.6.2",
                 "phing/phing": "2.16.3",
                 "php-parallel-lint/php-parallel-lint": "1.2.0",
-                "phpstan/phpstan": "0.12.19",
-                "phpstan/phpstan-deprecation-rules": "0.12.2",
-                "phpstan/phpstan-phpunit": "0.12.8",
-                "phpstan/phpstan-strict-rules": "0.12.2",
-                "phpunit/phpunit": "7.5.20|8.5.2|9.1.2"
+                "phpstan/phpstan": "0.12.48",
+                "phpstan/phpstan-deprecation-rules": "0.12.5",
+                "phpstan/phpstan-phpunit": "0.12.16",
+                "phpstan/phpstan-strict-rules": "0.12.5",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.4.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -5920,6 +5945,10 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/6.4.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/kukulich",
@@ -5930,20 +5959,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-16T07:24:48+00:00"
+            "time": "2020-10-05T12:39:37+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
+                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
                 "shasum": ""
             },
             "require": {
@@ -5981,7 +6010,12 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2020-10-23T02:01:07+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -6237,7 +6271,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "ext-mongo": "1.6.16"
+        "php": "7.2.15"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -236,7 +236,7 @@ return [
 
     'hydrators' => [
         'factories' => [
-            DoctrineObject::class => Service\DoctrineObjectHydratorFactory::class
+            DoctrineObject::class => Service\DoctrineObjectHydratorFactory::class,
         ],
     ],
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,7 +7,12 @@
     <arg name="colors"/>
 
     <!-- inherit rules from: -->
-    <rule ref="PSR2"/>
+    <rule ref="Doctrine">
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+    </rule>
+
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
     <rule ref="Generic.Formatting.SpaceAfterNot"/>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing">
@@ -20,6 +25,14 @@
             <property name="ignoreBlankLines" value="false"/>
         </properties>
     </rule>
+
+    <!-- Disable the rules that will require PHP 7.4 -->
+    <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
+        <properties>
+            <property name="enableNativeTypeHint" value="false"/>
+        </properties>
+    </rule>
+
 
     <!-- Paths to check -->
     <file>config</file>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -11,6 +11,7 @@
         <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
         <exclude name="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+        <exclude name="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
     </rule>
 
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
@@ -33,6 +34,13 @@
         </properties>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements.UnusedProperty">
+        <exclude-pattern>test/*</exclude-pattern>
+    </rule>
+
+    <rule ref="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed">
+        <exclude-pattern>config/module.config.php</exclude-pattern>
+    </rule>
 
     <!-- Paths to check -->
     <file>config</file>

--- a/src/DoctrineORMModule/CliConfigurator.php
+++ b/src/DoctrineORMModule/CliConfigurator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\InputOption;
+
 use function class_exists;
 
 class CliConfigurator
@@ -62,7 +63,7 @@ class CliConfigurator
         $this->container = $container;
     }
 
-    public function configure(Application $cli) : void
+    public function configure(Application $cli): void
     {
         $commands = $this->getAvailableCommands();
         foreach ($commands as $commandName) {
@@ -83,7 +84,7 @@ class CliConfigurator
     /**
      * @return mixed[]
      */
-    private function getHelpers(EntityManagerInterface $objectManager) : array
+    private function getHelpers(EntityManagerInterface $objectManager): array
     {
         $helpers = [];
 
@@ -99,7 +100,7 @@ class CliConfigurator
         return $helpers;
     }
 
-    private function createObjectManagerInputOption() : InputOption
+    private function createObjectManagerInputOption(): InputOption
     {
         return new InputOption(
             'object-manager',
@@ -110,7 +111,7 @@ class CliConfigurator
         );
     }
 
-    private function getObjectManagerName() : string
+    private function getObjectManagerName(): string
     {
         $arguments = new ArgvInput();
 
@@ -124,7 +125,7 @@ class CliConfigurator
     /**
      * @return mixed[]
      */
-    private function getAvailableCommands() : array
+    private function getAvailableCommands(): array
     {
         if (class_exists(VersionCommand::class)) {
             return ArrayUtils::merge($this->commands, $this->migrationCommands);

--- a/src/DoctrineORMModule/Collector/MappingCollector.php
+++ b/src/DoctrineORMModule/Collector/MappingCollector.php
@@ -10,6 +10,7 @@ use Laminas\DeveloperTools\Collector\AutoHideInterface;
 use Laminas\DeveloperTools\Collector\CollectorInterface;
 use Laminas\Mvc\MvcEvent;
 use Serializable;
+
 use function ksort;
 use function serialize;
 use function unserialize;
@@ -109,7 +110,7 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
     /**
      * @return ClassMetadata[]
      */
-    public function getClasses() : array
+    public function getClasses(): array
     {
         return $this->classes;
     }

--- a/src/DoctrineORMModule/Collector/SQLLoggerCollector.php
+++ b/src/DoctrineORMModule/Collector/SQLLoggerCollector.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Logging\DebugStack;
 use Laminas\DeveloperTools\Collector\AutoHideInterface;
 use Laminas\DeveloperTools\Collector\CollectorInterface;
 use Laminas\Mvc\MvcEvent;
+
 use function count;
 
 /**
@@ -63,7 +64,7 @@ class SQLLoggerCollector implements CollectorInterface, AutoHideInterface
         return empty($this->sqlLogger->queries);
     }
 
-    public function getQueryCount() : int
+    public function getQueryCount(): int
     {
         return count($this->sqlLogger->queries);
     }
@@ -71,12 +72,12 @@ class SQLLoggerCollector implements CollectorInterface, AutoHideInterface
     /**
      * @return mixed[]
      */
-    public function getQueries() : array
+    public function getQueries(): array
     {
         return $this->sqlLogger->queries;
     }
 
-    public function getQueryTime() : float
+    public function getQueryTime(): float
     {
         $time = 0.0;
 

--- a/src/DoctrineORMModule/ConfigProvider.php
+++ b/src/DoctrineORMModule/ConfigProvider.php
@@ -12,7 +12,7 @@ class ConfigProvider
     /**
      * @return mixed[]
      */
-    public function __invoke() : array
+    public function __invoke(): array
     {
         $config                 = include __DIR__ . '/../../config/module.config.php';
         $config['dependencies'] = $config['service_manager'];

--- a/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
+++ b/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php
@@ -10,6 +10,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use DoctrineModule\Form\Element;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Form\Annotation\AnnotationBuilder as LaminasAnnotationBuilder;
+
 use function get_class;
 use function in_array;
 use function is_object;
@@ -110,7 +111,7 @@ class AnnotationBuilder extends LaminasAnnotationBuilder
         return $formSpec;
     }
 
-    protected function checkForExcludeElementFromMetadata(ClassMetadata $metadata, string $name) : bool
+    protected function checkForExcludeElementFromMetadata(ClassMetadata $metadata, string $name): bool
     {
         $params = ['metadata' => $metadata, 'name' => $name];
         $result = false;

--- a/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
+++ b/src/DoctrineORMModule/Form/Annotation/ElementAnnotationsListener.php
@@ -12,6 +12,7 @@ use Laminas\EventManager\AbstractListenerAggregate;
 use Laminas\EventManager\EventInterface;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\Form\Element as LaminasFormElement;
+
 use function array_key_exists;
 use function array_merge;
 use function in_array;
@@ -72,7 +73,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleToOne(EventInterface $event) : void
+    public function handleToOne(EventInterface $event): void
     {
         $metadata = $event->getParam('metadata');
         $mapping  = $this->getAssociationMapping($event);
@@ -87,7 +88,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleToMany(EventInterface $event) : void
+    public function handleToMany(EventInterface $event): void
     {
         $metadata = $event->getParam('metadata');
         $mapping  = $this->getAssociationMapping($event);
@@ -109,7 +110,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleExcludeAssociation(EventInterface $event) : bool
+    public function handleExcludeAssociation(EventInterface $event): bool
     {
         $metadata = $event->getParam('metadata');
 
@@ -119,7 +120,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleExcludeField(EventInterface $event) : bool
+    public function handleExcludeField(EventInterface $event): bool
     {
         $metadata    = $event->getParam('metadata');
         $identifiers = $metadata->getIdentifierFieldNames();
@@ -131,7 +132,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleFilterField(EventInterface $event) : void
+    public function handleFilterField(EventInterface $event): void
     {
         $metadata = $event->getParam('metadata');
         if (! $metadata || ! $metadata->hasField($event->getParam('name'))) {
@@ -166,7 +167,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleRequiredAssociation(EventInterface $event) : void
+    public function handleRequiredAssociation(EventInterface $event): void
     {
         $metadata = $event->getParam('metadata');
         $mapping  = $this->getAssociationMapping($event);
@@ -189,7 +190,8 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
                 }
 
                 $required = false;
-                if ((isset($elementSpec['spec']['options']) &&
+                if (
+                    (isset($elementSpec['spec']['options']) &&
                      ! array_key_exists('empty_option', $elementSpec['spec']['options'])) ||
                      ! isset($elementSpec['spec']['options'])
                 ) {
@@ -206,7 +208,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleRequiredField(EventInterface $event) : void
+    public function handleRequiredField(EventInterface $event): void
     {
         $this->prepareEvent($event);
 
@@ -223,7 +225,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleTypeField(EventInterface $event) : void
+    public function handleTypeField(EventInterface $event): void
     {
         $metadata = $event->getParam('metadata');
         $mapping  = $this->getFieldMapping($event);
@@ -279,7 +281,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @internal
      */
-    public function handleValidatorField(EventInterface $event) : void
+    public function handleValidatorField(EventInterface $event): void
     {
         $mapping = $this->getFieldMapping($event);
         if (! $mapping) {
@@ -310,7 +312,8 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
                 break;
             case 'string':
                 $elementSpec = $event->getParam('elementSpec');
-                if (isset($elementSpec['spec']['type']) &&
+                if (
+                    isset($elementSpec['spec']['type']) &&
                     in_array($elementSpec['spec']['type'], ['File', 'Laminas\Form\Element\File'])
                 ) {
                     return;
@@ -330,7 +333,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @return mixed[]|null
      */
-    protected function getFieldMapping(EventInterface $event) : ?array
+    protected function getFieldMapping(EventInterface $event): ?array
     {
         $metadata = $event->getParam('metadata');
         if ($metadata && $metadata->hasField($event->getParam('name'))) {
@@ -343,7 +346,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * @return mixed[]|null
      */
-    protected function getAssociationMapping(EventInterface $event) : ?array
+    protected function getAssociationMapping(EventInterface $event): ?array
     {
         $metadata = $event->getParam('metadata');
         if ($metadata && $metadata->hasAssociation($event->getParam('name'))) {
@@ -353,7 +356,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
         return null;
     }
 
-    protected function mergeAssociationOptions(ArrayObject $elementSpec, string $targetEntity) : void
+    protected function mergeAssociationOptions(ArrayObject $elementSpec, string $targetEntity): void
     {
         $options = $elementSpec['spec']['options'] ?? [];
         $options = array_merge(
@@ -375,7 +378,7 @@ class ElementAnnotationsListener extends AbstractListenerAggregate
     /**
      * Normalizes event setting all expected parameters.
      */
-    protected function prepareEvent(EventInterface $event) : void
+    protected function prepareEvent(EventInterface $event): void
     {
         foreach (['elementSpec', 'inputSpec'] as $type) {
             if ($event->getParam($type)) {

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -10,6 +10,7 @@ use Laminas\ModuleManager\Feature\ConfigProviderInterface;
 use Laminas\ModuleManager\Feature\ControllerProviderInterface;
 use Laminas\ModuleManager\Feature\DependencyIndicatorInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;
+
 use function class_exists;
 
 /**
@@ -32,7 +33,7 @@ class Module implements
             ->attach(
                 'doctrine',
                 'loadCli.post',
-                static function (EventInterface $event) : void {
+                static function (EventInterface $event): void {
                     $event
                         ->getParam('ServiceManager')
                         ->get(CliConfigurator::class)
@@ -50,7 +51,7 @@ class Module implements
             ->getEventManager()
             ->attach(
                 ProfilerEvent::EVENT_PROFILER_INIT,
-                static function ($event) : void {
+                static function ($event): void {
                     $container = $event->getTarget()->getParam('ServiceManager');
                     $container->get('doctrine.sql_logger_collector.orm_default');
                 }

--- a/src/DoctrineORMModule/Options/Configuration.php
+++ b/src/DoctrineORMModule/Options/Configuration.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Repository\RepositoryFactory;
 use Laminas\Stdlib\Exception\InvalidArgumentException;
+
 use function get_class;
 use function gettype;
 use function is_object;
@@ -216,7 +217,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param mixed[] $datetimeFunctions
      */
-    public function setDatetimeFunctions(array $datetimeFunctions) : self
+    public function setDatetimeFunctions(array $datetimeFunctions): self
     {
         $this->datetimeFunctions = $datetimeFunctions;
 
@@ -226,19 +227,19 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getDatetimeFunctions() : array
+    public function getDatetimeFunctions(): array
     {
         return $this->datetimeFunctions;
     }
 
-    public function setDriver(string $driver) : self
+    public function setDriver(string $driver): self
     {
         $this->driver = $driver;
 
         return $this;
     }
 
-    public function getDriver() : string
+    public function getDriver(): string
     {
         return 'doctrine.driver.' . $this->driver;
     }
@@ -246,7 +247,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param mixed[] $entityNamespaces
      */
-    public function setEntityNamespaces(array $entityNamespaces) : self
+    public function setEntityNamespaces(array $entityNamespaces): self
     {
         $this->entityNamespaces = $entityNamespaces;
 
@@ -256,53 +257,53 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getEntityNamespaces() : array
+    public function getEntityNamespaces(): array
     {
         return $this->entityNamespaces;
     }
 
-    public function setGenerateProxies(bool $generateProxies) : self
+    public function setGenerateProxies(bool $generateProxies): self
     {
         $this->generateProxies = $generateProxies;
 
         return $this;
     }
 
-    public function getGenerateProxies() : bool
+    public function getGenerateProxies(): bool
     {
         return $this->generateProxies;
     }
 
-    public function setMetadataCache(string $metadataCache) : self
+    public function setMetadataCache(string $metadataCache): self
     {
         $this->metadataCache = $metadataCache;
 
         return $this;
     }
 
-    public function getMetadataCache() : string
+    public function getMetadataCache(): string
     {
         return 'doctrine.cache.' . $this->metadataCache;
     }
 
-    public function setResultCache(string $resultCache) : void
+    public function setResultCache(string $resultCache): void
     {
         $this->resultCache = $resultCache;
     }
 
-    public function getResultCache() : string
+    public function getResultCache(): string
     {
         return 'doctrine.cache.' . $this->resultCache;
     }
 
-    public function setHydrationCache(string $hydrationCache) : self
+    public function setHydrationCache(string $hydrationCache): self
     {
         $this->hydrationCache = $hydrationCache;
 
         return $this;
     }
 
-    public function getHydrationCache() : string
+    public function getHydrationCache(): string
     {
         return 'doctrine.cache.' . $this->hydrationCache;
     }
@@ -310,7 +311,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param mixed[] $namedNativeQueries
      */
-    public function setNamedNativeQueries(array $namedNativeQueries) : self
+    public function setNamedNativeQueries(array $namedNativeQueries): self
     {
         $this->namedNativeQueries = $namedNativeQueries;
 
@@ -320,7 +321,7 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getNamedNativeQueries() : array
+    public function getNamedNativeQueries(): array
     {
         return $this->namedNativeQueries;
     }
@@ -328,7 +329,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param mixed[] $namedQueries
      */
-    public function setNamedQueries(array $namedQueries) : self
+    public function setNamedQueries(array $namedQueries): self
     {
         $this->namedQueries = $namedQueries;
 
@@ -338,7 +339,7 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getNamedQueries() : array
+    public function getNamedQueries(): array
     {
         return $this->namedQueries;
     }
@@ -346,7 +347,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param  mixed[] $numericFunctions
      */
-    public function setNumericFunctions(array $numericFunctions) : self
+    public function setNumericFunctions(array $numericFunctions): self
     {
         $this->numericFunctions = $numericFunctions;
 
@@ -356,7 +357,7 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getNumericFunctions() : array
+    public function getNumericFunctions(): array
     {
         return $this->numericFunctions;
     }
@@ -364,7 +365,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param mixed[] $filters
      */
-    public function setFilters(array $filters) : self
+    public function setFilters(array $filters): self
     {
         $this->filters = $filters;
 
@@ -374,43 +375,43 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getFilters() : array
+    public function getFilters(): array
     {
         return $this->filters;
     }
 
-    public function setProxyDir(string $proxyDir) : self
+    public function setProxyDir(string $proxyDir): self
     {
         $this->proxyDir = $proxyDir;
 
         return $this;
     }
 
-    public function getProxyDir() : string
+    public function getProxyDir(): string
     {
         return $this->proxyDir;
     }
 
-    public function setProxyNamespace(string $proxyNamespace) : self
+    public function setProxyNamespace(string $proxyNamespace): self
     {
         $this->proxyNamespace = $proxyNamespace;
 
         return $this;
     }
 
-    public function getProxyNamespace() : string
+    public function getProxyNamespace(): string
     {
         return $this->proxyNamespace;
     }
 
-    public function setQueryCache(string $queryCache) : self
+    public function setQueryCache(string $queryCache): self
     {
         $this->queryCache = $queryCache;
 
         return $this;
     }
 
-    public function getQueryCache() : string
+    public function getQueryCache(): string
     {
         return 'doctrine.cache.' . $this->queryCache;
     }
@@ -418,7 +419,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param  mixed[] $stringFunctions
      */
-    public function setStringFunctions(array $stringFunctions) : self
+    public function setStringFunctions(array $stringFunctions): self
     {
         $this->stringFunctions = $stringFunctions;
 
@@ -428,7 +429,7 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getStringFunctions() : array
+    public function getStringFunctions(): array
     {
         return $this->stringFunctions;
     }
@@ -436,7 +437,7 @@ class Configuration extends DBALConfiguration
     /**
      * @param mixed[] $modes
      */
-    public function setCustomHydrationModes(array $modes) : self
+    public function setCustomHydrationModes(array $modes): self
     {
         $this->customHydrationModes = $modes;
 
@@ -446,7 +447,7 @@ class Configuration extends DBALConfiguration
     /**
      * @return mixed[]
      */
-    public function getCustomHydrationModes() : array
+    public function getCustomHydrationModes(): array
     {
         return $this->customHydrationModes;
     }
@@ -456,9 +457,10 @@ class Configuration extends DBALConfiguration
      *
      * @throws InvalidArgumentException   when the provided naming strategy does not fit the expected type.
      */
-    public function setNamingStrategy($namingStrategy) : self
+    public function setNamingStrategy($namingStrategy): self
     {
-        if ($namingStrategy === null
+        if (
+            $namingStrategy === null
             || is_string($namingStrategy)
             || $namingStrategy instanceof NamingStrategy
         ) {
@@ -489,9 +491,10 @@ class Configuration extends DBALConfiguration
      *
      * @throws InvalidArgumentException   when the provided quote strategy does not fit the expected type.
      */
-    public function setQuoteStrategy($quoteStrategy) : self
+    public function setQuoteStrategy($quoteStrategy): self
     {
-        if ($quoteStrategy === null
+        if (
+            $quoteStrategy === null
             || is_string($quoteStrategy)
             || $quoteStrategy instanceof QuoteStrategy
         ) {
@@ -522,9 +525,10 @@ class Configuration extends DBALConfiguration
      *
      * @throws InvalidArgumentException   when the provided repository factory does not fit the expected type.
      */
-    public function setRepositoryFactory($repositoryFactory) : self
+    public function setRepositoryFactory($repositoryFactory): self
     {
-        if ($repositoryFactory === null
+        if (
+            $repositoryFactory === null
             || is_string($repositoryFactory)
             || $repositoryFactory instanceof RepositoryFactory
         ) {
@@ -555,14 +559,14 @@ class Configuration extends DBALConfiguration
      *
      * @see \Doctrine\ORM\Configuration::setClassMetadataFactoryName()
      */
-    public function setClassMetadataFactoryName(string $factoryName) : self
+    public function setClassMetadataFactoryName(string $factoryName): self
     {
         $this->classMetadataFactoryName = (string) $factoryName;
 
         return $this;
     }
 
-    public function getClassMetadataFactoryName() : ?string
+    public function getClassMetadataFactoryName(): ?string
     {
         return $this->classMetadataFactoryName;
     }
@@ -573,9 +577,10 @@ class Configuration extends DBALConfiguration
      * @throws InvalidArgumentException           When the provided entity listener resolver
      *                                            does not fit the expected type.
      */
-    public function setEntityListenerResolver($entityListenerResolver) : self
+    public function setEntityListenerResolver($entityListenerResolver): self
     {
-        if ($entityListenerResolver === null
+        if (
+            $entityListenerResolver === null
             || $entityListenerResolver instanceof EntityListenerResolver
             || is_string($entityListenerResolver)
         ) {
@@ -602,26 +607,26 @@ class Configuration extends DBALConfiguration
     /**
      * @param  mixed[] $secondLevelCache
      */
-    public function setSecondLevelCache(array $secondLevelCache) : self
+    public function setSecondLevelCache(array $secondLevelCache): self
     {
         $this->secondLevelCache = new SecondLevelCacheConfiguration($secondLevelCache);
 
         return $this;
     }
 
-    public function getSecondLevelCache() : SecondLevelCacheConfiguration
+    public function getSecondLevelCache(): SecondLevelCacheConfiguration
     {
         return $this->secondLevelCache ?: new SecondLevelCacheConfiguration();
     }
 
-    public function setFilterSchemaAssetsExpression(string $filterSchemaAssetsExpression) : self
+    public function setFilterSchemaAssetsExpression(string $filterSchemaAssetsExpression): self
     {
         $this->filterSchemaAssetsExpression = $filterSchemaAssetsExpression;
 
         return $this;
     }
 
-    public function getFilterSchemaAssetsExpression() : ?string
+    public function getFilterSchemaAssetsExpression(): ?string
     {
         return $this->filterSchemaAssetsExpression;
     }
@@ -629,7 +634,7 @@ class Configuration extends DBALConfiguration
     /**
      * Sets default repository class.
      */
-    public function setDefaultRepositoryClassName(string $className) : self
+    public function setDefaultRepositoryClassName(string $className): self
     {
         $this->defaultRepositoryClassName = (string) $className;
 
@@ -639,7 +644,7 @@ class Configuration extends DBALConfiguration
     /**
      * Get default repository class name.
      */
-    public function getDefaultRepositoryClassName() : ?string
+    public function getDefaultRepositoryClassName(): ?string
     {
         return $this->defaultRepositoryClassName;
     }

--- a/src/DoctrineORMModule/Options/DBALConfiguration.php
+++ b/src/DoctrineORMModule/Options/DBALConfiguration.php
@@ -35,22 +35,22 @@ class DBALConfiguration extends AbstractOptions
      */
     protected $types = [];
 
-    public function setResultCache(string $resultCache) : void
+    public function setResultCache(string $resultCache): void
     {
         $this->resultCache = $resultCache;
     }
 
-    public function getResultCache() : string
+    public function getResultCache(): string
     {
         return 'doctrine.cache.' . $this->resultCache;
     }
 
-    public function setSqlLogger(string $sqlLogger) : void
+    public function setSqlLogger(string $sqlLogger): void
     {
         $this->sqlLogger = $sqlLogger;
     }
 
-    public function getSqlLogger() : ?string
+    public function getSqlLogger(): ?string
     {
         return $this->sqlLogger;
     }
@@ -58,7 +58,7 @@ class DBALConfiguration extends AbstractOptions
     /**
      * @param mixed[] $types
      */
-    public function setTypes(array $types) : void
+    public function setTypes(array $types): void
     {
         $this->types = $types;
     }

--- a/src/DoctrineORMModule/Options/DBALConnection.php
+++ b/src/DoctrineORMModule/Options/DBALConnection.php
@@ -71,22 +71,22 @@ class DBALConnection extends AbstractOptions
     /** @var bool */
     protected $useSavepoints = false;
 
-    public function setConfiguration(string $configuration) : void
+    public function setConfiguration(string $configuration): void
     {
         $this->configuration = $configuration;
     }
 
-    public function getConfiguration() : string
+    public function getConfiguration(): string
     {
         return 'doctrine.configuration.' . $this->configuration;
     }
 
-    public function setEventmanager(string $eventmanager) : void
+    public function setEventmanager(string $eventmanager): void
     {
         $this->eventmanager = $eventmanager;
     }
 
-    public function getEventmanager() : string
+    public function getEventmanager(): string
     {
         return 'doctrine.eventmanager.' . $this->eventmanager;
     }
@@ -94,7 +94,7 @@ class DBALConnection extends AbstractOptions
     /**
      * @param mixed[] $params
      */
-    public function setParams(array $params) : void
+    public function setParams(array $params): void
     {
         $this->params = $params;
     }
@@ -102,7 +102,7 @@ class DBALConnection extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getParams() : array
+    public function getParams(): array
     {
         return $this->params;
     }
@@ -110,7 +110,7 @@ class DBALConnection extends AbstractOptions
     /**
      * @param mixed[] $doctrineTypeMappings
      */
-    public function setDoctrineTypeMappings(array $doctrineTypeMappings) : DBALConnection
+    public function setDoctrineTypeMappings(array $doctrineTypeMappings): DBALConnection
     {
         $this->doctrineTypeMappings = (array) $doctrineTypeMappings;
 
@@ -120,7 +120,7 @@ class DBALConnection extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getDoctrineTypeMappings() : array
+    public function getDoctrineTypeMappings(): array
     {
         return $this->doctrineTypeMappings;
     }
@@ -128,7 +128,7 @@ class DBALConnection extends AbstractOptions
     /**
      * @param mixed[] $doctrineCommentedTypes
      */
-    public function setDoctrineCommentedTypes(array $doctrineCommentedTypes) : void
+    public function setDoctrineCommentedTypes(array $doctrineCommentedTypes): void
     {
         $this->doctrineCommentedTypes = $doctrineCommentedTypes;
     }
@@ -136,17 +136,17 @@ class DBALConnection extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getDoctrineCommentedTypes() : array
+    public function getDoctrineCommentedTypes(): array
     {
         return $this->doctrineCommentedTypes;
     }
 
-    public function setDriverClass(?string $driverClass) : void
+    public function setDriverClass(?string $driverClass): void
     {
         $this->driverClass = $driverClass;
     }
 
-    public function getDriverClass() : ?string
+    public function getDriverClass(): ?string
     {
         return $this->driverClass;
     }
@@ -154,7 +154,7 @@ class DBALConnection extends AbstractOptions
     /**
      * @param PDO|string|null $pdo
      */
-    public function setPdo($pdo) : void
+    public function setPdo($pdo): void
     {
         $this->pdo = $pdo;
     }
@@ -167,22 +167,22 @@ class DBALConnection extends AbstractOptions
         return $this->pdo;
     }
 
-    public function setWrapperClass(string $wrapperClass) : void
+    public function setWrapperClass(string $wrapperClass): void
     {
         $this->wrapperClass = $wrapperClass;
     }
 
-    public function getWrapperClass() : ?string
+    public function getWrapperClass(): ?string
     {
         return $this->wrapperClass;
     }
 
-    public function useSavepoints() : bool
+    public function useSavepoints(): bool
     {
         return $this->useSavepoints;
     }
 
-    public function setUseSavepoints(bool $useSavepoints) : void
+    public function setUseSavepoints(bool $useSavepoints): void
     {
         $this->useSavepoints = $useSavepoints;
     }

--- a/src/DoctrineORMModule/Options/EntityManager.php
+++ b/src/DoctrineORMModule/Options/EntityManager.php
@@ -36,19 +36,19 @@ class EntityManager extends AbstractOptions
      */
     protected $entityResolver = 'orm_default';
 
-    public function setConfiguration(string $configuration) : self
+    public function setConfiguration(string $configuration): self
     {
         $this->configuration = $configuration;
 
         return $this;
     }
 
-    public function getConfiguration() : string
+    public function getConfiguration(): string
     {
         return 'doctrine.configuration.' . $this->configuration;
     }
 
-    public function setConnection(string $connection) : self
+    public function setConnection(string $connection): self
     {
         $this->connection = $connection;
 
@@ -58,12 +58,12 @@ class EntityManager extends AbstractOptions
     /**
      * @return self
      */
-    public function getConnection() : string
+    public function getConnection(): string
     {
         return 'doctrine.connection.' . $this->connection;
     }
 
-    public function setEntityResolver(string $entityResolver) : self
+    public function setEntityResolver(string $entityResolver): self
     {
         $this->entityResolver = (string) $entityResolver;
 
@@ -73,7 +73,7 @@ class EntityManager extends AbstractOptions
     /**
      * @return self
      */
-    public function getEntityResolver() : string
+    public function getEntityResolver(): string
     {
         return 'doctrine.entity_resolver.' . $this->entityResolver;
     }

--- a/src/DoctrineORMModule/Options/EntityResolver.php
+++ b/src/DoctrineORMModule/Options/EntityResolver.php
@@ -6,6 +6,7 @@ namespace DoctrineORMModule\Options;
 
 use InvalidArgumentException;
 use Laminas\Stdlib\AbstractOptions;
+
 use function class_exists;
 use function sprintf;
 
@@ -28,14 +29,14 @@ class EntityResolver extends AbstractOptions
      */
     protected $resolvers = [];
 
-    public function setEventManager(string $eventManager) : self
+    public function setEventManager(string $eventManager): self
     {
         $this->eventManager = $eventManager;
 
         return $this;
     }
 
-    public function getEventManager() : string
+    public function getEventManager(): string
     {
         return 'doctrine.eventmanager.' . $this->eventManager;
     }
@@ -45,7 +46,7 @@ class EntityResolver extends AbstractOptions
      *
      * @throws InvalidArgumentException
      */
-    public function setResolvers(array $resolvers) : void
+    public function setResolvers(array $resolvers): void
     {
         foreach ($resolvers as $old => $new) {
             if (! class_exists($new)) {
@@ -65,7 +66,7 @@ class EntityResolver extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getResolvers() : array
+    public function getResolvers(): array
     {
         return $this->resolvers;
     }

--- a/src/DoctrineORMModule/Options/SQLLoggerCollectorOptions.php
+++ b/src/DoctrineORMModule/Options/SQLLoggerCollectorOptions.php
@@ -20,7 +20,7 @@ class SQLLoggerCollectorOptions extends AbstractOptions
     /** @var string|null service name of the SQLLogger to be used */
     protected $sqlLogger;
 
-    public function setName(?string $name) : void
+    public function setName(?string $name): void
     {
         $this->name = (string) $name;
     }
@@ -28,12 +28,12 @@ class SQLLoggerCollectorOptions extends AbstractOptions
     /**
      * Name of the collector
      */
-    public function getName() : string
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function setConfiguration(?string $configuration) : void
+    public function setConfiguration(?string $configuration): void
     {
         $this->configuration = $configuration ? (string) $configuration : null;
     }
@@ -41,12 +41,12 @@ class SQLLoggerCollectorOptions extends AbstractOptions
     /**
      * Configuration service name (where to set the logger)
      */
-    public function getConfiguration() : string
+    public function getConfiguration(): string
     {
         return $this->configuration ? $this->configuration : 'doctrine.configuration.orm_default';
     }
 
-    public function setSqlLogger(?string $sqlLogger) : void
+    public function setSqlLogger(?string $sqlLogger): void
     {
         $this->sqlLogger = $sqlLogger ? (string) $sqlLogger : null;
     }
@@ -54,7 +54,7 @@ class SQLLoggerCollectorOptions extends AbstractOptions
     /**
      * SQLLogger service name
      */
-    public function getSqlLogger() : ?string
+    public function getSqlLogger(): ?string
     {
         return $this->sqlLogger;
     }

--- a/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
+++ b/src/DoctrineORMModule/Options/SecondLevelCacheConfiguration.php
@@ -50,42 +50,42 @@ class SecondLevelCacheConfiguration extends AbstractOptions
      */
     protected $regions = [];
 
-    public function setEnabled(bool $enabled) : void
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = (bool) $enabled;
     }
 
-    public function isEnabled() : bool
+    public function isEnabled(): bool
     {
         return $this->enabled;
     }
 
-    public function setDefaultLifetime(int $defaultLifetime) : void
+    public function setDefaultLifetime(int $defaultLifetime): void
     {
         $this->defaultLifetime = (int) $defaultLifetime;
     }
 
-    public function getDefaultLifetime() : int
+    public function getDefaultLifetime(): int
     {
         return $this->defaultLifetime;
     }
 
-    public function setDefaultLockLifetime(int $defaultLockLifetime) : void
+    public function setDefaultLockLifetime(int $defaultLockLifetime): void
     {
         $this->defaultLockLifetime = (int) $defaultLockLifetime;
     }
 
-    public function getDefaultLockLifetime() : int
+    public function getDefaultLockLifetime(): int
     {
         return $this->defaultLockLifetime;
     }
 
-    public function setFileLockRegionDirectory(string $fileLockRegionDirectory) : void
+    public function setFileLockRegionDirectory(string $fileLockRegionDirectory): void
     {
         $this->fileLockRegionDirectory = (string) $fileLockRegionDirectory;
     }
 
-    public function getFileLockRegionDirectory() : string
+    public function getFileLockRegionDirectory(): string
     {
         return $this->fileLockRegionDirectory;
     }
@@ -93,7 +93,7 @@ class SecondLevelCacheConfiguration extends AbstractOptions
     /**
      * @param mixed[] $regions
      */
-    public function setRegions(array $regions) : void
+    public function setRegions(array $regions): void
     {
         $this->regions = $regions;
     }
@@ -101,7 +101,7 @@ class SecondLevelCacheConfiguration extends AbstractOptions
     /**
      * @return mixed[]
      */
-    public function getRegions() : array
+    public function getRegions(): array
     {
         return $this->regions;
     }

--- a/src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php
@@ -23,12 +23,12 @@ class DoctrinePaginator implements AdapterInterface
         $this->paginator = $paginator;
     }
 
-    public function setPaginator(Paginator $paginator) : self
+    public function setPaginator(Paginator $paginator): self
     {
         $this->paginator = $paginator;
     }
 
-    public function getPaginator() : Paginator
+    public function getPaginator(): Paginator
     {
         return $this->paginator;
     }

--- a/src/DoctrineORMModule/Service/ConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/ConfigurationFactory.php
@@ -14,6 +14,7 @@ use DoctrineORMModule\Service\DBALConfigurationFactory as DoctrineConfigurationF
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function is_string;
 use function sprintf;
 
@@ -168,7 +169,7 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
         return $this($container, Configuration::class);
     }
 
-    protected function getOptionsClass() : string
+    protected function getOptionsClass(): string
     {
         return DoctrineORMModuleConfiguration::class;
     }

--- a/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConfigurationFactory.php
@@ -11,6 +11,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
+
 use function is_string;
 use function sprintf;
 
@@ -50,7 +51,7 @@ class DBALConfigurationFactory implements FactoryInterface
         return $this($container, Configuration::class);
     }
 
-    public function setupDBALConfiguration(ContainerInterface $container, Configuration $config) : void
+    public function setupDBALConfiguration(ContainerInterface $container, Configuration $config): void
     {
         $options = $this->getOptions($container);
         $config->setResultCacheImpl($container->get($options->resultCache));
@@ -96,7 +97,7 @@ class DBALConfigurationFactory implements FactoryInterface
         return new $optionsClass($options);
     }
 
-    protected function getOptionsClass() : string
+    protected function getOptionsClass(): string
     {
         return DoctrineORMModuleConfiguration::class;
     }

--- a/src/DoctrineORMModule/Service/DBALConnectionFactory.php
+++ b/src/DoctrineORMModule/Service/DBALConnectionFactory.php
@@ -11,6 +11,7 @@ use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\DBALConnection;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function array_key_exists;
 use function array_merge;
 use function is_string;
@@ -41,7 +42,8 @@ class DBALConnectionFactory extends AbstractFactory
         ];
         $params = array_merge($params, $options->getParams());
 
-        if (array_key_exists('platform', $params)
+        if (
+            array_key_exists('platform', $params)
             && is_string($params['platform'])
             && $container->has($params['platform'])
         ) {
@@ -80,7 +82,7 @@ class DBALConnectionFactory extends AbstractFactory
     /**
      * Get the class name of the options associated with this factory.
      */
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return DBALConnection::class;
     }

--- a/src/DoctrineORMModule/Service/EntityManagerFactory.php
+++ b/src/DoctrineORMModule/Service/EntityManagerFactory.php
@@ -40,7 +40,7 @@ class EntityManagerFactory extends AbstractFactory
         return $this($container, EntityManager::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return DoctrineORMModuleEntityManager::class;
     }

--- a/src/DoctrineORMModule/Service/EntityResolverFactory.php
+++ b/src/DoctrineORMModule/Service/EntityResolverFactory.php
@@ -51,7 +51,7 @@ class EntityResolverFactory extends AbstractFactory
     /**
      * Get the class name of the options associated with this factory.
      */
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
         return EntityResolver::class;
     }

--- a/src/DoctrineORMModule/Service/FormAnnotationBuilderFactory.php
+++ b/src/DoctrineORMModule/Service/FormAnnotationBuilderFactory.php
@@ -40,14 +40,14 @@ class FormAnnotationBuilderFactory extends AbstractFactory
         return $this($container, AnnotationBuilder::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
     }
 
     /**
      * Retrieve the form factory
      */
-    private function getFormFactory(ContainerInterface $services) : Factory
+    private function getFormFactory(ContainerInterface $services): Factory
     {
         $elements = null;
 

--- a/src/DoctrineORMModule/Service/MappingCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/MappingCollectorFactory.php
@@ -37,7 +37,7 @@ class MappingCollectorFactory extends AbstractFactory
         return $this($container, MappingCollector::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
     }
 }

--- a/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
@@ -9,6 +9,7 @@ use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function class_exists;
 use function strtolower;
 use function ucfirst;
@@ -52,7 +53,7 @@ class MigrationsCommandFactory implements FactoryInterface
     /**
      * @throws InvalidArgumentException
      */
-    public function createService(ServiceLocatorInterface $container) : AbstractCommand
+    public function createService(ServiceLocatorInterface $container): AbstractCommand
     {
         return $this($container, 'Doctrine\Migrations\Tools\Console\Command\\' . $this->name . 'Command');
     }

--- a/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsConfigurationFactory.php
@@ -10,6 +10,7 @@ use DoctrineModule\Service\AbstractFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
+
 use function method_exists;
 
 /**
@@ -32,7 +33,7 @@ class MigrationsConfigurationFactory extends AbstractFactory
         $configuration = new Configuration($connection);
 
         $output         = new ConsoleOutput();
-        $writerCallback = static function ($message) use ($output) : void {
+        $writerCallback = static function ($message) use ($output): void {
             $output->writeln($message);
         };
 
@@ -71,7 +72,7 @@ class MigrationsConfigurationFactory extends AbstractFactory
         return $this($container, Configuration::class);
     }
 
-    public function getOptionsClass() : string
+    public function getOptionsClass(): string
     {
     }
 }

--- a/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
+++ b/src/DoctrineORMModule/Service/SQLLoggerCollectorFactory.php
@@ -12,6 +12,7 @@ use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use RuntimeException;
+
 use function sprintf;
 
 /**

--- a/src/DoctrineORMModule/Yuml/MetadataGrapher.php
+++ b/src/DoctrineORMModule/Yuml/MetadataGrapher.php
@@ -6,6 +6,7 @@ namespace DoctrineORMModule\Yuml;
 
 use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use Exception;
+
 use function class_exists;
 use function get_parent_class;
 use function implode;
@@ -40,7 +41,7 @@ class MetadataGrapher
      *
      * @param ClassMetadata[] $metadata
      */
-    public function generateFromMetadata(array $metadata) : string
+    public function generateFromMetadata(array $metadata): string
     {
         $this->metadata            = $metadata;
         $this->visitedAssociations = [];
@@ -77,7 +78,7 @@ class MetadataGrapher
         return implode(',', $str);
     }
 
-    private function getAssociationString(ClassMetadata $class1, string $association) : string
+    private function getAssociationString(ClassMetadata $class1, string $association): string
     {
         $targetClassName = $class1->getAssociationTargetClass($association);
         $class2          = $this->getClassByName($targetClassName);
@@ -120,7 +121,7 @@ class MetadataGrapher
             . $this->getClassString($class2);
     }
 
-    private function getClassReverseAssociationName(ClassMetadata $class1, ClassMetadata $class2) : ?string
+    private function getClassReverseAssociationName(ClassMetadata $class1, ClassMetadata $class2): ?string
     {
         foreach ($class2->getAssociationNames() as $class2Side) {
             $targetClass = $this->getClassByName($class2->getAssociationTargetClass($class2Side));
@@ -139,7 +140,7 @@ class MetadataGrapher
     /**
      * Build the string representing the single graph item
      */
-    private function getClassString(ClassMetadata $class) : string
+    private function getClassString(ClassMetadata $class): string
     {
         $this->visitAssociation($class->getName());
 
@@ -173,7 +174,7 @@ class MetadataGrapher
     /**
      * Retrieve a class metadata instance by name from the given array
      */
-    private function getClassByName(string $className) : ?ClassMetadata
+    private function getClassByName(string $className): ?ClassMetadata
     {
         if (! isset($this->classByNames[$className])) {
             foreach ($this->metadata as $class) {
@@ -190,7 +191,7 @@ class MetadataGrapher
     /**
      * Retrieve a class metadata's parent class metadata
      */
-    private function getParent(ClassMetadata $class) : ?ClassMetadata
+    private function getParent(ClassMetadata $class): ?ClassMetadata
     {
         $className = $class->getName();
         $parent    = get_parent_class($className);
@@ -207,7 +208,7 @@ class MetadataGrapher
      *
      * @return bool true if the association was visited before
      */
-    private function visitAssociation(string $className, ?string $association = null) : bool
+    private function visitAssociation(string $className, ?string $association = null): bool
     {
         if ($association === null) {
             if (isset($this->visitedAssociations[$className])) {

--- a/src/DoctrineORMModule/Yuml/YumlController.php
+++ b/src/DoctrineORMModule/Yuml/YumlController.php
@@ -28,7 +28,7 @@ class YumlController extends AbstractActionController
      *
      * @throws UnexpectedValueException if the YUML service answered incorrectly.
      */
-    public function indexAction() : Response
+    public function indexAction(): Response
     {
         $request = $this->getRequest();
         $this->httpClient->setMethod(Request::METHOD_POST);

--- a/src/DoctrineORMModule/Yuml/YumlControllerFactory.php
+++ b/src/DoctrineORMModule/Yuml/YumlControllerFactory.php
@@ -10,6 +10,7 @@ use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+
 use function sprintf;
 
 class YumlControllerFactory implements FactoryInterface
@@ -17,7 +18,7 @@ class YumlControllerFactory implements FactoryInterface
     /**
      * Create service
      */
-    public function createService(ServiceLocatorInterface $serviceLocator) : YumlController
+    public function createService(ServiceLocatorInterface $serviceLocator): YumlController
     {
         if ($serviceLocator instanceof AbstractPluginManager) {
             $serviceLocator = $serviceLocator->getServiceLocator() ?: $serviceLocator;
@@ -35,10 +36,11 @@ class YumlControllerFactory implements FactoryInterface
         ContainerInterface $container,
         $requestedName,
         ?array $options = null
-    ) : YumlController {
+    ): YumlController {
         $config = $container->get('config');
 
-        if (! isset($config['laminas-developer-tools']['toolbar']['enabled'])
+        if (
+            ! isset($config['laminas-developer-tools']['toolbar']['enabled'])
             || ! $config['laminas-developer-tools']['toolbar']['enabled']
         ) {
             throw new ServiceNotFoundException(

--- a/test/DoctrineORMModuleTest/Assets/Entity/Category.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Category.php
@@ -14,10 +14,16 @@ class Category
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
     protected $name;
 
     public function getId(): ?int
@@ -25,14 +31,14 @@ class Category
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Category.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Category.php
@@ -17,15 +17,10 @@ class Category
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $name;
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/City.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/City.php
@@ -17,20 +17,13 @@ class City
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $name;
 
-    /**
-     * @ORM\OneToOne(targetEntity="Country")
-     */
+    /** @ORM\OneToOne(targetEntity="Country") */
     protected $country;
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/City.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/City.php
@@ -14,13 +14,23 @@ class City
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
     protected $name;
 
-    /** @ORM\OneToOne(targetEntity="Country") */
+    /**
+     * @ORM\OneToOne(targetEntity="Country")
+     *
+     * @var Country
+     */
     protected $country;
 
     public function getId(): ?int
@@ -28,26 +38,26 @@ class City
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function setCountry(Country $country)
+    public function setCountry(Country $country): self
     {
         $this->country = $country;
 
         return $this;
     }
 
-    public function getCountry()
+    public function getCountry(): Country
     {
         return $this->country;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Country.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Country.php
@@ -14,10 +14,16 @@ class Country
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
     protected $name;
 
     public function getId(): ?int
@@ -25,14 +31,14 @@ class Country
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Country.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Country.php
@@ -17,15 +17,10 @@ class Country
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $name;
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Date.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Date.php
@@ -2,6 +2,7 @@
 
 namespace DoctrineORMModuleTest\Assets\Entity;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -17,31 +18,20 @@ class Date
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="date", nullable=true)
-     */
+    /** @ORM\Column(type="date", nullable=true) */
     protected $date;
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param \DateTime $date
-     */
-    public function setDate($date)
+    public function setDate(DateTime $date): void
     {
         $this->date = $date;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getDate()
+    public function getDate(): DateTime
     {
         return $this->date;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Date.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Date.php
@@ -15,10 +15,16 @@ class Date
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="date", nullable=true) */
+    /**
+     * @ORM\Column(type="date", nullable=true)
+     *
+     * @var DateTime
+     */
     protected $date;
 
     public function getId(): ?int

--- a/test/DoctrineORMModuleTest/Assets/Entity/EntityWithoutRepository.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/EntityWithoutRepository.php
@@ -13,6 +13,8 @@ class EntityWithoutRepository
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     private $id;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
@@ -8,8 +8,6 @@ use Laminas\Form\Annotation as Form;
 /**
  * @ORM\Entity
  * @ORM\Table(name="doctrine_orm_module_form_entity")
- *
- * @author Kyle Spraggs <theman@spiffyjr.me>
  */
 class FormEntity
 {
@@ -19,74 +17,46 @@ class FormEntity
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="bool")
-     */
+    /** @ORM\Column(type="bool") */
     protected $bool;
 
-    /**
-     * @ORM\Column(type="boolean")
-     */
+    /** @ORM\Column(type="boolean") */
     protected $boolean;
 
-    /**
-     * @ORM\Column(type="float")
-     */
+    /** @ORM\Column(type="float") */
     protected $float;
 
-    /**
-     * @ORM\Column(type="bigint")
-     */
+    /** @ORM\Column(type="bigint") */
     protected $bigint;
 
-    /**
-     * @ORM\Column(type="integer")
-     */
+    /** @ORM\Column(type="integer") */
     protected $integer;
 
-    /**
-     * @ORM\Column(type="smallint")
-     */
+    /** @ORM\Column(type="smallint") */
     protected $smallint;
 
-    /**
-     * @ORM\Column(type="datetime")
-     */
+    /** @ORM\Column(type="datetime") */
     protected $datetime;
 
-    /**
-     * @ORM\Column(type="datetimetz")
-     */
+    /** @ORM\Column(type="datetimetz") */
     protected $datetimetz;
 
-    /**
-     * @ORM\Column(type="date")
-     */
+    /** @ORM\Column(type="date") */
     protected $date;
 
-    /**
-     * @ORM\Column(type="time")
-     */
+    /** @ORM\Column(type="time") */
     protected $time;
 
-    /**
-     * @ORM\Column(type="text")
-     */
+    /** @ORM\Column(type="text") */
     protected $text;
 
-    /**
-     * @ORM\Column(type="string", nullable=false, length=20)
-     */
+    /** @ORM\Column(type="string", nullable=false, length=20) */
     protected $string;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $stringNullable;
 
-    /**
-     * @ORM\OneToOne(targetEntity="TargetInterface")
-     */
+    /** @ORM\OneToOne(targetEntity="TargetInterface") */
     protected $targetOne;
 
     /**
@@ -96,20 +66,20 @@ class FormEntity
     protected $targetOneNullable;
 
    /**
-    * @Form\Type("DoctrineModule\Form\Element\ObjectSelect")
     * @ORM\OneToOne(targetEntity="TargetInterface")
     * @ORM\JoinColumn(nullable=true)
+    *
+    * @Form\Type("DoctrineModule\Form\Element\ObjectSelect")
     * @Form\Options({"empty_option":null})
     */
     protected $noDisplayEmptyOption;
 
-    /**
-     * @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntity")
-     */
+    /** @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntity") */
     protected $targetMany;
 
     /**
      * @ORM\Column(type="integer")
+     *
      * @Form\Options({"label":"Please Choose", "value_options":{"f":"false","t":"true"}})
      * @Form\Type("Radio")
      */
@@ -117,12 +87,14 @@ class FormEntity
 
     /**
      * @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntityMulti")
+     *
      * @Form\Type("DoctrineORMModule\Form\Element\EntityMultiCheckbox")
      */
     protected $specificMultiType;
 
     /**
      * @ORM\Column(type="integer")
+     *
      * @Form\Options({"label":"Please Choose", "value_options":{"f":"false","t":"true"}})
      * @Form\Attributes({"type":"textarea"})
      */
@@ -130,8 +102,9 @@ class FormEntity
 
     /**
      * @ORM\Column(type="string", length=256)
-     * @Form\Type("File")
      * @ORM\JoinColumn(nullable=true)
+     *
+     * @Form\Type("File")
      * @Form\Options({"label":"Image"})
      */
     protected $image;

--- a/test/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
@@ -14,54 +14,114 @@ class FormEntity
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="bool") */
+    /**
+     * @ORM\Column(type="bool")
+     *
+     * @var bool
+     */
     protected $bool;
 
-    /** @ORM\Column(type="boolean") */
+    /**
+     * @ORM\Column(type="boolean")
+     *
+     * @var bool
+     */
     protected $boolean;
 
-    /** @ORM\Column(type="float") */
+    /**
+     * @ORM\Column(type="float")
+     *
+     * @var float
+     */
     protected $float;
 
-    /** @ORM\Column(type="bigint") */
+    /**
+     * @ORM\Column(type="bigint")
+     *
+     * @var int
+     */
     protected $bigint;
 
-    /** @ORM\Column(type="integer") */
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @var int
+     */
     protected $integer;
 
-    /** @ORM\Column(type="smallint") */
+    /**
+     * @ORM\Column(type="smallint")
+     *
+     * @var int
+     */
     protected $smallint;
 
-    /** @ORM\Column(type="datetime") */
+    /**
+     * @ORM\Column(type="datetime")
+     *
+     * @var DateTime
+     */
     protected $datetime;
 
-    /** @ORM\Column(type="datetimetz") */
+    /**
+     * @ORM\Column(type="datetimetz")
+     *
+     * @var DateTime
+     */
     protected $datetimetz;
 
-    /** @ORM\Column(type="date") */
+    /**
+     * @ORM\Column(type="date")
+     *
+     * @var DateTime
+     */
     protected $date;
 
-    /** @ORM\Column(type="time") */
+    /**
+     * @ORM\Column(type="time")
+     *
+     * @var DateTime
+     */
     protected $time;
 
-    /** @ORM\Column(type="text") */
+    /**
+     * @ORM\Column(type="text")
+     *
+     * @var string
+     */
     protected $text;
 
-    /** @ORM\Column(type="string", nullable=false, length=20) */
+    /**
+     * @ORM\Column(type="string", nullable=false, length=20)
+     *
+     * @var string
+     */
     protected $string;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
+     */
     protected $stringNullable;
 
-    /** @ORM\OneToOne(targetEntity="TargetInterface") */
+    /**
+     * @ORM\OneToOne(targetEntity="TargetInterface")
+     *
+     * @var TargetInterface
+     */
     protected $targetOne;
 
     /**
      * @ORM\OneToOne(targetEntity="TargetInterface")
      * @ORM\JoinColumn(nullable=true)
+     *
+     * @var TargetInterface|null
      */
     protected $targetOneNullable;
 
@@ -71,10 +131,16 @@ class FormEntity
     *
     * @Form\Type("DoctrineModule\Form\Element\ObjectSelect")
     * @Form\Options({"empty_option":null})
+    *
+    * @var TargetInterface|null
     */
     protected $noDisplayEmptyOption;
 
-    /** @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntity") */
+    /**
+     * @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntity")
+     *
+     * @var TargetInterface[]
+     */
     protected $targetMany;
 
     /**
@@ -82,6 +148,8 @@ class FormEntity
      *
      * @Form\Options({"label":"Please Choose", "value_options":{"f":"false","t":"true"}})
      * @Form\Type("Radio")
+     *
+     * @var int
      */
     protected $specificType;
 
@@ -89,6 +157,8 @@ class FormEntity
      * @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntityMulti")
      *
      * @Form\Type("DoctrineORMModule\Form\Element\EntityMultiCheckbox")
+     *
+     * @var FormEntityTarget[]
      */
     protected $specificMultiType;
 
@@ -97,6 +167,8 @@ class FormEntity
      *
      * @Form\Options({"label":"Please Choose", "value_options":{"f":"false","t":"true"}})
      * @Form\Attributes({"type":"textarea"})
+     *
+     * @var int
      */
     protected $specificAttributeType;
 
@@ -106,6 +178,8 @@ class FormEntity
      *
      * @Form\Type("File")
      * @Form\Options({"label":"Image"})
+     *
+     * @var string
      */
     protected $image;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/FormEntityTarget.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/FormEntityTarget.php
@@ -13,6 +13,8 @@ class FormEntityTarget
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/FormEntityTarget.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/FormEntityTarget.php
@@ -6,8 +6,6 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- *
- * @author Kyle Spraggs <theman@spiffyjr.me>
  */
 class FormEntityTarget
 {

--- a/test/DoctrineORMModuleTest/Assets/Entity/Issue237.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Issue237.php
@@ -3,13 +3,10 @@
 namespace DoctrineORMModuleTest\Assets\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Laminas\Form\Annotation as Form;
 
 /**
  * @ORM\Entity
  * @ORM\Table(name="doctrine_orm_module_form_entity")
- *
- * @author Kyle Spraggs <theman@spiffyjr.me>
  */
 class Issue237
 {

--- a/test/DoctrineORMModuleTest/Assets/Entity/Issue237.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Issue237.php
@@ -14,6 +14,8 @@ class Issue237
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="IDENTITY")
+     *
+     * @var int
      */
     protected $id;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Product.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Product.php
@@ -17,20 +17,13 @@ class Product
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $name;
 
-    /**
-     * @ORM\ManyToMany(targetEntity="Category")
-     */
+    /** @ORM\ManyToMany(targetEntity="Category") */
     protected $categories;
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Product.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Product.php
@@ -14,13 +14,23 @@ class Product
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
     protected $name;
 
-    /** @ORM\ManyToMany(targetEntity="Category") */
+    /**
+     * @ORM\ManyToMany(targetEntity="Category")
+     *
+     * @var Category[]
+     */
     protected $categories;
 
     public function getId(): ?int
@@ -28,26 +38,32 @@ class Product
         return $this->id;
     }
 
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function setCategories($categories)
+    /**
+     * @param Category[] $categories
+     */
+    public function setCategories(array $categories): self
     {
         $this->categories = $categories;
 
         return $this;
     }
 
-    public function getCategories()
+    /**
+     * @return Category[]
+     */
+    public function getCategories(): array
     {
         return $this->categories;
     }

--- a/test/DoctrineORMModuleTest/Assets/Entity/ResolveTarget.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/ResolveTarget.php
@@ -16,8 +16,6 @@ class ResolveTarget
      */
     protected $id;
 
-    /**
-     * @ORM\OneToOne(targetEntity="TargetInterface")
-     */
+    /** @ORM\OneToOne(targetEntity="TargetInterface") */
     protected $target;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/ResolveTarget.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/ResolveTarget.php
@@ -13,9 +13,15 @@ class ResolveTarget
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\OneToOne(targetEntity="TargetInterface") */
+    /**
+     * @ORM\OneToOne(targetEntity="TargetInterface")
+     *
+     * @var TargetInterface
+     */
     protected $target;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/TargetEntity.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/TargetEntity.php
@@ -13,6 +13,8 @@ class TargetEntity implements TargetInterface
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     private $id;
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/Test.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Test.php
@@ -14,13 +14,23 @@ class Test
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int
      */
     protected $id;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
     protected $username;
 
-    /** @ORM\Column(type="string", nullable=true) */
+    /**
+     * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string
+     */
     protected $password;
 
     public function getId(): ?int

--- a/test/DoctrineORMModuleTest/Assets/Entity/Test.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Test.php
@@ -17,62 +17,41 @@ class Test
      */
     protected $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $username;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     */
+    /** @ORM\Column(type="string", nullable=true) */
     protected $password;
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @param string $password
-     */
-    public function setPassword($password)
+    public function setPassword(string $password): void
     {
         $this->password = (string) $password;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getPassword()
+    public function getPassword(): ?string
     {
         return $this->password;
     }
 
-    /**
-     * @param string $username
-     */
-    public function setUsername($username)
+    public function setUsername(string $username): void
     {
         $this->username = (string) $username;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getUsername()
+    public function getUsername(): ?string
     {
         return $this->username;
     }
 
     /**
      * Used for testing DoctrineEntity form element
-     *
-     * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->username;
     }

--- a/test/DoctrineORMModuleTest/Assets/Fixture/TestFixture.php
+++ b/test/DoctrineORMModuleTest/Assets/Fixture/TestFixture.php
@@ -18,10 +18,7 @@ class TestFixture extends AbstractFixture
      */
     public const INSTANCES_COUNT = 100;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function load(ObjectManager $manager)
+    public function load(ObjectManager $manager): void
     {
         for ($i = 0; $i < self::INSTANCES_COUNT; $i += 1) {
             $instance = new TestEntity();

--- a/test/DoctrineORMModuleTest/Assets/Fixture/TestFixture.php
+++ b/test/DoctrineORMModuleTest/Assets/Fixture/TestFixture.php
@@ -4,10 +4,9 @@ namespace DoctrineORMModuleTest\Assets\Fixture;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\Persistence\ObjectManager;
-
-use DoctrineORMModuleTest\Assets\Entity\Test as TestEntity;
 use DoctrineORMModuleTest\Assets\Entity\Category;
 use DoctrineORMModuleTest\Assets\Entity\Country;
+use DoctrineORMModuleTest\Assets\Entity\Test as TestEntity;
 
 /**
  * Fixture that loads a constant amount of \DoctrineORMModuleTest\Assets\Entity\Test objects into the manager
@@ -17,7 +16,7 @@ class TestFixture extends AbstractFixture
     /**
      * Number of instances to build when the fixture is loaded
      */
-    const INSTANCES_COUNT = 100;
+    public const INSTANCES_COUNT = 100;
 
     /**
      * {@inheritDoc}

--- a/test/DoctrineORMModuleTest/Assets/GraphEntity/Address.php
+++ b/test/DoctrineORMModuleTest/Assets/GraphEntity/Address.php
@@ -2,31 +2,27 @@
 
 namespace DoctrineORMModuleTest\Assets\GraphEntity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Part of the test assets used to produce a demo of graphs in the Laminas Developer Tools integration
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  *
  * @ORM\Entity()
  */
 class Address
 {
     /**
-     * @var int
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     protected $id;
 
-    /**
-     *
-     */
     public function __construct()
     {
         $this->groups = new ArrayCollection();

--- a/test/DoctrineORMModuleTest/Assets/GraphEntity/Session.php
+++ b/test/DoctrineORMModuleTest/Assets/GraphEntity/Session.php
@@ -7,25 +7,25 @@ use Doctrine\ORM\Mapping as ORM;
 /**
  * Part of the test assets used to produce a demo of graphs in the Laminas Developer Tools integration
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  *
  * @ORM\Entity()
  */
 class Session
 {
     /**
-     * @var int
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     protected $id;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="User", inversedBy="address")
+     *
+     * @var User
      */
     protected $user;
 }

--- a/test/DoctrineORMModuleTest/Assets/GraphEntity/User.php
+++ b/test/DoctrineORMModuleTest/Assets/GraphEntity/User.php
@@ -2,49 +2,49 @@
 
 namespace DoctrineORMModuleTest\Assets\GraphEntity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Part of the test assets used to produce a demo of graphs in the Laminas Developer Tools integration
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  *
  * @ORM\Entity()
  */
 class User
 {
     /**
-     * @var int
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection|UserGroup[]
      * @ORM\ManyToMany(targetEntity="UserGroup", mappedBy="users")
+     *
+     * @var Collection|UserGroup[]
      */
     protected $groups;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection|Session[]
      * @ORM\OneToMany(targetEntity="Session", mappedBy="user")
+     *
+     * @var Collection|Session[]
      */
     protected $sessions;
 
     /**
-     * @var Address
      * @ORM\OneToOne(targetEntity="Address")
+     *
+     * @var Address
      */
     protected $address;
 
-    /**
-     *
-     */
     public function __construct()
     {
         $this->groups   = new ArrayCollection();

--- a/test/DoctrineORMModuleTest/Assets/GraphEntity/UserGroup.php
+++ b/test/DoctrineORMModuleTest/Assets/GraphEntity/UserGroup.php
@@ -2,35 +2,35 @@
 
 namespace DoctrineORMModuleTest\Assets\GraphEntity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * Part of the test assets used to produce a demo of graphs in the Laminas Developer Tools integration
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  *
  * @ORM\Entity()
  */
 class UserGroup
 {
     /**
-     * @var int
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     protected $id;
 
     /**
-     * @var \Doctrine\Common\Collections\Collection|User[]
      * @ORM\ManyToMany(targetEntity="User", inversedBy="groups")
+     *
+     * @var Collection|User[]
      */
     protected $users;
 
-    /* */
     public function __construct()
     {
         $this->users = new ArrayCollection();

--- a/test/DoctrineORMModuleTest/Assets/RepositoryClass.php
+++ b/test/DoctrineORMModuleTest/Assets/RepositoryClass.php
@@ -2,7 +2,8 @@
 
 namespace DoctrineORMModuleTest\Assets;
 
-class RepositoryClass extends \Doctrine\ORM\EntityRepository
-{
+use Doctrine\ORM\EntityRepository;
 
+class RepositoryClass extends EntityRepository
+{
 }

--- a/test/DoctrineORMModuleTest/Assets/Types/MoneyType.php
+++ b/test/DoctrineORMModuleTest/Assets/Types/MoneyType.php
@@ -12,22 +12,33 @@ class MoneyType extends Type
 {
     public const MONEY = 'money';
 
-    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    /**
+     * @param mixed[] $fieldDeclaration
+     */
+    public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
         return 'MyMoney';
     }
 
-    public function convertToPHPValue($value, AbstractPlatform $platform)
+    /**
+     * @param mixed $value
+     */
+    public function convertToPHPValue($value, AbstractPlatform $platform): Money
     {
         return new Money($value);
     }
 
+    /**
+     * @param mixed $value
+     *
+     * @return mixed
+     */
     public function convertToDatabaseValue($value, AbstractPlatform $platform)
     {
         return $value->toDecimal();
     }
 
-    public function getName()
+    public function getName(): string
     {
         return self::MONEY;
     }

--- a/test/DoctrineORMModuleTest/Assets/Types/MoneyType.php
+++ b/test/DoctrineORMModuleTest/Assets/Types/MoneyType.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace DoctrineORMModuleTest\Assets\Types;
 
-use Doctrine\DBAL\Types\Type;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\Type;
 
 /**
  * My custom datatype.
  */
 class MoneyType extends Type
 {
-    const MONEY = 'money';
+    public const MONEY = 'money';
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
     {

--- a/test/DoctrineORMModuleTest/CliConfiguratorTest.php
+++ b/test/DoctrineORMModuleTest/CliConfiguratorTest.php
@@ -145,7 +145,7 @@ class CliConfiguratorTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return list<array{string, class-string}>
      */
     public function dataProviderForTestValidCommands(): array
     {

--- a/test/DoctrineORMModuleTest/Collector/MappingCollectorTest.php
+++ b/test/DoctrineORMModuleTest/Collector/MappingCollectorTest.php
@@ -2,42 +2,43 @@
 
 namespace DoctrineORMModuleTest\Collector;
 
-use PHPUnit\Framework\TestCase;
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
+use Doctrine\Common\Persistence\Mapping\ClassMetadataFactory;
 use DoctrineORMModule\Collector\MappingCollector;
+use Laminas\Mvc\MvcEvent;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+
+use function assert;
+use function serialize;
+use function unserialize;
 
 /**
  * Tests for the MappingCollector
- *
- * @author  Marco Pivetta <ocramius@gmail.com>
- * @license MIT
  */
 class MappingCollectorTest extends TestCase
 {
-    /**
-     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadataFactory|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var ClassMetadataFactory|PHPUnit_Framework_MockObject_MockObject */
     protected $metadataFactory;
 
-    /**
-     * @var MappingCollector
-     */
+    /** @var MappingCollector */
     protected $collector;
 
     /**
      * @covers \DoctrineORMModule\Collector\MappingCollector::__construct
      */
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
-        $this->metadataFactory = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadataFactory::class);
+        $this->metadataFactory = $this->createMock(ClassMetadataFactory::class);
         $this->collector       = new MappingCollector($this->metadataFactory, 'test-collector');
     }
 
     /**
      * @covers \DoctrineORMModule\Collector\MappingCollector::getName
      */
-    public function testGetName()
+    public function testGetName(): void
     {
         $this->assertSame('test-collector', $this->collector->getName());
     }
@@ -45,7 +46,7 @@ class MappingCollectorTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Collector\MappingCollector::getPriority
      */
-    public function testGetPriority()
+    public function testGetPriority(): void
     {
         $this->assertIsInt($this->collector->getPriority());
     }
@@ -54,11 +55,11 @@ class MappingCollectorTest extends TestCase
      * @covers \DoctrineORMModule\Collector\MappingCollector::collect
      * @covers \DoctrineORMModule\Collector\MappingCollector::getClasses
      */
-    public function testCollect()
+    public function testCollect(): void
     {
-        $m1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $m1 = $this->createMock(ClassMetadata::class);
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
-        $m2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $m2 = $this->createMock(ClassMetadata::class);
         $m2->expects($this->any())->method('getName')->will($this->returnValue('M2'));
         $this
             ->metadataFactory
@@ -66,7 +67,7 @@ class MappingCollectorTest extends TestCase
             ->method('getAllMetadata')
             ->will($this->returnValue([$m1, $m2]));
 
-        $this->collector->collect($this->createMock(\Laminas\Mvc\MvcEvent::class));
+        $this->collector->collect($this->createMock(MvcEvent::class));
 
         $classes = $this->collector->getClasses();
 
@@ -78,15 +79,15 @@ class MappingCollectorTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Collector\MappingCollector::canHide
      */
-    public function testCanHide()
+    public function testCanHide(): void
     {
         $this->assertTrue($this->collector->canHide());
 
-        $m1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $m1 = $this->createMock(ClassMetadata::class);
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
         $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue([$m1]));
 
-        $this->collector->collect($this->createMock(\Laminas\Mvc\MvcEvent::class));
+        $this->collector->collect($this->createMock(MvcEvent::class));
 
         $this->assertFalse($this->collector->canHide());
     }
@@ -96,23 +97,23 @@ class MappingCollectorTest extends TestCase
      * @covers \DoctrineORMModule\Collector\MappingCollector::unserialize
      * @covers \DoctrineORMModule\Collector\MappingCollector::collect
      */
-    public function testSerializeUnserializeAndCollectWithNoMetadataFactory()
+    public function testSerializeUnserializeAndCollectWithNoMetadataFactory(): void
     {
-        $m1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $m1 = $this->createMock(ClassMetadata::class);
         $m1->expects($this->any())->method('getName')->will($this->returnValue('M1'));
         $this->metadataFactory->expects($this->any())->method('getAllMetadata')->will($this->returnValue([$m1]));
 
-        $this->collector->collect($this->createMock(\Laminas\Mvc\MvcEvent::class));
+        $this->collector->collect($this->createMock(MvcEvent::class));
 
-        /* @var $collector MappingCollector */
         $collector = unserialize(serialize($this->collector));
+        assert($collector instanceof MappingCollector);
 
         $classes = $collector->getClasses();
         $this->assertCount(1, $classes);
         $this->assertEquals($m1, $classes['M1']);
         $this->assertSame('test-collector', $collector->getName());
 
-        $collector->collect($this->createMock(\Laminas\Mvc\MvcEvent::class));
+        $collector->collect($this->createMock(MvcEvent::class));
 
         $classes = $collector->getClasses();
         $this->assertCount(1, $classes);

--- a/test/DoctrineORMModuleTest/Collector/SQLLoggerCollectorTest.php
+++ b/test/DoctrineORMModuleTest/Collector/SQLLoggerCollectorTest.php
@@ -2,59 +2,56 @@
 
 namespace DoctrineORMModuleTest\Collector;
 
-use PHPUnit\Framework\TestCase;
-use DoctrineORMModule\Collector\SQLLoggerCollector;
 use Doctrine\DBAL\Logging\DebugStack;
+use DoctrineORMModule\Collector\SQLLoggerCollector;
 use Laminas\Mvc\MvcEvent;
+use PHPUnit\Framework\TestCase;
+
+use function microtime;
+use function sleep;
 
 class SQLLoggerCollectorTest extends TestCase
 {
-    /**
-     * @var DebugStack
-     */
+    /** @var DebugStack */
     protected $logger;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     protected $name = 'test-collector-name';
 
-    /**
-     * @var SQLLoggerCollector
-     */
+    /** @var SQLLoggerCollector */
     protected $collector;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
-        $this->logger = new DebugStack();
+        $this->logger    = new DebugStack();
         $this->collector = new SQLLoggerCollector($this->logger, $this->name);
     }
 
-    public function testHasCorrectName()
+    public function testHasCorrectName(): void
     {
         $this->assertSame($this->name, $this->collector->getName());
     }
 
-    public function testGetPriority()
+    public function testGetPriority(): void
     {
         $this->assertIsInt($this->collector->getPriority());
     }
 
-    public function testCollect()
+    public function testCollect(): void
     {
         $this->collector->collect(new MvcEvent());
         $this->addToAssertionCount(1);
     }
 
-    public function testCanHide()
+    public function testCanHide(): void
     {
         $this->assertTrue($this->collector->canHide());
         $this->logger->startQuery('some sql');
         $this->assertFalse($this->collector->canHide());
     }
 
-    public function testGetQueryCount()
+    public function testGetQueryCount(): void
     {
         $this->assertSame(0, $this->collector->getQueryCount());
         $this->logger->startQuery('some sql');
@@ -63,7 +60,7 @@ class SQLLoggerCollectorTest extends TestCase
         $this->assertSame(2, $this->collector->getQueryCount());
     }
 
-    public function testGetQueryTime()
+    public function testGetQueryTime(): void
     {
         $start = microtime(true);
         $this->assertEquals(0, $this->collector->getQueryTime());
@@ -71,14 +68,14 @@ class SQLLoggerCollectorTest extends TestCase
         $this->logger->startQuery('some sql');
         sleep(1);
         $this->logger->stopQuery();
-        $time = microtime(true) - $start;
+        $time  = microtime(true) - $start;
         $time1 = $this->collector->getQueryTime();
         $this->assertGreaterThan(0, $time1);
         $this->assertLessThan($time, $time1);
 
         $this->logger->startQuery('some more sql');
         $this->logger->stopQuery();
-        $time = microtime(true) - $start;
+        $time  = microtime(true) - $start;
         $time2 = $this->collector->getQueryTime();
         $this->assertGreaterThan($time1, $time2);
         $this->assertLessThan($time, $time1);

--- a/test/DoctrineORMModuleTest/ConfigProviderTest.php
+++ b/test/DoctrineORMModuleTest/ConfigProviderTest.php
@@ -8,13 +8,11 @@ use PHPUnit\Framework\TestCase;
 /**
  * Tests used to ensure ConfigProvider operates as expected
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  James Titcumb <james@asgrim.com>
  */
 class ConfigProviderTest extends TestCase
 {
-    public function testInvokeHasDependencyKeyAndNotServiceManager()
+    public function testInvokeHasDependencyKeyAndNotServiceManager(): void
     {
         $config = (new ConfigProvider())->__invoke();
 

--- a/test/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
+++ b/test/DoctrineORMModuleTest/Form/AnnotationBuilderTest.php
@@ -8,23 +8,26 @@ use DoctrineORMModuleTest\Assets\Entity\Issue237;
 use DoctrineORMModuleTest\Framework\TestCase;
 use Laminas\Form\Annotation\AnnotationBuilder as LaminasAnnotationBuilder;
 
+use function array_key_exists;
+use function get_class;
+use function in_array;
+
 class AnnotationBuilderTest extends TestCase
 {
-    /**
-     * @var AnnotationBuilder
-     */
+    /** @var AnnotationBuilder */
     protected $builder;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->builder = new AnnotationBuilder($this->getEntityManager());
     }
 
     /**
-     * @covers \DoctrineORMModule\Form\Annotation\AnnotationBuilder::getFormSpecification
      * @link   https://github.com/doctrine/DoctrineORMModule/issues/237
+     *
+     * @covers \DoctrineORMModule\Form\Annotation\AnnotationBuilder::getFormSpecification
      */
-    public function testIssue237()
+    public function testIssue237(): void
     {
         $entity = new Issue237();
         $spec   = $this->builder->getFormSpecification($entity);
@@ -35,46 +38,51 @@ class AnnotationBuilderTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Form\Annotation\AnnotationBuilder::getFormSpecification
      */
-    public function testAnnotationBuilderSupportsClassNames()
+    public function testAnnotationBuilderSupportsClassNames(): void
     {
-        $spec = $this->builder->getFormSpecification(\DoctrineORMModuleTest\Assets\Entity\Issue237::class);
+        $spec = $this->builder->getFormSpecification(Issue237::class);
 
         $this->assertCount(0, $spec['elements'], 'Annotation builder allows also class names');
     }
 
     /**
      * empty_option behavior - !isset can't evaluate null value
+     *
      * @link https://github.com/doctrine/DoctrineORMModule/pull/247
      */
-    public function testEmptyOptionNullDoesntGenerateValue()
+    public function testEmptyOptionNullDoesntGenerateValue(): void
     {
         $showEmptyValue = true;
         $entity         = new FormEntity();
         $spec           = $this->builder->getFormSpecification($entity);
 
         foreach ($spec['elements'] as $elementSpec) {
-            if (isset($elementSpec['spec']['options'])) {
-                if (array_key_exists('empty_option', $elementSpec['spec']['options']) &&
-                    $elementSpec['spec']['options']['empty_option'] === null
-                ) {
-                    $showEmptyValue = false;
-                    break;
-                }
+            if (! isset($elementSpec['spec']['options'])) {
+                continue;
+            }
+
+            if (
+                array_key_exists('empty_option', $elementSpec['spec']['options']) &&
+                $elementSpec['spec']['options']['empty_option'] === null
+            ) {
+                $showEmptyValue = false;
+                break;
             }
         }
+
         $this->assertFalse($showEmptyValue);
     }
 
     /**
      * Ensure user defined \Type or type attribute overrides the listener one
      */
-    public function testEnsureCustomTypeOrAttributeTypeIsUsedInAnnotations()
+    public function testEnsureCustomTypeOrAttributeTypeIsUsedInAnnotations(): void
     {
         $userDefinedTypeOverridesListenerType = true;
         $entity                               = new FormEntity();
 
         $laminasAnnotationBuilder = new LaminasAnnotationBuilder();
-        $laminasForm                 = $laminasAnnotationBuilder->createForm($entity);
+        $laminasForm              = $laminasAnnotationBuilder->createForm($entity);
 
         $spec           = $this->builder->getFormSpecification($entity);
         $annotationForm = $this->builder->createForm($entity);
@@ -83,27 +91,33 @@ class AnnotationBuilderTest extends TestCase
 
         foreach ($spec['elements'] as $element) {
             $elementName = $element['spec']['name'];
-            if (in_array($elementName, $attributesToTest)) {
-                $annotationFormElement = $annotationForm->get($elementName);
-                $laminasFormElement       = $laminasForm->get($elementName);
-
-                $annotationElementAttribute = $annotationFormElement->getAttribute('type');
-                $laminasElementAttribute       = $laminasFormElement->getAttribute('type');
-
-                if ((get_class($laminasFormElement) !== get_class($annotationFormElement)) ||
-                    ($annotationElementAttribute !== $laminasElementAttribute)
-                ) {
-                    $userDefinedTypeOverridesListenerType = false;
-                }
+            if (! in_array($elementName, $attributesToTest)) {
+                continue;
             }
+
+            $annotationFormElement = $annotationForm->get($elementName);
+            $laminasFormElement    = $laminasForm->get($elementName);
+
+            $annotationElementAttribute = $annotationFormElement->getAttribute('type');
+            $laminasElementAttribute    = $laminasFormElement->getAttribute('type');
+
+            if (
+                (get_class($laminasFormElement) === get_class($annotationFormElement)) &&
+                ($annotationElementAttribute === $laminasElementAttribute)
+            ) {
+                continue;
+            }
+
+            $userDefinedTypeOverridesListenerType = false;
         }
+
         $this->assertTrue($userDefinedTypeOverridesListenerType);
     }
 
     /**
      * @link https://github.com/zendframework/zf2/issues/7096
      */
-    public function testFileTypeDoesntGrabStringLengthValidator()
+    public function testFileTypeDoesntGrabStringLengthValidator(): void
     {
         $validators = $this
             ->builder
@@ -119,7 +133,7 @@ class AnnotationBuilderTest extends TestCase
     /**
      * Ensure prefer_form_input_filter is set to true for the generated form
      */
-    public function testPreferFormInputFilterIsTrue()
+    public function testPreferFormInputFilterIsTrue(): void
     {
         $entity = new FormEntity();
         $form   = $this->builder->createForm($entity);

--- a/test/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
+++ b/test/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
@@ -4,17 +4,26 @@ namespace DoctrineORMModuleTest\Form;
 
 use ArrayObject;
 use DoctrineORMModule\Form\Annotation\ElementAnnotationsListener;
+use DoctrineORMModule\Form\Element\EntitySelect;
+use DoctrineORMModuleTest\Assets\Entity\FormEntity;
+use DoctrineORMModuleTest\Assets\Entity\FormEntityTarget;
+use DoctrineORMModuleTest\Assets\Entity\TargetEntity;
 use DoctrineORMModuleTest\Framework\TestCase;
 use Laminas\EventManager\Event;
+use Laminas\Form\Element;
+use Laminas\Form\Element\Checkbox;
+use Laminas\Form\Element\Date;
+use Laminas\Form\Element\DateTime;
+use Laminas\Form\Element\Number;
+use Laminas\Form\Element\Textarea;
+use Laminas\Form\Element\Time;
 
 class ElementAnnotationsListenerTest extends TestCase
 {
-    /**
-     * @var ElementAnnotationsListener
-     */
+    /** @var ElementAnnotationsListener */
     protected $listener;
 
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->listener = new ElementAnnotationsListener($this->getEntityManager());
     }
@@ -22,7 +31,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventNameProvider
      */
-    public function testEventsWithNoMetadata($method)
+    public function testEventsWithNoMetadata($method): void
     {
         $event = $this->getMetadataEvent();
         $this->listener->{$method}($event);
@@ -30,7 +39,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testToOne()
+    public function testToOne(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -41,17 +50,17 @@ class ElementAnnotationsListenerTest extends TestCase
         $elementSpec = $event->getParam('elementSpec');
         $this->assertEquals($this->getEntityManager(), $elementSpec['spec']['options']['object_manager']);
         $this->assertEquals(
-            \DoctrineORMModuleTest\Assets\Entity\TargetEntity::class,
+            TargetEntity::class,
             $elementSpec['spec']['options']['target_class']
         );
-        $this->assertEquals(\DoctrineORMModule\Form\Element\EntitySelect::class, $elementSpec['spec']['type']);
+        $this->assertEquals(EntitySelect::class, $elementSpec['spec']['type']);
     }
 
-    public function testToOneMergesOptions()
+    public function testToOneMergesOptions(): void
     {
-        $listener    = $this->listener;
-        $event       = $this->getMetadataEvent();
-        $elementSpec = new ArrayObject();
+        $listener                              = $this->listener;
+        $event                                 = $this->getMetadataEvent();
+        $elementSpec                           = new ArrayObject();
         $elementSpec['spec']['options']['foo'] = 'bar';
 
         $event->setParam('name', 'targetOne');
@@ -62,7 +71,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertCount(3, $elementSpec['spec']['options']);
     }
 
-    public function testToOneHasNoEffectOnToMany()
+    public function testToOneHasNoEffectOnToMany(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -74,7 +83,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertNull($event->getParam('inputSpec'));
     }
 
-    public function testToManyHasNoEffectOnToOne()
+    public function testToManyHasNoEffectOnToOne(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -86,7 +95,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertNull($event->getParam('inputSpec'));
     }
 
-    public function testToMany()
+    public function testToMany(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -100,18 +109,18 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertTrue($elementSpec['spec']['attributes']['multiple']);
         $this->assertEquals($this->getEntityManager(), $elementSpec['spec']['options']['object_manager']);
         $this->assertEquals(
-            \DoctrineORMModuleTest\Assets\Entity\FormEntityTarget::class,
+            FormEntityTarget::class,
             $elementSpec['spec']['options']['target_class']
         );
-        $this->assertEquals(\DoctrineORMModule\Form\Element\EntitySelect::class, $elementSpec['spec']['type']);
+        $this->assertEquals(EntitySelect::class, $elementSpec['spec']['type']);
         $this->assertFalse($inputSpec['required']);
     }
 
-    public function testToManyMergesOptions()
+    public function testToManyMergesOptions(): void
     {
-        $listener    = $this->listener;
-        $event       = $this->getMetadataEvent();
-        $elementSpec = new ArrayObject();
+        $listener                              = $this->listener;
+        $event                                 = $this->getMetadataEvent();
+        $elementSpec                           = new ArrayObject();
         $elementSpec['spec']['options']['foo'] = 'bar';
 
         $event->setParam('name', 'targetMany');
@@ -122,7 +131,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertCount(3, $elementSpec['spec']['options']);
     }
 
-    public function testHandleExcludeAssociation()
+    public function testHandleExcludeAssociation(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -137,7 +146,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventFilterProvider
      */
-    public function testHandleFilterField($name, $type)
+    public function testHandleFilterField($name, $type): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -152,7 +161,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertEquals($type, $inputSpec['filters'][0]['name']);
     }
 
-    public function testHandlRequiredAssociation()
+    public function testHandlRequiredAssociation(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -167,7 +176,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertFalse($inputSpec['required']);
     }
 
-    public function testHandlRequiredAssociationSetsNullOption()
+    public function testHandlRequiredAssociationSetsNullOption(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -184,7 +193,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertEquals('foo', $elementSpec['spec']['options']['empty_option']);
     }
 
-    public function testHandleRequiredField()
+    public function testHandleRequiredField(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -203,7 +212,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $this->assertFalse($inputSpec['required']);
     }
 
-    public function testHandleRequiredFieldNonFieldProperty()
+    public function testHandleRequiredFieldNonFieldProperty(): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -215,7 +224,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventTypeProvider
      */
-    public function testHandleTypeField($name, $type)
+    public function testHandleTypeField($name, $type): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -233,7 +242,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventValidatorProvider
      */
-    public function testHandlevalidatorField($name, $type)
+    public function testHandlevalidatorField($name, $type): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -245,7 +254,7 @@ class ElementAnnotationsListenerTest extends TestCase
         $listener->handleValidatorField($event);
 
         $inputSpec = $event->getParam('inputSpec');
-        if (null === $type) {
+        if ($type === null) {
             $this->assertEmpty($inputSpec['validators']);
         } else {
             $this->assertEquals($type, $inputSpec['validators'][0]['name']);
@@ -291,17 +300,17 @@ class ElementAnnotationsListenerTest extends TestCase
     public function eventTypeProvider()
     {
         return [
-            ['bool', \Laminas\Form\Element\Checkbox::class],
-            ['boolean', \Laminas\Form\Element\Checkbox::class],
-            ['bigint', \Laminas\Form\Element\Number::class],
-            ['integer', \Laminas\Form\Element\Number::class],
-            ['smallint', \Laminas\Form\Element\Number::class],
-            ['datetime', \Laminas\Form\Element\DateTime::class],
-            ['datetimetz', \Laminas\Form\Element\DateTime::class],
-            ['date', \Laminas\Form\Element\Date::class],
-            ['time', \Laminas\Form\Element\Time::class],
-            ['string', \Laminas\Form\Element::class],
-            ['text', \Laminas\Form\Element\Textarea::class],
+            ['bool', Checkbox::class],
+            ['boolean', Checkbox::class],
+            ['bigint', Number::class],
+            ['integer', Number::class],
+            ['smallint', Number::class],
+            ['datetime', DateTime::class],
+            ['datetimetz', DateTime::class],
+            ['date', Date::class],
+            ['time', Time::class],
+            ['string', Element::class],
+            ['text', Textarea::class],
         ];
     }
 
@@ -325,7 +334,7 @@ class ElementAnnotationsListenerTest extends TestCase
     protected function getMetadataEvent()
     {
         $event    = new Event();
-        $metadata = $this->getEntityManager()->getClassMetadata(\DoctrineORMModuleTest\Assets\Entity\FormEntity::class);
+        $metadata = $this->getEntityManager()->getClassMetadata(FormEntity::class);
         $event->setParam('metadata', $metadata);
 
         return $event;

--- a/test/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
+++ b/test/DoctrineORMModuleTest/Form/ElementAnnotationsListenerTest.php
@@ -31,7 +31,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventNameProvider
      */
-    public function testEventsWithNoMetadata($method): void
+    public function testEventsWithNoMetadata(string $method): void
     {
         $event = $this->getMetadataEvent();
         $this->listener->{$method}($event);
@@ -146,7 +146,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventFilterProvider
      */
-    public function testHandleFilterField($name, $type): void
+    public function testHandleFilterField(string $name, string $type): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -224,7 +224,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventTypeProvider
      */
-    public function testHandleTypeField($name, $type): void
+    public function testHandleTypeField(string $name, string $type): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -242,7 +242,7 @@ class ElementAnnotationsListenerTest extends TestCase
     /**
      * @dataProvider eventValidatorProvider
      */
-    public function testHandlevalidatorField($name, $type): void
+    public function testHandlevalidatorField(string $name, ?string $type): void
     {
         $listener = $this->listener;
         $event    = $this->getMetadataEvent();
@@ -261,6 +261,9 @@ class ElementAnnotationsListenerTest extends TestCase
         }
     }
 
+    /**
+     * @return list<array{string, string|null}>
+     */
     public function eventValidatorProvider()
     {
         return [
@@ -280,6 +283,9 @@ class ElementAnnotationsListenerTest extends TestCase
         ];
     }
 
+    /**
+     * @return list<array{string, string}>
+     */
     public function eventFilterProvider()
     {
         return [
@@ -297,6 +303,9 @@ class ElementAnnotationsListenerTest extends TestCase
         ];
     }
 
+    /**
+     * @return list<array{string, class-string}>
+     */
     public function eventTypeProvider()
     {
         return [
@@ -314,7 +323,10 @@ class ElementAnnotationsListenerTest extends TestCase
         ];
     }
 
-    public function eventNameProvider()
+    /**
+     * @return list<array{string}>
+     */
+    public function eventNameProvider(): array
     {
         return [
             [
@@ -331,7 +343,7 @@ class ElementAnnotationsListenerTest extends TestCase
         ];
     }
 
-    protected function getMetadataEvent()
+    protected function getMetadataEvent(): Event
     {
         $event    = new Event();
         $metadata = $this->getEntityManager()->getClassMetadata(FormEntity::class);

--- a/test/DoctrineORMModuleTest/Framework/TestCase.php
+++ b/test/DoctrineORMModuleTest/Framework/TestCase.php
@@ -2,30 +2,26 @@
 
 namespace DoctrineORMModuleTest\Framework;
 
-use DoctrineORMModuleTest\ServiceManagerFactory;
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
+use DoctrineORMModuleTest\ServiceManagerFactory;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
  * Base test case for tests using the entity manager
  */
 class TestCase extends PHPUnitTestCase
 {
-    /**
-     * @var boolean
-     */
+    /** @var bool */
     protected $hasDb = false;
 
-    /**
-     * @var EntityManager
-     */
+    /** @var EntityManager */
     private $entityManager;
 
     /**
      * Creates a database if not done already.
      */
-    public function createDb()
+    public function createDb(): void
     {
         if ($this->hasDb) {
             return;
@@ -40,7 +36,7 @@ class TestCase extends PHPUnitTestCase
     /**
      * Drops existing database
      */
-    public function dropDb()
+    public function dropDb(): void
     {
         $em   = $this->getEntityManager();
         $tool = new SchemaTool($em);
@@ -52,10 +48,8 @@ class TestCase extends PHPUnitTestCase
 
     /**
      * Get EntityManager.
-     *
-     * @return EntityManager
      */
-    public function getEntityManager()
+    public function getEntityManager(): EntityManager
     {
         if ($this->entityManager) {
             return $this->entityManager;

--- a/test/DoctrineORMModuleTest/Options/ConfigurationOptionsTest.php
+++ b/test/DoctrineORMModuleTest/Options/ConfigurationOptionsTest.php
@@ -2,13 +2,18 @@
 
 namespace DoctrineORMModuleTest\Options;
 
-use PHPUnit\Framework\TestCase;
-use DoctrineORMModule\Options\Configuration;
+use Doctrine\ORM\Mapping\EntityListenerResolver;
+use Doctrine\ORM\Mapping\NamingStrategy;
+use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\ORM\Repository\DefaultRepositoryFactory;
+use DoctrineORMModule\Options\Configuration;
+use Laminas\Stdlib\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
 
 class ConfigurationOptionsTest extends TestCase
 {
-    public function testSetGetNamingStrategy()
+    public function testSetGetNamingStrategy(): void
     {
         $options = new Configuration();
         $options->setNamingStrategy(null);
@@ -17,15 +22,15 @@ class ConfigurationOptionsTest extends TestCase
         $options->setNamingStrategy('test');
         $this->assertSame('test', $options->getNamingStrategy());
 
-        $namingStrategy = $this->createMock(\Doctrine\ORM\Mapping\NamingStrategy::class);
+        $namingStrategy = $this->createMock(NamingStrategy::class);
         $options->setNamingStrategy($namingStrategy);
         $this->assertSame($namingStrategy, $options->getNamingStrategy());
 
-        $this->expectException(\Laminas\Stdlib\Exception\InvalidArgumentException::class);
-        $options->setNamingStrategy(new \stdClass());
+        $this->expectException(InvalidArgumentException::class);
+        $options->setNamingStrategy(new stdClass());
     }
 
-    public function testSetGetQuoteStrategy()
+    public function testSetGetQuoteStrategy(): void
     {
         $options = new Configuration();
         $options->setQuoteStrategy(null);
@@ -34,15 +39,15 @@ class ConfigurationOptionsTest extends TestCase
         $options->setQuoteStrategy('test');
         $this->assertSame('test', $options->getQuoteStrategy());
 
-        $quoteStrategy = $this->createMock(\Doctrine\ORM\Mapping\QuoteStrategy::class);
+        $quoteStrategy = $this->createMock(QuoteStrategy::class);
         $options->setQuoteStrategy($quoteStrategy);
         $this->assertSame($quoteStrategy, $options->getQuoteStrategy());
 
-        $this->expectException(\Laminas\Stdlib\Exception\InvalidArgumentException::class);
-        $options->setQuoteStrategy(new \stdClass());
+        $this->expectException(InvalidArgumentException::class);
+        $options->setQuoteStrategy(new stdClass());
     }
 
-    public function testSetRepositoryFactory()
+    public function testSetRepositoryFactory(): void
     {
         $options = new Configuration();
         $options->setRepositoryFactory(null);
@@ -55,11 +60,11 @@ class ConfigurationOptionsTest extends TestCase
         $options->setRepositoryFactory($repositoryFactory);
         $this->assertSame($repositoryFactory, $options->getRepositoryFactory());
 
-        $this->expectException(\Laminas\Stdlib\Exception\InvalidArgumentException::class);
-        $options->setRepositoryFactory(new \stdClass());
+        $this->expectException(InvalidArgumentException::class);
+        $options->setRepositoryFactory(new stdClass());
     }
 
-    public function testSetGetEntityListenerResolver()
+    public function testSetGetEntityListenerResolver(): void
     {
         $options = new Configuration();
 
@@ -69,12 +74,12 @@ class ConfigurationOptionsTest extends TestCase
         $options->setEntityListenerResolver('test');
         $this->assertSame('test', $options->getEntityListenerResolver());
 
-        $entityListenerResolver = $this->createMock(\Doctrine\ORM\Mapping\EntityListenerResolver::class);
+        $entityListenerResolver = $this->createMock(EntityListenerResolver::class);
 
         $options->setEntityListenerResolver($entityListenerResolver);
         $this->assertSame($entityListenerResolver, $options->getEntityListenerResolver());
 
-        $this->expectException(\Laminas\Stdlib\Exception\InvalidArgumentException::class);
-        $options->setEntityListenerResolver(new \stdClass());
+        $this->expectException(InvalidArgumentException::class);
+        $options->setEntityListenerResolver(new stdClass());
     }
 }

--- a/test/DoctrineORMModuleTest/Options/DBALConnectionTest.php
+++ b/test/DoctrineORMModuleTest/Options/DBALConnectionTest.php
@@ -2,23 +2,22 @@
 
 namespace DoctrineORMModuleTest\Options;
 
-use PHPUnit\Framework\TestCase;
 use DoctrineORMModule\Options\DBALConnection;
-use Doctrine\ORM\Repository\DefaultRepositoryFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DoctrineORMModule\Options\DBALConnection
  */
 class DBALConnectionTest extends TestCase
 {
-    public function testSetNullCommentedTypes()
+    public function testSetNullCommentedTypes(): void
     {
         $options = new DBALConnection();
         $options->setDoctrineCommentedTypes([]);
         $this->assertSame([], $options->getDoctrineCommentedTypes());
     }
 
-    public function testSetGetCommentedTypes()
+    public function testSetGetCommentedTypes(): void
     {
         $options = new DBALConnection();
         $options->setDoctrineCommentedTypes(['mytype']);

--- a/test/DoctrineORMModuleTest/Options/DefaultRepositoryTest.php
+++ b/test/DoctrineORMModuleTest/Options/DefaultRepositoryTest.php
@@ -2,15 +2,17 @@
 
 namespace DoctrineORMModuleTest\Collector;
 
+use DoctrineORMModuleTest\Assets\Entity\EntityWithoutRepository;
+use DoctrineORMModuleTest\Assets\RepositoryClass;
 use DoctrineORMModuleTest\Framework\TestCase;
 
 class DefaultRepositoryTest extends TestCase
 {
-    public function testEntityHasDefaultRepositoryInstance()
+    public function testEntityHasDefaultRepositoryInstance(): void
     {
-        $entityWithDefaultRepository = \DoctrineORMModuleTest\Assets\Entity\EntityWithoutRepository::class;
+        $entityWithDefaultRepository = EntityWithoutRepository::class;
 
         $repository = $this->getEntityManager()->getRepository($entityWithDefaultRepository);
-        $this->assertInstanceOf(\DoctrineORMModuleTest\Assets\RepositoryClass::class, $repository);
+        $this->assertInstanceOf(RepositoryClass::class, $repository);
     }
 }

--- a/test/DoctrineORMModuleTest/Options/EntityManagerTest.php
+++ b/test/DoctrineORMModuleTest/Options/EntityManagerTest.php
@@ -2,19 +2,17 @@
 
 namespace DoctrineORMModuleTest\Options;
 
-use PHPUnit\Framework\TestCase;
 use DoctrineORMModule\Options\EntityManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \DoctrineORMModule\Options\EntityManager}
  *
  * @covers \DoctrineORMModule\Options\EntityManager
- *
- * @author Marco Pivetta <ocramius@gmail.com>
  */
 class EntityManagerTest extends TestCase
 {
-    public function testSetGetResolver()
+    public function testSetGetResolver(): void
     {
         $options = new EntityManager();
 

--- a/test/DoctrineORMModuleTest/Options/SQLLoggerCollectorOptionsTest.php
+++ b/test/DoctrineORMModuleTest/Options/SQLLoggerCollectorOptionsTest.php
@@ -2,12 +2,12 @@
 
 namespace DoctrineORMModuleTest\Options;
 
-use PHPUnit\Framework\TestCase;
 use DoctrineORMModule\Options\SQLLoggerCollectorOptions;
+use PHPUnit\Framework\TestCase;
 
 class SQLLoggerCollectorOptionsTest extends TestCase
 {
-    public function testSetGetSQLLogger()
+    public function testSetGetSQLLogger(): void
     {
         $options = new SQLLoggerCollectorOptions();
         $options->setSqlLogger('sql-logger-name');
@@ -16,7 +16,7 @@ class SQLLoggerCollectorOptionsTest extends TestCase
         $this->assertNull($options->getSqlLogger());
     }
 
-    public function testSetGetConfiguration()
+    public function testSetGetConfiguration(): void
     {
         $options = new SQLLoggerCollectorOptions();
         $options->setConfiguration('configuration-name');
@@ -25,7 +25,7 @@ class SQLLoggerCollectorOptionsTest extends TestCase
         $this->assertSame('doctrine.configuration.orm_default', $options->getConfiguration());
     }
 
-    public function testSetGetName()
+    public function testSetGetName(): void
     {
         $options = new SQLLoggerCollectorOptions();
         $this->assertSame('orm_default', $options->getName()); // testing defaults too!

--- a/test/DoctrineORMModuleTest/Paginator/AdapterTestIgnore.php
+++ b/test/DoctrineORMModuleTest/Paginator/AdapterTestIgnore.php
@@ -17,7 +17,7 @@ use function count;
 class AdapterTestIgnore extends TestCase
 {
     /** @var QueryBuilder */
-    protected $qb;
+    protected $queryBuilder;
 
     /** @var PaginatorAdapter */
     protected $paginatorAdapter;
@@ -36,14 +36,14 @@ class AdapterTestIgnore extends TestCase
         $executor = new ORMExecutor($this->getEntityManager(), $purger);
         $executor->execute($loader->getFixtures());
 
-        $this->qb = $this
+        $this->queryBuilder = $this
             ->getEntityManager()
             ->createQueryBuilder()
             ->select('t')
             ->from(Test::class, 't')
             ->orderBy('t.id', 'ASC');
 
-        $this->paginator        = new DoctrinePaginator($this->qb);
+        $this->paginator        = new DoctrinePaginator($this->queryBuilder);
         $this->paginatorAdapter = new PaginatorAdapter($this->paginator);
     }
 
@@ -57,7 +57,7 @@ class AdapterTestIgnore extends TestCase
 
     public function testContainedItemsCount(): void
     {
-        $itemsCount = $this->qb->select('COUNT(t)')->getQuery()->getSingleScalarResult();
+        $itemsCount = $this->queryBuilder->select('COUNT(t)')->getQuery()->getSingleScalarResult();
 
         $this->assertEquals($itemsCount, $this->paginatorAdapter->count());
         $this->assertEquals($itemsCount, count($this->paginatorAdapter->getItems(0, $itemsCount + 100)));
@@ -65,7 +65,7 @@ class AdapterTestIgnore extends TestCase
 
     public function testGetsItemsAtOffsetZero(): void
     {
-        $expected = $this->qb->setMaxResults(10)->getQuery()->getResult();
+        $expected = $this->queryBuilder->setMaxResults(10)->getQuery()->getResult();
         $actual   = $this->paginatorAdapter->getItems(0, 10);
 
         foreach ($expected as $key => $expectedItem) {
@@ -75,7 +75,7 @@ class AdapterTestIgnore extends TestCase
 
     public function testGetsItemsAtOffsetTen(): void
     {
-        $expected = $this->qb->setFirstResult(10)->setMaxResults(10)->getQuery()->getResult();
+        $expected = $this->queryBuilder->setFirstResult(10)->setMaxResults(10)->getQuery()->getResult();
         $actual   = $this->paginatorAdapter->getItems(10, 10);
 
         foreach ($expected as $key => $expectedItem) {

--- a/test/DoctrineORMModuleTest/Paginator/AdapterTestIgnore.php
+++ b/test/DoctrineORMModuleTest/Paginator/AdapterTestIgnore.php
@@ -2,42 +2,37 @@
 
 namespace DoctrineORMModuleTest\Paginator;
 
-use DoctrineORMModuleTest\Framework\TestCase;
-use DoctrineORMModuleTest\Assets\Fixture\TestFixture;
-
-use Doctrine\Common\DataFixtures\Loader as FixtureLoader;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
+use Doctrine\Common\DataFixtures\Loader as FixtureLoader;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\ORM\Tools\Pagination\Paginator as DoctrinePaginator;
 use DoctrineORMModule\Paginator\Adapter\DoctrinePaginator as PaginatorAdapter;
+use DoctrineORMModuleTest\Assets\Entity\Test;
+use DoctrineORMModuleTest\Assets\Fixture\TestFixture;
+use DoctrineORMModuleTest\Framework\TestCase;
+
+use function count;
 
 class AdapterTestIgnore extends TestCase
 {
-    /**
-     * @var QueryBuilder
-     */
+    /** @var QueryBuilder */
     protected $qb;
 
-    /**
-     * @var PaginatorAdapter
-     */
+    /** @var PaginatorAdapter */
     protected $paginatorAdapter;
 
-    /**
-     * @var DoctrinePaginator
-     */
+    /** @var DoctrinePaginator */
     protected $paginator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $this->createDb();
         $loader = new FixtureLoader();
         $loader->addFixture(new TestFixture());
-        $purger = new ORMPurger();
+        $purger   = new ORMPurger();
         $executor = new ORMExecutor($this->getEntityManager(), $purger);
         $executor->execute($loader->getFixtures());
 
@@ -45,14 +40,14 @@ class AdapterTestIgnore extends TestCase
             ->getEntityManager()
             ->createQueryBuilder()
             ->select('t')
-            ->from(\DoctrineORMModuleTest\Assets\Entity\Test::class, 't')
+            ->from(Test::class, 't')
             ->orderBy('t.id', 'ASC');
 
-        $this->paginator = new DoctrinePaginator($this->qb);
+        $this->paginator        = new DoctrinePaginator($this->qb);
         $this->paginatorAdapter = new PaginatorAdapter($this->paginator);
     }
 
-    public function testCanSetPaginator()
+    public function testCanSetPaginator(): void
     {
         $this->assertSame($this->paginator, $this->paginatorAdapter->getPaginator());
         $doctrinePaginator = new DoctrinePaginator($this->getEntityManager()->createQuery(''));
@@ -60,7 +55,7 @@ class AdapterTestIgnore extends TestCase
         $this->assertSame($doctrinePaginator, $this->paginatorAdapter->getPaginator());
     }
 
-    public function testContainedItemsCount()
+    public function testContainedItemsCount(): void
     {
         $itemsCount = $this->qb->select('COUNT(t)')->getQuery()->getSingleScalarResult();
 
@@ -68,20 +63,20 @@ class AdapterTestIgnore extends TestCase
         $this->assertEquals($itemsCount, count($this->paginatorAdapter->getItems(0, $itemsCount + 100)));
     }
 
-    public function testGetsItemsAtOffsetZero()
+    public function testGetsItemsAtOffsetZero(): void
     {
         $expected = $this->qb->setMaxResults(10)->getQuery()->getResult();
-        $actual = $this->paginatorAdapter->getItems(0, 10);
+        $actual   = $this->paginatorAdapter->getItems(0, 10);
 
         foreach ($expected as $key => $expectedItem) {
             $this->assertEquals($expectedItem, $actual[$key]);
         }
     }
 
-    public function testGetsItemsAtOffsetTen()
+    public function testGetsItemsAtOffsetTen(): void
     {
         $expected = $this->qb->setFirstResult(10)->setMaxResults(10)->getQuery()->getResult();
-        $actual = $this->paginatorAdapter->getItems(10, 10);
+        $actual   = $this->paginatorAdapter->getItems(10, 10);
 
         foreach ($expected as $key => $expectedItem) {
             $this->assertEquals($expectedItem, $actual[$key]);

--- a/test/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Service/DBALConnectionFactoryTest.php
@@ -2,55 +2,46 @@
 
 namespace DoctrineORMModuleTest\Service;
 
+use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\EventManager;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\DBAL\Driver\PDOSqlite\Driver as PDOSqliteDriver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Doctrine\ORM\Configuration;
-use DoctrineORMModuleTest\Assets\Types\MoneyType;
-use PHPUnit\Framework\TestCase;
-use DoctrineORMModule\Service\DBALConnectionFactory;
 use Doctrine\DBAL\Types\Type;
-use Doctrine\Common\Cache\ArrayCache;
-use Doctrine\Common\EventManager;
-use Laminas\ServiceManager\ServiceManager;
+use Doctrine\ORM\Configuration;
 use DoctrineORMModule\Service\ConfigurationFactory;
+use DoctrineORMModule\Service\DBALConnectionFactory;
+use DoctrineORMModuleTest\Assets\Types\MoneyType;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DoctrineORMModule\Service\DBALConnectionFactory
  */
 class DBALConnectionFactoryTest extends TestCase
 {
-    /**
-     * @var ServiceManager
-     */
+    /** @var ServiceManager */
     protected $serviceManager;
-    /**
-     * @var DBALConnectionFactory
-     */
+    /** @var DBALConnectionFactory */
     protected $factory;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->serviceManager = new ServiceManager();
-        $this->factory = new DBALConnectionFactory('orm_default');
+        $this->factory        = new DBALConnectionFactory('orm_default');
         $this->serviceManager->setService('doctrine.cache.array', new ArrayCache());
         $this->serviceManager->setService('doctrine.eventmanager.orm_default', new EventManager());
     }
 
-    public function testNoConnectWithoutCustomMappingsAndCommentedTypes()
+    public function testNoConnectWithoutCustomMappingsAndCommentedTypes(): void
     {
-        $config = [
+        $config            = [
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
                         'driverClass'   => PDOSqliteDriver::class,
-                        'params' => [
-                            'memory' => true,
-                        ],
-                    ]
+                        'params' => ['memory' => true],
+                    ],
                 ],
             ],
         ];
@@ -66,19 +57,15 @@ class DBALConnectionFactoryTest extends TestCase
         $this->assertFalse($dbal->isConnected());
     }
 
-    public function testDoctrineMappingTypeReturnCorrectParent()
+    public function testDoctrineMappingTypeReturnCorrectParent(): void
     {
-        $config = [
+        $config            = [
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
                         'driverClass'   => PDOSqliteDriver::class,
-                        'params' => [
-                            'memory' => true,
-                        ],
-                        'doctrineTypeMappings' => [
-                            'money' => 'string',
-                        ],
+                        'params' => ['memory' => true],
+                        'doctrineTypeMappings' => ['money' => 'string'],
                     ],
                 ],
             ],
@@ -91,27 +78,21 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
 
-        $dbal = $this->factory->createService($this->serviceManager);
+        $dbal     = $this->factory->createService($this->serviceManager);
         $platform = $dbal->getDatabasePlatform();
-        $this->assertSame('string', $platform->getDoctrineTypeMapping("money"));
+        $this->assertSame('string', $platform->getDoctrineTypeMapping('money'));
     }
 
-    public function testDoctrineAddCustomCommentedType()
+    public function testDoctrineAddCustomCommentedType(): void
     {
         $config = [
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
                         'driverClass'   => PDOSqliteDriver::class,
-                        'params' => [
-                            'memory' => true,
-                        ],
-                        'doctrineTypeMappings' => [
-                            'money' => 'money',
-                        ],
-                        'doctrineCommentedTypes' => [
-                            'money',
-                        ],
+                        'params' => ['memory' => true],
+                        'doctrineTypeMappings' => ['money' => 'money'],
+                        'doctrineCommentedTypes' => ['money'],
                     ],
                 ],
                 'configuration' => [
@@ -134,25 +115,23 @@ class DBALConnectionFactoryTest extends TestCase
             'doctrine.configuration.orm_default',
             $configurationFactory->createService($this->serviceManager)
         );
-        $dbal = $this->factory->createService($this->serviceManager);
+        $dbal     = $this->factory->createService($this->serviceManager);
         $platform = $dbal->getDatabasePlatform();
-        $type = Type::getType($platform->getDoctrineTypeMapping("money"));
+        $type     = Type::getType($platform->getDoctrineTypeMapping('money'));
 
         $this->assertInstanceOf(MoneyType::class, $type);
         $this->assertTrue($platform->isCommentedDoctrineType($type));
     }
 
-    public function testGettingPlatformFromContainer()
+    public function testGettingPlatformFromContainer(): void
     {
-        $config = [
+        $config            = [
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
                         'driverClass'   => PDOSqliteDriver::class,
-                        'params' => [
-                            'platform' => 'platform_service',
-                        ],
-                    ]
+                        'params' => ['platform' => 'platform_service'],
+                    ],
                 ],
             ],
         ];
@@ -169,22 +148,20 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('Configuration', $config);
         $this->serviceManager->setService('platform_service', $platformMock);
 
-        $dbal = $this->factory->createService($this->serviceManager);
+        $dbal     = $this->factory->createService($this->serviceManager);
         $platform = $dbal->getDatabasePlatform();
         $this->assertSame($platformMock, $platform);
     }
 
-    public function testWithoutUseSavepoints()
+    public function testWithoutUseSavepoints(): void
     {
-        $config = [
+        $config            = [
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
                         'driverClass'   => PDOSqliteDriver::class,
-                        'params' => [
-                            'memory' => true,
-                        ],
-                    ]
+                        'params' => ['memory' => true],
+                    ],
                 ],
             ],
         ];
@@ -200,18 +177,16 @@ class DBALConnectionFactoryTest extends TestCase
         $this->assertFalse($dbal->getNestTransactionsWithSavepoints());
     }
 
-    public function testWithUseSavepoints()
+    public function testWithUseSavepoints(): void
     {
-        $config = [
+        $config            = [
             'doctrine' => [
                 'connection' => [
                     'orm_default' => [
                         'driverClass'   => PDOSqliteDriver::class,
                         'use_savepoints' => true,
-                        'params' => [
-                            'memory' => true,
-                        ],
-                    ]
+                        'params' => ['memory' => true],
+                    ],
                 ],
             ],
         ];

--- a/test/DoctrineORMModuleTest/Service/EntityResolverFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Service/EntityResolverFactoryTest.php
@@ -3,20 +3,22 @@
 namespace DoctrineORMModuleTest\Service;
 
 use Doctrine\ORM\Events;
-use DoctrineORMModuleTest\Framework\TestCase as TestCase;
+use DoctrineORMModuleTest\Assets\Entity\ResolveTarget;
+use DoctrineORMModuleTest\Assets\Entity\TargetEntity;
+use DoctrineORMModuleTest\Framework\TestCase;
 
 class EntityResolverFactoryTest extends TestCase
 {
-    public function testCanResolveTargetEntity()
+    public function testCanResolveTargetEntity(): void
     {
         $em            = $this->getEntityManager();
-        $classMetadata = $em->getClassMetadata(\DoctrineORMModuleTest\Assets\Entity\ResolveTarget::class);
+        $classMetadata = $em->getClassMetadata(ResolveTarget::class);
         $meta          = $classMetadata->associationMappings;
 
-        $this->assertSame(\DoctrineORMModuleTest\Assets\Entity\TargetEntity::class, $meta['target']['targetEntity']);
+        $this->assertSame(TargetEntity::class, $meta['target']['targetEntity']);
     }
 
-    public function testAssertSubscriberIsAdded()
+    public function testAssertSubscriberIsAdded(): void
     {
         $evm = $this->getEntityManager()->getEventManager();
 

--- a/test/DoctrineORMModuleTest/Service/FormAnnotationBuilderFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Service/FormAnnotationBuilderFactoryTest.php
@@ -2,9 +2,11 @@
 
 namespace DoctrineORMModuleTest\Service;
 
+use Doctrine\ORM\EntityManager;
 use DoctrineORMModule\Service\FormAnnotationBuilderFactory;
-use PHPUnit\Framework\TestCase;
+use Laminas\Form\FormElementManager;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \DoctrineORMModule\Service\FormAnnotationBuilderFactory}
@@ -16,12 +18,12 @@ class FormAnnotationBuilderFactoryTest extends TestCase
     /**
      * @group #352
      */
-    public function testFormElementManagerGetsInjected()
+    public function testFormElementManagerGetsInjected(): void
     {
-        $entityManager      = $this->getMockBuilder(\Doctrine\ORM\EntityManager::class)
+        $entityManager      = $this->getMockBuilder(EntityManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $formElementManager = $this->getMockBuilder(\Laminas\Form\FormElementManager::class)
+        $formElementManager = $this->getMockBuilder(FormElementManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -31,7 +33,7 @@ class FormAnnotationBuilderFactoryTest extends TestCase
         $serviceManager->setService('FormElementManager', $formElementManager);
 
         $annotationBuilderFactory = new FormAnnotationBuilderFactory('test');
-        $annotationBuilder = $annotationBuilderFactory->createService($serviceManager);
+        $annotationBuilder        = $annotationBuilderFactory->createService($serviceManager);
 
         $this->assertSame($formElementManager, $annotationBuilder->getFormFactory()->getFormElementManager());
     }

--- a/test/DoctrineORMModuleTest/Service/MigrationsCommandFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Service/MigrationsCommandFactoryTest.php
@@ -18,58 +18,54 @@
 
 namespace DoctrineORMModuleTest\Service;
 
+use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
+use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
 use DoctrineORMModule\Service\MigrationsCommandFactory;
 use DoctrineORMModuleTest\ServiceManagerFactory;
+use InvalidArgumentException;
+use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 
 /**
  * Tests for {@see \DoctrineORMModule\Service\MigrationsCommandFactory}
  *
- * @license MIT
- * @author Aleksandr Sandrovskiy <a.sandrovsky@gmail.com>
- *
  * @covers \DoctrineORMModule\Service\MigrationsCommandFactory
  */
 class MigrationsCommandFactoryTest extends TestCase
 {
-    /**
-     * @var \Laminas\ServiceManager\ServiceManager
-     */
+    /** @var ServiceManager */
     private $serviceLocator;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function setUp() : void
+    public function setUp(): void
     {
         $this->serviceLocator = ServiceManagerFactory::getServiceManager();
     }
 
-    public function testExecuteFactory()
+    public function testExecuteFactory(): void
     {
         $factory = new MigrationsCommandFactory('execute');
 
         $this->assertInstanceOf(
-            \Doctrine\Migrations\Tools\Console\Command\ExecuteCommand::class,
+            ExecuteCommand::class,
             $factory->createService($this->serviceLocator)
         );
     }
 
-    public function testDiffFactory()
+    public function testDiffFactory(): void
     {
         $factory = new MigrationsCommandFactory('diff');
 
         $this->assertInstanceOf(
-            \Doctrine\Migrations\Tools\Console\Command\DiffCommand::class,
+            DiffCommand::class,
             $factory->createService($this->serviceLocator)
         );
     }
 
-    public function testThrowException()
+    public function testThrowException(): void
     {
         $factory = new MigrationsCommandFactory('unknowncommand');
 
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $factory->createService($this->serviceLocator);
     }
 }

--- a/test/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Service/SQLLoggerCollectorFactoryTest.php
@@ -2,35 +2,32 @@
 
 namespace DoctrineORMModuleTest\Service;
 
-use PHPUnit\Framework\TestCase;
-use DoctrineORMModule\Service\SQLLoggerCollectorFactory;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Logging\SQLLogger;
 use Doctrine\ORM\Configuration as ORMConfiguration;
+use DoctrineORMModule\Collector\SQLLoggerCollector;
+use DoctrineORMModule\Service\SQLLoggerCollectorFactory;
 use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
 
 class SQLLoggerCollectorFactoryTest extends TestCase
 {
-    /**
-     * @var ServiceManager
-     */
+    /** @var ServiceManager */
     protected $services;
 
-    /**
-     * @var SQLLoggerCollectorFactory
-     */
+    /** @var SQLLoggerCollectorFactory */
     protected $factory;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
         $this->services = new ServiceManager();
-        $this->factory = new SQLLoggerCollectorFactory('orm_default');
+        $this->factory  = new SQLLoggerCollectorFactory('orm_default');
     }
 
-    public function testCreateSQLLoggerCollector()
+    public function testCreateSQLLoggerCollector(): void
     {
         $configuration = new ORMConfiguration();
         $this->services->setService('doctrine.configuration.orm_default', $configuration);
@@ -45,11 +42,11 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             ]
         );
         $service = $this->factory->createService($this->services);
-        $this->assertInstanceOf(\DoctrineORMModule\Collector\SQLLoggerCollector::class, $service);
-        $this->assertInstanceOf(\Doctrine\DBAL\Logging\SQLLogger::class, $configuration->getSQLLogger());
+        $this->assertInstanceOf(SQLLoggerCollector::class, $service);
+        $this->assertInstanceOf(SQLLogger::class, $configuration->getSQLLogger());
     }
 
-    public function testCreateSQLLoggerWithCustomConfiguration()
+    public function testCreateSQLLoggerWithCustomConfiguration(): void
     {
         $configuration = new ORMConfiguration();
         $this->services->setService('configuration_service_id', $configuration);
@@ -58,25 +55,23 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             [
                 'doctrine' => [
                     'sql_logger_collector' => [
-                        'orm_default' => [
-                            'configuration' => 'configuration_service_id',
-                        ],
+                        'orm_default' => ['configuration' => 'configuration_service_id'],
                     ],
                 ],
             ]
         );
         $this->factory->createService($this->services);
-        $this->assertInstanceOf(\Doctrine\DBAL\Logging\SQLLogger::class, $configuration->getSQLLogger());
+        $this->assertInstanceOf(SQLLogger::class, $configuration->getSQLLogger());
     }
 
-    public function testCreateSQLLoggerWithPreviousExistingLoggerChainsLoggers()
+    public function testCreateSQLLoggerWithPreviousExistingLoggerChainsLoggers(): void
     {
-        $originalLogger = $this->createMock(\Doctrine\DBAL\Logging\SQLLogger::class);
+        $originalLogger = $this->createMock(SQLLogger::class);
         $originalLogger
             ->expects($this->once())
             ->method('startQuery')
             ->with($this->equalTo('test query'));
-        $injectedLogger = $this->createMock(\Doctrine\DBAL\Logging\DebugStack::class);
+        $injectedLogger = $this->createMock(DebugStack::class);
         $injectedLogger
             ->expects($this->once())
             ->method('startQuery')
@@ -91,23 +86,21 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             [
                 'doctrine' => [
                     'sql_logger_collector' => [
-                        'orm_default' => [
-                            'sql_logger' => 'custom_logger',
-                        ],
+                        'orm_default' => ['sql_logger' => 'custom_logger'],
                     ],
                 ],
             ]
         );
         $this->factory->createService($this->services);
-        /* @var $logger \Doctrine\DBAL\Logging\SQLLogger */
         $logger = $configuration->getSQLLogger();
+        assert($logger instanceof SQLLogger);
         $logger->startQuery('test query');
     }
 
-    public function testCreateSQLLoggerWithCustomLogger()
+    public function testCreateSQLLoggerWithCustomLogger(): void
     {
         $configuration = new ORMConfiguration();
-        $logger = new DebugStack();
+        $logger        = new DebugStack();
         $this->services->setService('doctrine.configuration.orm_default', $configuration);
         $this->services->setService('logger_service_id', $logger);
         $this->services->setService(
@@ -115,9 +108,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             [
                 'doctrine' => [
                     'sql_logger_collector' => [
-                        'orm_default' => [
-                            'sql_logger' => 'logger_service_id',
-                        ],
+                        'orm_default' => ['sql_logger' => 'logger_service_id'],
                     ],
                 ],
             ]
@@ -126,7 +117,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
         $this->assertSame($logger, $configuration->getSQLLogger());
     }
 
-    public function testCreateSQLLoggerWithCustomName()
+    public function testCreateSQLLoggerWithCustomName(): void
     {
         $this->services->setService('doctrine.configuration.orm_default', new ORMConfiguration());
         $this->services->setService(
@@ -134,15 +125,13 @@ class SQLLoggerCollectorFactoryTest extends TestCase
             [
                 'doctrine' => [
                     'sql_logger_collector' => [
-                        'orm_default' => [
-                            'name' => 'test_collector_name',
-                        ],
+                        'orm_default' => ['name' => 'test_collector_name'],
                     ],
                 ],
             ]
         );
-        /* @var $service \DoctrineORMModule\Collector\SQLLoggerCollector */
         $service = $this->factory->createService($this->services);
+        assert($service instanceof SQLLoggerCollector);
         $this->assertSame('doctrine.sql_logger_collector.test_collector_name', $service->getName());
     }
 }

--- a/test/DoctrineORMModuleTest/ServiceManagerFactory.php
+++ b/test/DoctrineORMModuleTest/ServiceManagerFactory.php
@@ -2,25 +2,25 @@
 
 namespace DoctrineORMModuleTest;
 
+use Laminas\ModuleManager\ModuleManager;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\ServiceManager\ServiceManager;
+
+use function assert;
 
 /**
  * Utility used to retrieve a freshly bootstrapped application's service manager
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class ServiceManagerFactory
 {
     /**
      * Builds a new ServiceManager instance
      *
-     * @param  array|null     $configuration
-     * @return ServiceManager
+     * @param  array|null $configuration
      */
-    public static function getServiceManager(array $configuration = null)
+    public static function getServiceManager(?array $configuration = null): ServiceManager
     {
         $configuration        = $configuration ?: include __DIR__ . '/../config.php';
         $serviceManager       = new ServiceManager();
@@ -30,8 +30,8 @@ class ServiceManagerFactory
         $serviceManagerConfig->configureServiceManager($serviceManager);
         $serviceManager->setService('ApplicationConfig', $configuration);
 
-        /** @var $moduleManager \Laminas\ModuleManager\ModuleManager */
         $moduleManager = $serviceManager->get('ModuleManager');
+        assert($moduleManager instanceof ModuleManager);
         $moduleManager->loadModules();
 
         return $serviceManager;

--- a/test/DoctrineORMModuleTest/ServiceManagerFactory.php
+++ b/test/DoctrineORMModuleTest/ServiceManagerFactory.php
@@ -18,7 +18,7 @@ class ServiceManagerFactory
     /**
      * Builds a new ServiceManager instance
      *
-     * @param  array|null $configuration
+     * @param  mixed[]|null $configuration
      */
     public static function getServiceManager(?array $configuration = null): ServiceManager
     {

--- a/test/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/test/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -386,8 +386,12 @@ class MetadataGrapherTest extends TestCase
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      * @dataProvider injectMultipleRelationsWithBothBiAndMonoDirectional
      */
-    public function testDrawMultipleClassRelatedBothBiAndMonoDirectional($class1, $class2, $class3, $expected): void
-    {
+    public function testDrawMultipleClassRelatedBothBiAndMonoDirectional(
+        ClassMetadata $class1,
+        ClassMetadata $class2,
+        ClassMetadata $class3,
+        string $expected
+    ): void {
         $this->assertSame(
             $expected,
             $this->grapher->generateFromMetadata([$class1, $class2, $class3])
@@ -398,7 +402,7 @@ class MetadataGrapherTest extends TestCase
      * dataProvider to inject classes in every order possible into the test
      *     testDrawMultipleClassRelatedBothBiAndMonoDirectional
      *
-     * @return array
+     * @return list<array{ClassMetadata, ClassMetadata, ClassMetadata, string}>
      */
     public function injectMultipleRelationsWithBothBiAndMonoDirectional(): array
     {

--- a/test/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
+++ b/test/DoctrineORMModuleTest/Yuml/MetadataGrapherTest.php
@@ -2,27 +2,25 @@
 
 namespace DoctrineORMModuleTest\Yuml;
 
+use Doctrine\Common\Persistence\Mapping\ClassMetadata;
 use DoctrineORMModule\Yuml\MetadataGrapher;
 use PHPUnit\Framework\TestCase;
+
+use function get_class;
+use function str_replace;
+use function strtoupper;
 
 /**
  * Tests for the metadata to string converter
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class MetadataGrapherTest extends TestCase
 {
-    /**
-     * @var MetadataGrapher
-     */
+    /** @var MetadataGrapher */
     protected $grapher;
 
-    /**
-     * {@inheritDoc}
-     */
-    public function setUp() : void
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -32,9 +30,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawSimpleEntity()
+    public function testDrawSimpleEntity(): void
     {
-        $class = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class = $this->createMock(ClassMetadata::class);
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
         $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
@@ -45,15 +43,15 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawSimpleEntityWithFields()
+    public function testDrawSimpleEntityWithFields(): void
     {
-        $class = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class = $this->createMock(ClassMetadata::class);
         $class->expects($this->any())->method('getName')->will($this->returnValue('Simple\\Entity'));
         $class->expects($this->any())->method('getFieldNames')->will($this->returnValue(['a', 'b', 'c']));
         $class->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class->expects($this->any())->method('isIdentifier')->will(
             $this->returnCallback(
-                function ($field) {
+                static function ($field) {
                     return $field === 'a';
                 }
             )
@@ -65,9 +63,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawOneToOneUniDirectionalAssociation()
+    public function testDrawOneToOneUniDirectionalAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -75,7 +73,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
@@ -86,9 +84,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawOneToOneBiDirectionalAssociation()
+    public function testDrawOneToOneBiDirectionalAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -96,7 +94,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -111,9 +109,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawOneToOneBiDirectionalInverseAssociation()
+    public function testDrawOneToOneBiDirectionalInverseAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -122,7 +120,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -136,9 +134,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawOneToManyBiDirectionalAssociation()
+    public function testDrawOneToManyBiDirectionalAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -146,7 +144,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -161,9 +159,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawOneToManyBiDirectionalInverseAssociation()
+    public function testDrawOneToManyBiDirectionalInverseAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -171,7 +169,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -186,9 +184,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawManyToManyUniDirectionalAssociation()
+    public function testDrawManyToManyUniDirectionalAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -196,7 +194,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
@@ -207,14 +205,14 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawManyToManyUniDirectionalInverseAssociation()
+    public function testDrawManyToManyUniDirectionalInverseAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -228,9 +226,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawManyToManyBiDirectionalAssociation()
+    public function testDrawManyToManyBiDirectionalAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -238,7 +236,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -253,9 +251,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawManyToManyBiDirectionalInverseAssociation()
+    public function testDrawManyToManyBiDirectionalInverseAssociation(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -264,7 +262,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('getAssociationMappedByTargetField')->will($this->returnValue('a'));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['a']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('A'));
@@ -278,9 +276,9 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawManyToManyAssociationWithoutKnownInverseSide()
+    public function testDrawManyToManyAssociationWithoutKnownInverseSide(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('B'));
@@ -294,10 +292,10 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawInheritance()
+    public function testDrawInheritance(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $child  = get_class($this->createMock('stdClass'));
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue([]));
@@ -315,10 +313,10 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawInheritedFields()
+    public function testDrawInheritedFields(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $child  = get_class($this->createMock('stdClass'));
 
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
@@ -338,12 +336,12 @@ class MetadataGrapherTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      */
-    public function testDrawInheritedAssociations()
+    public function testDrawInheritedAssociations(): void
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
-        $class3 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
-        $class4 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
+        $class3 = $this->createMock(ClassMetadata::class);
+        $class4 = $this->createMock(ClassMetadata::class);
         $child  = get_class($this->createMock('stdClass'));
 
         $class1->expects($this->any())->method('getName')->will($this->returnValue('stdClass'));
@@ -360,7 +358,7 @@ class MetadataGrapherTest extends TestCase
             ->method('getAssociationTargetClass')
             ->will(
                 $this->returnCallback(
-                    function ($assoc) {
+                    static function ($assoc) {
                         return strtoupper($assoc);
                     }
                 )
@@ -388,11 +386,11 @@ class MetadataGrapherTest extends TestCase
      * @covers \DoctrineORMModule\Yuml\MetadataGrapher
      * @dataProvider injectMultipleRelationsWithBothBiAndMonoDirectional
      */
-    public function testDrawMultipleClassRelatedBothBiAndMonoDirectional($class1, $class2, $class3, $expected)
+    public function testDrawMultipleClassRelatedBothBiAndMonoDirectional($class1, $class2, $class3, $expected): void
     {
         $this->assertSame(
             $expected,
-            $this->grapher->generateFromMetadata([$class1, $class2,$class3])
+            $this->grapher->generateFromMetadata([$class1, $class2, $class3])
         );
     }
 
@@ -402,9 +400,9 @@ class MetadataGrapherTest extends TestCase
      *
      * @return array
      */
-    public function injectMultipleRelationsWithBothBiAndMonoDirectional()
+    public function injectMultipleRelationsWithBothBiAndMonoDirectional(): array
     {
-        $class1 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class1 = $this->createMock(ClassMetadata::class);
         $class1->expects($this->any())->method('getName')->will($this->returnValue('A'));
         $class1->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['c']));
         $class1->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
@@ -412,7 +410,7 @@ class MetadataGrapherTest extends TestCase
         $class1->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class1->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class2 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class2 = $this->createMock(ClassMetadata::class);
         $class2->expects($this->any())->method('getName')->will($this->returnValue('B'));
         $class2->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['c']));
         $class2->expects($this->any())->method('getAssociationTargetClass')->will($this->returnValue('C'));
@@ -420,14 +418,14 @@ class MetadataGrapherTest extends TestCase
         $class2->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(false));
         $class2->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
 
-        $class3 = $this->createMock(\Doctrine\Common\Persistence\Mapping\ClassMetadata::class);
+        $class3 = $this->createMock(ClassMetadata::class);
         $class3->expects($this->any())->method('getName')->will($this->returnValue('C'));
         $class3->expects($this->any())->method('getAssociationNames')->will($this->returnValue(['b']));
         $class3
             ->expects($this->any())
             ->method('getAssociationTargetClass')
             ->with($this->logicalOr($this->equalTo('b'), $this->equalTo('c')))
-            ->will($this->returnCallback([$this,'getAssociationTargetClassMock']));
+            ->will($this->returnCallback([$this, 'getAssociationTargetClassMock']));
         $class3->expects($this->any())->method('isAssociationInverseSide')->will($this->returnValue(true));
         $class3->expects($this->any())->method('isCollectionValuedAssociation')->will($this->returnValue(true));
         $class3->expects($this->any())->method('getFieldNames')->will($this->returnValue([]));
@@ -444,11 +442,8 @@ class MetadataGrapherTest extends TestCase
 
     /**
      * To mock getAssociationTargetClass method with args
-     *
-     * @param  string $a
-     * @return string
      */
-    public function getAssociationTargetClassMock($a)
+    public function getAssociationTargetClassMock(string $a): string
     {
         return strtoupper($a);
     }

--- a/test/DoctrineORMModuleTest/Yuml/YumlControllerFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Yuml/YumlControllerFactoryTest.php
@@ -2,50 +2,47 @@
 
 namespace DoctrineORMModuleTest\Yuml;
 
-use PHPUnit\Framework\TestCase;
 use DoctrineORMModule\Yuml\YumlController;
 use DoctrineORMModule\Yuml\YumlControllerFactory;
 use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use PHPUnit\Framework\TestCase;
 
 class YumlControllerFactoryTest extends TestCase
 {
-    public function testCreateService()
+    public function testCreateService(): void
     {
         $config = [
             'laminas-developer-tools' => [
-                'toolbar' => [
-                    'enabled' => true,
-                ],
+                'toolbar' => ['enabled' => true],
             ],
         ];
 
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-        $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
+        $pluginManager  = $this->getMockBuilder(AbstractPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
         $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
         $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
 
-        $factory = new YumlControllerFactory();
+        $factory    = new YumlControllerFactory();
         $controller = $factory->createService($pluginManager);
 
         $this->assertInstanceOf(YumlController::class, $controller);
     }
 
-    public function testCreateServiceWithNotEnabledToolbar()
+    public function testCreateServiceWithNotEnabledToolbar(): void
     {
         $config = [
             'laminas-developer-tools' => [
-                'toolbar' => [
-                    'enabled' => false,
-                ],
+                'toolbar' => ['enabled' => false],
             ],
         ];
 
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-        $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
+        $pluginManager  = $this->getMockBuilder(AbstractPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -54,18 +51,18 @@ class YumlControllerFactoryTest extends TestCase
 
         $factory = new YumlControllerFactory();
 
-        $this->expectException(\Laminas\ServiceManager\Exception\ServiceNotFoundException::class);
+        $this->expectException(ServiceNotFoundException::class);
         $factory->createService($pluginManager);
     }
 
-    public function testCreateServiceWithNoConfigKey()
+    public function testCreateServiceWithNoConfigKey(): void
     {
         $config = [
             'laminas-developer-tools' => [],
         ];
 
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-        $pluginManager = $this->getMockBuilder(AbstractPluginManager::class)
+        $pluginManager  = $this->getMockBuilder(AbstractPluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -74,7 +71,7 @@ class YumlControllerFactoryTest extends TestCase
 
         $factory = new YumlControllerFactory();
 
-        $this->expectException(\Laminas\ServiceManager\Exception\ServiceNotFoundException::class);
+        $this->expectException(ServiceNotFoundException::class);
         $factory->createService($pluginManager);
     }
 }

--- a/test/DoctrineORMModuleTest/Yuml/YumlControllerTest.php
+++ b/test/DoctrineORMModuleTest/Yuml/YumlControllerTest.php
@@ -3,30 +3,28 @@
 namespace DoctrineORMModuleTest\Yuml;
 
 use DoctrineORMModule\Yuml\YumlController;
+use Laminas\Http\Client;
+use Laminas\Http\Response;
+use Laminas\Mvc\Controller\Plugin\Redirect;
+use Laminas\Mvc\Controller\PluginManager;
 use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
+use UnexpectedValueException;
 
 /**
  * Tests for Yuml redirector controller
  *
- * @license MIT
  * @link    http://www.doctrine-project.org/
- * @author  Marco Pivetta <ocramius@gmail.com>
  */
 class YumlControllerTest extends TestCase
 {
-    /**
-     * @var YumlController
-     */
+    /** @var YumlController */
     protected $controller;
 
-    /**
-     * @var \Laminas\Http\Client|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var Client|PHPUnit_Framework_MockObject_MockObject */
     protected $httpClient;
 
-    /**
-     * @var \Laminas\Mvc\Controller\PluginManager|\PHPUnit_Framework_MockObject_MockObject
-     */
+    /** @var PluginManager|PHPUnit_Framework_MockObject_MockObject */
     protected $pluginManager;
 
     /**
@@ -34,11 +32,11 @@ class YumlControllerTest extends TestCase
      *
      * @covers \DoctrineORMModule\Yuml\YumlController::__construct
      */
-    public function setUp() : void
+    public function setUp(): void
     {
-        $this->httpClient     = $this->createMock(\Laminas\Http\Client::class);
-        $this->controller     = new YumlController($this->httpClient);
-        $this->pluginManager  = $this->getMockBuilder(\Laminas\Mvc\Controller\PluginManager::class)
+        $this->httpClient    = $this->createMock(Client::class);
+        $this->controller    = new YumlController($this->httpClient);
+        $this->pluginManager = $this->getMockBuilder(PluginManager::class)
             ->disableOriginalConstructor()
             ->getMock();
         $this->controller->setPluginManager($this->pluginManager);
@@ -47,11 +45,11 @@ class YumlControllerTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\YumlController::indexAction
      */
-    public function testIndexActionWillRedirectToYuml()
+    public function testIndexActionWillRedirectToYuml(): void
     {
-        $response = $this->createMock(\Laminas\Http\Response::class);
-        $controllerResponse = $this->createMock(\Laminas\Http\Response::class);
-        $redirect = $this->createMock(\Laminas\Mvc\Controller\Plugin\Redirect::class);
+        $response           = $this->createMock(Response::class);
+        $controllerResponse = $this->createMock(Response::class);
+        $redirect           = $this->createMock(Redirect::class);
         $this->httpClient->expects($this->any())->method('send')->will($this->returnValue($response));
         $response->expects($this->any())->method('isSuccess')->will($this->returnValue(true));
         $response->expects($this->any())->method('getBody')->will($this->returnValue('short-url'));
@@ -72,13 +70,13 @@ class YumlControllerTest extends TestCase
     /**
      * @covers \DoctrineORMModule\Yuml\YumlController::indexAction
      */
-    public function testIndexActionWillFailOnMalformedResponse()
+    public function testIndexActionWillFailOnMalformedResponse(): void
     {
-        $response = $this->createMock(\Laminas\Http\Response::class);
+        $response = $this->createMock(Response::class);
         $this->httpClient->expects($this->any())->method('send')->will($this->returnValue($response));
         $response->expects($this->any())->method('isSuccess')->will($this->returnValue(false));
 
-        $this->expectException(\UnexpectedValueException::class);
+        $this->expectException(UnexpectedValueException::class);
         $this->controller->indexAction();
     }
 }

--- a/test/testing.config.php
+++ b/test/testing.config.php
@@ -1,30 +1,35 @@
 <?php
+
+use Doctrine\DBAL\Driver\PDOSqlite\Driver;
+use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use DoctrineORMModuleTest\Assets\Entity\TargetEntity;
+use DoctrineORMModuleTest\Assets\Entity\TargetInterface;
+use DoctrineORMModuleTest\Assets\RepositoryClass;
+
 return [
     'doctrine' => [
         'configuration' => [
             'orm_default' => [
-                'default_repository_class_name' => \DoctrineORMModuleTest\Assets\RepositoryClass::class,
+                'default_repository_class_name' => RepositoryClass::class,
             ],
         ],
         'driver' => [
             'DoctrineORMModuleTest\Assets\Entity' => [
-                'class' => \Doctrine\ORM\Mapping\Driver\AnnotationDriver::class,
+                'class' => AnnotationDriver::class,
                 'cache' => 'array',
                 'paths' => [
                     __DIR__ . '/DoctrineORMModuleTest/Assets/Entity',
                 ],
             ],
             'orm_default' => [
-                'drivers' => [
-                    'DoctrineORMModuleTest\Assets\Entity' => 'DoctrineORMModuleTest\Assets\Entity',
-                ],
+                'drivers' => ['DoctrineORMModuleTest\Assets\Entity' => 'DoctrineORMModuleTest\Assets\Entity'],
             ],
         ],
         'entity_resolver' => [
             'orm_default' => [
                 'resolvers' => [
-                    \DoctrineORMModuleTest\Assets\Entity\TargetInterface::class
-                        => \DoctrineORMModuleTest\Assets\Entity\TargetEntity::class,
+                    TargetInterface::class
+                        => TargetEntity::class,
                 ],
             ],
         ],
@@ -32,16 +37,12 @@ return [
             'orm_default' => [
                 'configuration' => 'orm_default',
                 'eventmanager'  => 'orm_default',
-                'driverClass'   => \Doctrine\DBAL\Driver\PDOSqlite\Driver::class,
-                'params' => [
-                    'memory' => true,
-                ],
+                'driverClass'   => Driver::class,
+                'params' => ['memory' => true],
             ],
         ],
         'migrations_configuration' => [
-            'orm_default' => [
-                'directory' => 'build/',
-            ],
+            'orm_default' => ['directory' => 'build/'],
         ],
     ],
 ];


### PR DESCRIPTION
Upgraded packages:
- `doctrine/coding-standard`
- `ocramius/package-versions`

New package required: `composer/package-versions-deprecated`

Also: I clicked the button to migrate from travis-ci.org to travis-ci.com.

And finally, I prevent the installation of `doctrine/migrations` 2.3.0, this needs to be fixed in a separate PR