### PR TITLE
Removed default value for orm_module organize_migrations because it c…

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -168,7 +168,7 @@ return [
                 'migrations' => [],
                 'all_or_nothing' => false,
                 'check_database_platform' => true,
-                'organize_migrations' => 'year', // year or year_and_month
+                // 'organize_migrations' => 'year', // year or year_and_month or leave unchanged for default
                 'custom_template' => null,
             ],
         ],


### PR DESCRIPTION
…annot be un-set

https://github.com/doctrine/DoctrineORMModule/issues/641
This issue points out that the default value of false for migration organization cannot be reset to false once set.  This is a problem with `doctrine/migrations` and a PR will be made to fix the issue there.