### PR TITLE
Have `DoctrinePaginator` implement `JsonSerializable` to improve cache key creation

### DIFF
--- a/src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace DoctrineORMModule\Paginator\Adapter;
 
 use Doctrine\ORM\Tools\Pagination\Paginator;
+use JsonSerializable;
 use Laminas\Paginator\Adapter\AdapterInterface;
 
 /**
  * Paginator adapter for the Laminas\Paginator component
  */
-class DoctrinePaginator implements AdapterInterface
+class DoctrinePaginator implements AdapterInterface, JsonSerializable
 {
     /** @var Paginator */
     protected $paginator;
@@ -54,5 +55,16 @@ class DoctrinePaginator implements AdapterInterface
     public function count()
     {
         return $this->paginator->count();
+    }
+
+    /**
+     * @return array{select: string, count_select: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'select' => $this->paginator->getQuery()->getSQL(),
+            'count_select' => $this->paginator->count(),
+        ];
     }
 }

--- a/test/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/FormEntity.php
@@ -20,7 +20,7 @@ class FormEntity
     protected $id;
 
     /**
-     * @ORM\Column(type="bool")
+     * @ORM\Column(type="boolean")
      *
      * @var bool
      */

--- a/test/DoctrineORMModuleTest/Assets/Entity/Issue237.php
+++ b/test/DoctrineORMModuleTest/Assets/Entity/Issue237.php
@@ -6,7 +6,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity
- * @ORM\Table(name="doctrine_orm_module_form_entity")
+ * @ORM\Table(name="doctrine_orm_module_form_entity_issue237")
  */
 class Issue237
 {

--- a/test/DoctrineORMModuleTest/Paginator/AdapterTest.php
+++ b/test/DoctrineORMModuleTest/Paginator/AdapterTest.php
@@ -12,9 +12,10 @@ use DoctrineORMModuleTest\Assets\Entity\Test;
 use DoctrineORMModuleTest\Assets\Fixture\TestFixture;
 use DoctrineORMModuleTest\Framework\TestCase;
 
+use function class_exists;
 use function count;
 
-class AdapterTestIgnore extends TestCase
+class AdapterTest extends TestCase
 {
     /** @var QueryBuilder */
     protected $queryBuilder;
@@ -28,6 +29,12 @@ class AdapterTestIgnore extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        if (! class_exists(FixtureLoader::class)) {
+            $this->markTestIncomplete(
+                'DataFixtures must be installed to run this test.'
+            );
+        }
 
         $this->createDb();
         $loader = new FixtureLoader();

--- a/test/DoctrineORMModuleTest/Paginator/AdapterTest.php
+++ b/test/DoctrineORMModuleTest/Paginator/AdapterTest.php
@@ -89,4 +89,14 @@ class AdapterTest extends TestCase
             $this->assertEquals($expectedItem, $actual[$key]);
         }
     }
+
+    public function testJsonSerialize(): void
+    {
+        $result = $this->paginatorAdapter->jsonSerialize();
+
+        $this->assertArrayHasKey('select', $result);
+        $this->assertArrayHasKey('count_select', $result);
+        $this->assertSame($result['count_select'], $this->paginator->count());
+        $this->assertSame($result['select'], $this->paginator->getQuery()->getSQL());
+    }
 }


### PR DESCRIPTION
fixes #669

Adds `JsonSerializable` to `src/DoctrineORMModule/Paginator/Adapter/DoctrinePaginator.php` to optimize cache-key generation in `laminas/laminas-paginator` `_getCacheInternalId()`.