### PR TITLE
Removed migrations_configuration from services

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -229,7 +229,6 @@ return [
         'sql_logger_collector'     => Service\SQLLoggerCollectorFactory::class,
         'mapping_collector'        => Service\MappingCollectorFactory::class,
         'formannotationbuilder'    => Service\FormAnnotationBuilderFactory::class,
-        'migrations_configuration' => Service\MigrationsConfigurationFactory::class,
         'migrations_cmd'           => Service\MigrationsCommandFactory::class,
     ],
 


### PR DESCRIPTION
This config from migrations v1&2 was left in the module.config.php file when upgrading to migrations 3