### PR TITLE
Enabled multiple migration configurations

### DIFF
--- a/src/DoctrineORMModule/Console/Helper/ConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/ConfigurationHelper.php
@@ -11,11 +11,17 @@ use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
 
+use function strrpos;
+use function substr;
+
 class ConfigurationHelper implements
     HelperInterface,
     ConfigurationHelperInterface
 {
+    /** @var HelperSet */
     protected $helperSet;
+
+    /** @var ContainerInterface */
     protected $container;
 
     public function __construct(ContainerInterface $container)
@@ -23,19 +29,19 @@ class ConfigurationHelper implements
         $this->container = $container;
     }
 
-    public function setHelperSet(HelperSet $helperSet = null): ConfigurationHelper
+    public function setHelperSet(?HelperSet $helperSet = null): ConfigurationHelper
     {
         $this->helperSet = $helperSet;
 
         return $this;
     }
 
-    public function getHelperSet()
+    public function getHelperSet(): ?HelperSet
     {
         return $this->helperSet;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'configuration';
     }
@@ -43,7 +49,7 @@ class ConfigurationHelper implements
     public function getMigrationConfig(InputInterface $input): Configuration
     {
         $objectManagerAlias = $input->getOptions()['object-manager'] ?? 'doctrine.entitymanager.orm_default';
-        $objectManagerName = substr($objectManagerAlias, strrpos($objectManagerAlias, '.') + 1);
+        $objectManagerName  = substr($objectManagerAlias, strrpos($objectManagerAlias, '.') + 1);
 
         return $this->container->get('doctrine.migrations_configuration.' . $objectManagerName);
     }

--- a/src/DoctrineORMModule/Console/Helper/ConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/ConfigurationHelper.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModule\Console\Helper;
+
+use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Tools\Console\Helper\ConfigurationHelperInterface;
+use Interop\Container\ContainerInterface;
+use Symfony\Component\Console\Helper\HelperInterface;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\InputInterface;
+
+class ConfigurationHelper implements
+    HelperInterface,
+    ConfigurationHelperInterface
+{
+    protected $helperSet;
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function setHelperSet(HelperSet $helperSet = null): ConfigurationHelper
+    {
+        $this->helperSet = $helperSet;
+
+        return $this;
+    }
+
+    public function getHelperSet()
+    {
+        return $this->helperSet;
+    }
+
+    public function getName()
+    {
+        return 'configuration';
+    }
+
+    public function getMigrationConfig(InputInterface $input): Configuration
+    {
+        $objectManagerAlias = $input->getOptions()['object-manager'] ?? 'doctrine.entitymanager.orm_default';
+        $objectManagerName = substr($objectManagerAlias, strrpos($objectManagerAlias, '.') + 1);
+
+        return $this->container->get('doctrine.migrations_configuration.' . $objectManagerName);
+    }
+}

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -49,14 +49,9 @@ class MigrationsConfigurationHelper implements
 
     public function getMigrationConfig(InputInterface $input): Configuration
     {
-        try {
-            $objectManagerAlias = $input->getOption('object-manager');
-        } catch (Throwable $e) {
-            $objectManagerAlias = 'doctrine.entitymanager.orm_default';
-        }
+        $objectManagerAlias = $input->getOption('object-manager') ?: 'doctrine.entitymanager.orm_default';
+        $objectManagerName  = substr($objectManagerAlias, strrpos($objectManagerAlias, '.'));
 
-        $objectManagerName = substr($objectManagerAlias, strrpos($objectManagerAlias, '.') + 1);
-
-        return $this->container->get('doctrine.migrations_configuration.' . $objectManagerName);
+        return $this->container->get('doctrine.migrations_configuration' . $objectManagerName);
     }
 }

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -29,7 +29,7 @@ class MigrationsConfigurationHelper implements
         $this->container = $container;
     }
 
-    public function setHelperSet(?HelperSet $helperSet = null): ConfigurationHelper
+    public function setHelperSet(?HelperSet $helperSet = null): MigrationsConfigurationHelper
     {
         $this->helperSet = $helperSet;
 

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -10,10 +10,8 @@ use Interop\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
-use Throwable;
 
-use function strrpos;
-use function substr;
+use function preg_match;
 
 class MigrationsConfigurationHelper implements
     HelperInterface,

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use function strrpos;
 use function substr;
 
-class ConfigurationHelper implements
+class MigrationsConfigurationHelper implements
     HelperInterface,
     ConfigurationHelperInterface
 {

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -10,6 +10,7 @@ use Interop\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
+use Throwable;
 
 use function strrpos;
 use function substr;
@@ -48,8 +49,13 @@ class MigrationsConfigurationHelper implements
 
     public function getMigrationConfig(InputInterface $input): Configuration
     {
-        $objectManagerAlias = $input->getOptions()['object-manager'] ?? 'doctrine.entitymanager.orm_default';
-        $objectManagerName  = substr($objectManagerAlias, strrpos($objectManagerAlias, '.') + 1);
+        try {
+            $objectManagerAlias = $input->getOption('object-manager');
+        } catch (Throwable $e) {
+            $objectManagerAlias = 'doctrine.entitymanager.orm_default';
+        }
+
+        $objectManagerName = substr($objectManagerAlias, strrpos($objectManagerAlias, '.') + 1);
 
         return $this->container->get('doctrine.migrations_configuration.' . $objectManagerName);
     }

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -51,11 +51,13 @@ class MigrationsConfigurationHelper implements
         $objectManagerAlias = $input->getOption('object-manager') ?: 'doctrine.entitymanager.orm_default';
 
         // Copied from DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory
-        if (! preg_match(
-            '/^doctrine\.((?<mappingType>orm|odm)\.|)(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/',
-            $objectManagerAlias,
-            $matches
-        )) {
+        if (
+            ! preg_match(
+                '/^doctrine\.((?<mappingType>orm|odm)\.|)(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/',
+                $objectManagerAlias,
+                $matches
+            )
+        ) {
             throw new RuntimeException('The object manager alias is invalid: ' . $objectManagerAlias);
         }
 

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -50,8 +50,14 @@ class MigrationsConfigurationHelper implements
     public function getMigrationConfig(InputInterface $input): Configuration
     {
         $objectManagerAlias = $input->getOption('object-manager') ?: 'doctrine.entitymanager.orm_default';
-        $objectManagerName  = substr($objectManagerAlias, strrpos($objectManagerAlias, '.'));
 
-        return $this->container->get('doctrine.migrations_configuration' . $objectManagerName);
+        // Copied from DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory
+        preg_match(
+            '/^doctrine\.((?<mappingType>orm|odm)\.|)(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/',
+            $objectManagerAlias,
+            $matches
+        );
+
+        return $this->container->get('doctrine.migrations_configuration.' . $matches['serviceName']);
     }
 }

--- a/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
+++ b/src/DoctrineORMModule/Console/Helper/MigrationsConfigurationHelper.php
@@ -7,6 +7,7 @@ namespace DoctrineORMModule\Console\Helper;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Tools\Console\Helper\ConfigurationHelperInterface;
 use Interop\Container\ContainerInterface;
+use RuntimeException;
 use Symfony\Component\Console\Helper\HelperInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\InputInterface;
@@ -50,11 +51,13 @@ class MigrationsConfigurationHelper implements
         $objectManagerAlias = $input->getOption('object-manager') ?: 'doctrine.entitymanager.orm_default';
 
         // Copied from DoctrineModule/ServiceFactory/AbstractDoctrineServiceFactory
-        preg_match(
+        if (! preg_match(
             '/^doctrine\.((?<mappingType>orm|odm)\.|)(?<serviceType>[a-z0-9_]+)\.(?<serviceName>[a-z0-9_]+)$/',
             $objectManagerAlias,
             $matches
-        );
+        )) {
+            throw new RuntimeException('The object manager alias is invalid: ' . $objectManagerAlias);
+        }
 
         return $this->container->get('doctrine.migrations_configuration.' . $matches['serviceName']);
     }

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineORMModule;
 
-use DoctrineORMModule\Console\Helper\ConfigurationHelper;
+use DoctrineORMModule\Console\Helper\MigrationsConfigurationHelper;
 use Laminas\DeveloperTools\ProfilerEvent;
 use Laminas\EventManager\EventInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
@@ -41,7 +41,7 @@ class Module implements
                         ->configure($event->getTarget());
 
                     $event->getTarget()->getHelperSet()->set(
-                        new ConfigurationHelper($event->getParam('ServiceManager'))
+                        new MigrationsConfigurationHelper($event->getParam('ServiceManager'))
                     );
                 },
                 1

--- a/src/DoctrineORMModule/Module.php
+++ b/src/DoctrineORMModule/Module.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineORMModule;
 
+use DoctrineORMModule\Console\Helper\ConfigurationHelper;
 use Laminas\DeveloperTools\ProfilerEvent;
 use Laminas\EventManager\EventInterface;
 use Laminas\ModuleManager\Feature\ConfigProviderInterface;
@@ -38,6 +39,10 @@ class Module implements
                         ->getParam('ServiceManager')
                         ->get(CliConfigurator::class)
                         ->configure($event->getTarget());
+
+                    $event->getTarget()->getHelperSet()->set(
+                        new ConfigurationHelper($event->getParam('ServiceManager'))
+                    );
                 },
                 1
             );

--- a/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
@@ -42,9 +42,7 @@ class MigrationsCommandFactory implements FactoryInterface
             throw new InvalidArgumentException();
         }
 
-        $command = new $className();
-
-        return $command;
+        return new $className();
     }
 
     /**

--- a/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
+++ b/src/DoctrineORMModule/Service/MigrationsCommandFactory.php
@@ -42,10 +42,7 @@ class MigrationsCommandFactory implements FactoryInterface
             throw new InvalidArgumentException();
         }
 
-        $configuration = $container->get('doctrine.migrations_configuration.orm_default');
-        $command       = new $className();
-
-        $command->setMigrationConfiguration($configuration);
+        $command = new $className();
 
         return $command;
     }

--- a/test/DoctrineORMModuleTest/Console/Helper/ConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/ConfigurationHelperTest.php
@@ -18,17 +18,11 @@
 
 namespace DoctrineORMModuleTest\Console\Helper;
 
-use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
-use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
-use DoctrineORMModule\Service\MigrationsCommandFactory;
-
-use Symfony\Component\Console\Input\ArrayInput;
-use Symfony\Component\Console\Input\InputInterface;
 use DoctrineORMModule\Console\Helper\ConfigurationHelper;
 use DoctrineORMModuleTest\ServiceManagerFactory;
-use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
 
 /**
  * Tests for {@see \DoctrineORMModule\Service\MigrationsCommandFactory}
@@ -58,7 +52,7 @@ class ConfigurationHelperTest extends TestCase
     public function testGetMigrationConfig(): void
     {
         $configurationHelper = new ConfigurationHelper($this->serviceLocator);
-        $configuration = $configurationHelper->getMigrationConfig(new ArrayInput([]));
+        $configuration       = $configurationHelper->getMigrationConfig(new ArrayInput([]));
 
         $this->assertEquals(
             $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),

--- a/test/DoctrineORMModuleTest/Console/Helper/ConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/ConfigurationHelperTest.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+namespace DoctrineORMModuleTest\Console\Helper;
+
+use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
+use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
+use DoctrineORMModule\Service\MigrationsCommandFactory;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use DoctrineORMModule\Console\Helper\ConfigurationHelper;
+use DoctrineORMModuleTest\ServiceManagerFactory;
+use InvalidArgumentException;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for {@see \DoctrineORMModule\Service\MigrationsCommandFactory}
+ *
+ * @covers \DoctrineORMModule\Service\MigrationsCommandFactory
+ */
+class ConfigurationHelperTest extends TestCase
+{
+    /** @var ServiceManager */
+    private $serviceLocator;
+
+    public function setUp(): void
+    {
+        $this->serviceLocator = ServiceManagerFactory::getServiceManager();
+    }
+
+    public function testCreate(): void
+    {
+        $configurationHelper = new ConfigurationHelper($this->serviceLocator);
+
+        $this->assertInstanceOf(
+            ConfigurationHelper::class,
+            $configurationHelper
+        );
+    }
+
+    public function testGetMigrationConfig(): void
+    {
+        $configurationHelper = new ConfigurationHelper($this->serviceLocator);
+        $configuration = $configurationHelper->getMigrationConfig(new ArrayInput([]));
+
+        $this->assertEquals(
+            $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),
+            $configuration
+        );
+    }
+}

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -55,10 +55,13 @@ class MigrationsConfigurationHelperTest extends TestCase
 
     public function testGetDefaultMigrationConfig(): void
     {
-        $request       = new Request();
-        $requestInput  = new RequestInput($request);
-        $helper        = new MigrationsConfigurationHelper($this->serviceLocator);
-        $configuration = $helper->getMigrationConfig($requestInput);
+        $inputOption     = new InputOption('object-manager', [], InputOption::VALUE_REQUIRED);
+        $inputDefinition = new InputDefinition([$inputOption]);
+        $request         = new Request([]);
+        $requestInput    = new RequestInput($request, $inputDefinition);
+        $helper          = new MigrationsConfigurationHelper($this->serviceLocator);
+
+        $configuration   = $helper->getMigrationConfig($requestInput);
 
         $this->assertEquals(
             $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -63,7 +63,7 @@ class MigrationsConfigurationHelperTest extends TestCase
 
         $configuration = $helper->getMigrationConfig($requestInput);
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),
             $configuration
         );

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -75,13 +75,6 @@ class MigrationsConfigurationHelperTest extends TestCase
      */
     public function testGetNonDefaultMigrationConfig(): void
     {
-        $this->expectException(ServiceNotFoundException::class);
-        $this->expectExceptionMessage(
-            'Unable to resolve service '
-                . '"doctrine.migrations_configuration.orm_some_other_name" to '
-                . 'a factory; are you certain you provided it during configuration?'
-        );
-
         $inputOption     = new InputOption('object-manager', [], InputOption::VALUE_REQUIRED);
         $inputDefinition = new InputDefinition([$inputOption]);
         $request         = new Request([
@@ -89,8 +82,13 @@ class MigrationsConfigurationHelperTest extends TestCase
             '--object-manager=doctrine.entitymanager.orm_some_other_name',
         ]);
         $requestInput    = new RequestInput($request, $inputDefinition);
-        $helper          = new MigrationsConfigurationHelper($this->serviceLocator);
 
-        $configuration = $helper->getMigrationConfig($requestInput);
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(
+            'Unable to resolve service '
+                . '"doctrine.migrations_configuration.orm_some_other_name" to '
+                . 'a factory; are you certain you provided it during configuration?'
+        );
+        (new MigrationsConfigurationHelper($this->serviceLocator))->getMigrationConfig($requestInput);
     }
 }

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -18,7 +18,7 @@
 
 namespace DoctrineORMModuleTest\Console\Helper;
 
-use DoctrineORMModule\Console\Helper\ConfigurationHelper;
+use DoctrineORMModule\Console\Helper\MigrationsConfigurationHelper;
 use DoctrineORMModuleTest\ServiceManagerFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
@@ -29,7 +29,7 @@ use Symfony\Component\Console\Input\ArrayInput;
  *
  * @covers \DoctrineORMModule\Service\MigrationsCommandFactory
  */
-class ConfigurationHelperTest extends TestCase
+class MigrationsConfigurationHelperTest extends TestCase
 {
     /** @var ServiceManager */
     private $serviceLocator;
@@ -41,18 +41,18 @@ class ConfigurationHelperTest extends TestCase
 
     public function testCreate(): void
     {
-        $configurationHelper = new ConfigurationHelper($this->serviceLocator);
+        $helper = new MigrationsConfigurationHelper($this->serviceLocator);
 
         $this->assertInstanceOf(
-            ConfigurationHelper::class,
-            $configurationHelper
+            MigrationsConfigurationHelper::class,
+            $helper
         );
     }
 
     public function testGetMigrationConfig(): void
     {
-        $configurationHelper = new ConfigurationHelper($this->serviceLocator);
-        $configuration       = $configurationHelper->getMigrationConfig(new ArrayInput([]));
+        $helper        = new MigrationsConfigurationHelper($this->serviceLocator);
+        $configuration = $helper->getMigrationConfig(new ArrayInput([]));
 
         $this->assertEquals(
             $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -66,8 +66,19 @@ class MigrationsConfigurationHelperTest extends TestCase
         );
     }
 
+    /**
+     * This test queries for a non-orm_default object manager
+     * and throws an exception when the configuration is not found
+     */
     public function testGetNonDefaultMigrationConfig(): void
     {
+        $this->expectException(ServiceNotFoundException::class);
+        $this->expectExceptionMessage(
+            'Unable to resolve service '
+                . '"doctrine.migrations_configuration.orm_some_other_name" to '
+                . 'a factory; are you certain you provided it during configuration?'
+        );
+
         $inputOption     = new InputOption('object-manager', [], InputOption::VALUE_REQUIRED);
         $inputDefinition = new InputDefinition([$inputOption]);
         $request         = new Request([
@@ -77,12 +88,6 @@ class MigrationsConfigurationHelperTest extends TestCase
         $requestInput    = new RequestInput($request, $inputDefinition);
         $helper          = new MigrationsConfigurationHelper($this->serviceLocator);
 
-        try {
-            $configuration = $helper->getMigrationConfig($requestInput);
-        } catch (ServiceNotFoundException $e) {
-            $this->assertEquals('Unable to resolve service '
-                . '"doctrine.migrations_configuration.orm_some_other_name" to '
-                . 'a factory; are you certain you provided it during configuration?', $e->getMessage());
-        }
+        $configuration = $helper->getMigrationConfig($requestInput);
     }
 }

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -121,7 +121,7 @@ class MigrationsConfigurationHelperTest extends TestCase
         $inputDefinition = new InputDefinition([$inputOption]);
         $request         = new Request([
             'index.php',
-            '--object-manager=doctrine.entitymanager.orm_default',
+            '--object-manager=doctrine.entitymanager.orm_other',
         ]);
         $requestInput    = new RequestInput($request, $inputDefinition);
 
@@ -129,7 +129,7 @@ class MigrationsConfigurationHelperTest extends TestCase
             ->getMigrationConfig($requestInput);
 
         $this->assertSame(
-            $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),
+            $this->serviceLocator->get('doctrine.migrations_configuration.orm_other'),
             $configuration
         );
     }

--- a/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
+++ b/test/DoctrineORMModuleTest/Console/Helper/MigrationsConfigurationHelperTest.php
@@ -61,7 +61,7 @@ class MigrationsConfigurationHelperTest extends TestCase
         $requestInput    = new RequestInput($request, $inputDefinition);
         $helper          = new MigrationsConfigurationHelper($this->serviceLocator);
 
-        $configuration   = $helper->getMigrationConfig($requestInput);
+        $configuration = $helper->getMigrationConfig($requestInput);
 
         $this->assertEquals(
             $this->serviceLocator->get('doctrine.migrations_configuration.orm_default'),

--- a/test/testing.config.php
+++ b/test/testing.config.php
@@ -81,9 +81,9 @@ return [
     'service_manager' => [
         'factories' => [
             'doctrine.entitymanager.orm_other' => new EntityManagerFactory('orm_other'),
-            'doctrine.connection.orm_other' => new DBALConnectionFactory('orm_other'),
+            'doctrine.connection.orm_other'    => new DBALConnectionFactory('orm_other'),
             'doctrine.configuration.orm_other' => new ConfigurationFactory('orm_other'),
-            'doctrine.eventmanager.orm_other' => new EventManagerFactory('orm_other'),
+            'doctrine.eventmanager.orm_other'  => new EventManagerFactory('orm_other'),
         ],
     ],
 ];

--- a/test/testing.config.php
+++ b/test/testing.config.php
@@ -2,6 +2,10 @@
 
 use Doctrine\DBAL\Driver\PDOSqlite\Driver;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
+use DoctrineModule\Service\EventManagerFactory;
+use DoctrineORMModule\Service\ConfigurationFactory;
+use DoctrineORMModule\Service\DBALConnectionFactory;
+use DoctrineORMModule\Service\EntityManagerFactory;
 use DoctrineORMModuleTest\Assets\Entity\TargetEntity;
 use DoctrineORMModuleTest\Assets\Entity\TargetInterface;
 use DoctrineORMModuleTest\Assets\RepositoryClass;
@@ -10,6 +14,9 @@ return [
     'doctrine' => [
         'configuration' => [
             'orm_default' => [
+                'default_repository_class_name' => RepositoryClass::class,
+            ],
+            'orm_other' => [
                 'default_repository_class_name' => RepositoryClass::class,
             ],
         ],
@@ -24,9 +31,18 @@ return [
             'orm_default' => [
                 'drivers' => ['DoctrineORMModuleTest\Assets\Entity' => 'DoctrineORMModuleTest\Assets\Entity'],
             ],
+            'orm_other' => [
+                'drivers' => ['DoctrineORMModuleTest\Assets\Entity' => 'DoctrineORMModuleTest\Assets\Entity'],
+            ],
         ],
         'entity_resolver' => [
             'orm_default' => [
+                'resolvers' => [
+                    TargetInterface::class
+                        => TargetEntity::class,
+                ],
+            ],
+            'orm_other' => [
                 'resolvers' => [
                     TargetInterface::class
                         => TargetEntity::class,
@@ -40,9 +56,34 @@ return [
                 'driverClass'   => Driver::class,
                 'params' => ['memory' => true],
             ],
+            'orm_other' => [
+                'configuration' => 'orm_other',
+                'eventmanager'  => 'orm_other',
+                'driverClass'   => Driver::class,
+                'params' => ['memory' => true],
+            ],
+        ],
+        'eventmanager' => [
+            'orm_other' => [],
         ],
         'migrations_configuration' => [
             'orm_default' => ['directory' => 'build/'],
+            'orm_other' => [
+                'directory' => 'build/orm_other',
+                'name'      => 'Doctrine Database Migrations 2',
+                'namespace' => 'Application\MigrationsOther',
+                'table'     => 'MigrationsOther',
+                'column'    => 'versionOther',
+            ],
+        ],
+    ],
+
+    'service_manager' => [
+        'factories' => [
+            'doctrine.entitymanager.orm_other' => new EntityManagerFactory('orm_other'),
+            'doctrine.connection.orm_other' => new DBALConnectionFactory('orm_other'),
+            'doctrine.configuration.orm_other' => new ConfigurationFactory('orm_other'),
+            'doctrine.eventmanager.orm_other' => new EventManagerFactory('orm_other'),
         ],
     ],
 ];


### PR DESCRIPTION
As I learned the migrations code in preparation for moving to Migrations 3 I found the reason behind why it was only possible to create a migration for one configuration.  The object manager was hard coded because injecting the configuration was not a strait-forward affair.  I used a Helper injected into the console application's HelperSet to provide the configuration and voila multiple configurations are now supported.

I wanted to create this PR now, before Migrations 3, because I just don't think it will ever happen otherwise.