### PR TITLE
Update docs to reflect 4.0.x as the current version

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -22,7 +22,7 @@
       "branchName": "3.2.x",
       "slug": "3.2.x",
       "current": false,
-      "maintained": true
+      "maintained": false
     },
     {
       "name": "3.1.x",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -36,7 +36,7 @@
       "branchName": "3.0.x",
       "slug": "3.0.x",
       "current": false,
-      "maintained": true
+      "maintained": false
     },
     {
       "name": "2.x",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -6,9 +6,9 @@
   "docsSlug": "doctrine-orm-module",
   "versions": [
     {
-      "name": "3.1.x",
-      "branchName": "3.1.x",
-      "slug": "3.1.x",
+      "name": "4.0.x",
+      "branchName": "4.0.x",
+      "slug": "4.0.x",
       "current": true,
       "maintained": true,
       "aliases": [
@@ -18,17 +18,25 @@
       ]
     },
     {
+      "name": "3.2.x",
+      "branchName": "3.2.x",
+      "slug": "3.2.x",
+      "current": false,
+      "maintained": true
+    },
+    {
+      "name": "3.1.x",
+      "branchName": "3.1.x",
+      "slug": "3.1.x",
+      "current": false,
+      "maintained": true
+    },
+    {
       "name": "3.0.x",
       "branchName": "3.0.x",
       "slug": "3.0.x",
       "current": false,
       "maintained": true
-    },
-    {
-      "name": "3.x",
-      "branchName": "3.x",
-      "slug": "3.x",
-      "maintained": false
     },
     {
       "name": "2.x",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -29,7 +29,7 @@
       "branchName": "3.1.x",
       "slug": "3.1.x",
       "current": false,
-      "maintained": true
+      "maintained": false
     },
     {
       "name": "3.0.x",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Doctrine ORM Module for Laminas
+Doctrine ORM Module for Laminas
+===============================
 
 [![Build Status](https://github.com/doctrine/DoctrineORMModule/workflows/Continuous%20Integration/badge.svg)](https://github.com/doctrine/DoctrineORMModule/actions)
-[![Code Coverage](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/3.1.x/graph/badge.svg)](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/3.1.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/4.0.x/graph/badge.svg)](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/4.0.x)
 
 DoctrineORMModule integrates Doctrine ORM with Laminas quickly and easily.
 
@@ -12,13 +13,14 @@ DoctrineORMModule integrates Doctrine ORM with Laminas quickly and easily.
 
 ## Branches
 
-There are two active branches and one bug-fix only branch.   
+There is one active branch:
+
+* 4.0.x - Support for PHP 8.0
+
+There are two inactive branches: 
 
 * 3.0.x - Support for Migrations 1 & 2
 * 3.2.x - Support for Migrations 3
-
-Branch 3.1.x also supports Migrations 3 but new features required the 3.2.x branch to be created and now all enhancements happen on 3.2.x.
-3.1.x will continue to receive bug fixes only.
 
 ## Installation
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,8 @@
-Doctrine ORM Module for Zend Framework
-======================================
+Doctrine ORM Module for Laminas
+===============================
 
-This module works with Zend Framework 2 and 3.
+This module integrates `Doctrine ORM <https://www.doctrine-project.org/projects/orm.html>`_
+with `Laminas <https://getlaminas.org/>`_ (formerly Zend Framework).
 
 .. toctree::
     :caption: Table of Contents

--- a/docs/miscellaneous.rst
+++ b/docs/miscellaneous.rst
@@ -2,13 +2,13 @@ Miscellaneous
 =============
 
 The items listed below are optional and intended to enhance 
-integration between Zend Framework and Doctrine 2.
+integration between Laminas and Doctrine ORM.
 
 ObjectExists Validator and  NoObjectExists Validator
 ----------------------------------------------------
 
 ObjectExists and NoObjectExists are validators similar to
-`Zend Validators <https://framework.zend.com/manual/2.4/en/modules/zend.validator.html>`_. 
+`Laminas Validators <https://docs.laminas.dev/laminas-validator/>`_.
 You can pass a variety of options to determine validity.
 The most basic use case requires an entity manager, an entity, and
 a field. You also have the option of specifying a query\_builder Closure


### PR DESCRIPTION
With the release of `4.0.0` is looks like the file `.doctrine-project.json` has not been updated accordingly. This leads to https://www.doctrine-project.org/projects/DoctrineORMModule.html showing wrong information, where the `4.0.x` series is listed as unmaintained.

This PR updates `.doctrine-project.json` to reflect that 4.0.x is the current and maintained version of this project.