### PR TITLE
Prevent E_USER_DEPRECATED error when creating RunSqlCommand.

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -195,10 +195,11 @@ return [
         'factories' => [
             CliConfigurator::class => Service\CliConfiguratorFactory::class,
             'Doctrine\ORM\EntityManager' => Service\EntityManagerAliasCompatFactory::class,
+            // DBAL commands
+            'doctrine.dbal_cmd.runsql' => Service\RunSqlCommandFactory::class,
         ],
         'invokables' => [
             // DBAL commands
-            'doctrine.dbal_cmd.runsql' => Console\Command\RunSqlCommand::class,
             'doctrine.dbal_cmd.import' => Console\Command\ImportCommand::class,
             // ORM Commands
             'doctrine.orm_cmd.clear_cache_metadata' => Command\ClearCache\MetadataCommand::class,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -274,8 +274,7 @@ Laminas Configuration
 How to Override RunSqlCommand Creation
 -------------------------
 
-The following Laminas configuration can be used to override the `creation
-<../src/DoctrineORMModule/Service/RunSqlCommandFactory.php>`_ of the
+The following Laminas configuration can be used to override the creation of the
 ``Doctrine\DBAL\Tools\Console\Command\RunSqlCommand`` instance used by this
 module.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -227,7 +227,7 @@ How to Use Naming Strategy
 `Official documentation 
 <https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/namingstrategy.html>`__
 
-Zend Configuration
+Laminas Configuration
 
 .. code:: php
 
@@ -252,7 +252,7 @@ How to Use Quote Strategy
 `Official
 documentation <https://www.doctrine-project.org/projects/doctrine-orm/en/current/reference/basic-mapping.html#quoting-reserved-words>`__
 
-Zend Configuration
+Laminas Configuration
 
 .. code:: php
 
@@ -267,6 +267,24 @@ Zend Configuration
                 'orm_default' => [
                     'quote_strategy' => 'Doctrine\ORM\Mapping\AnsiQuoteStrategy',
                 ],
+            ],
+        ],
+    ];
+
+How to Override RunSqlCommand Creation
+-------------------------
+
+The following Laminas configuration can be used to override the `creation
+<../src/DoctrineORMModule/Service/RunSqlCommandFactory.php>`_ of the
+``Doctrine\DBAL\Tools\Console\Command\RunSqlCommand`` instance used by this
+module.
+
+.. code:: php
+
+    return [
+        'service_manager' => [
+            'factories' => [
+                'doctrine.dbal_cmd.runsql' => MyCustomRunSqlCommandFactory::class,
             ],
         ],
     ];

--- a/src/DoctrineORMModule/Service/RunSqlCommandFactory.php
+++ b/src/DoctrineORMModule/Service/RunSqlCommandFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModule\Service;
+
+use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider;
+use Interop\Container\ContainerInterface;
+use Laminas\ServiceManager\FactoryInterface;
+use Laminas\ServiceManager\ServiceLocatorInterface;
+
+use function class_exists;
+
+class RunSqlCommandFactory implements FactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
+    {
+        if (class_exists(SingleConnectionProvider::class)) {
+            return new RunSqlCommand(
+                new SingleConnectionProvider($container->get('doctrine.connection.orm_default'))
+            );
+        }
+
+        return new RunSqlCommand();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $container)
+    {
+        return $this($container, RunSqlCommand::class);
+    }
+}

--- a/test/DoctrineORMModuleTest/Service/RunSqlCommandFactoryTest.php
+++ b/test/DoctrineORMModuleTest/Service/RunSqlCommandFactoryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModuleTest\Service;
+
+use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
+use DoctrineORMModule\Service\RunSqlCommandFactory;
+use DoctrineORMModuleTest\ServiceManagerFactory;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \DoctrineORMModule\Service\RunSqlCommandFactory
+ */
+class RunSqlCommandFactoryTest extends TestCase
+{
+    /** @var ServiceManager */
+    private $serviceLocator;
+
+    public function setUp(): void
+    {
+        $this->serviceLocator = ServiceManagerFactory::getServiceManager();
+    }
+
+    public function testCreateCommand(): void
+    {
+        $factory = new RunSqlCommandFactory();
+
+        $this->assertInstanceOf(
+            RunSqlCommand::class,
+            $factory->createService($this->serviceLocator)
+        );
+    }
+}


### PR DESCRIPTION
Version 2.11 of doctrine/dbal triggers an E_USER_DEPRECATED error when
instantiating a RunSqlCommand without a ConnectionProvider. Create a
factory for instantiating this command that passes a
SingleConnectionProvider if that class exists.

https://github.com/doctrine/dbal/blob/2.11.0/lib/Doctrine/DBAL/Tools/Console/Command/RunSqlCommand.php#L42

Would this solution be acceptable? Is there a better way to ensure backwards
compatibility since version 2.10 of doctrine/dbal does not support this?