### PR TITLE
Allow config DependencyFactory

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -170,6 +170,7 @@ return [
                 'check_database_platform' => true,
                 // 'organize_migrations' => 'year', // year or year_and_month or leave unchanged for default
                 'custom_template' => null,
+                'dependency_factory_services' => [],
             ],
         ],
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -35,3 +35,54 @@ Configure
             ],
         ],
     ];
+
+Set a Custom configuration into DependencyFactory
+-------------------------------
+
+.. code:: php
+
+    return [
+        'doctrine' => [
+            'migrations_configuration' => [
+                'orm_default' => [
+                    'dependency_factory_services' => [
+                        'service_to_overwrite' => 'custom_service_id'
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+Note : 'custom_service_id' has to be defined in your DIC
+
+
+This configuration allows you, for example, to define a custom version comparator
+
+.. code:: php
+
+    return [
+        'doctrine' => [
+            'migrations_configuration' => [
+                'orm_default' => [
+                    'dependency_factory_services' => [
+                        \Doctrine\Migrations\Version\Comparator::class => MyComparator::class
+                    ],
+                ],
+            ],
+        ],
+    ];
+
+List of services that can be overwritten
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Doctrine\\Migrations\\Finder\\MigrationFinder
+- Doctrine\\Migrations\\Metadata\\Storage\\MetadataStorage
+- Doctrine\\Migrations\\MigrationsRepository
+- Doctrine\\Migrations\\Provider\\SchemaProvider
+- Doctrine\\Migrations\\Tools\\Console\\MigratorConfigurationFactory
+- Doctrine\\Migrations\\Version\\Comparator
+- Doctrine\\Migrations\\Version\\MigrationFactory
+- Doctrine\\Migrations\\Version\\MigrationPlanCalculator
+- Doctrine\\Migrations\\Version\\MigrationStatusCalculator
+- Psr\\Log\\LoggerInterface
+- Symfony\\Component\\Stopwatch\\Stopwatch


### PR DESCRIPTION
this PR allow to config DependencyFactory from config

It it useful for example to change Doctrine\Migrations\Version\Comparator strategies.

Example of usage : 

 ```php
use Doctrine\Migrations\Version\Comparator;

[
    'doctrine' => [
        'migrations_configuration' => [
            'orm_default' => [
                'dependency_factory_services' => [
                    Comparator::class => MyComparator::class
                ],
            ],
        ],
    ],
];

 ```

idea from https://github.com/doctrine/migrations/issues/1074


