### PR TITLE
Updated slugs for website generation

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -1,9 +1,7 @@
 {
   "active": true,
   "name": "Doctrine ORM Module for Laminas",
-  "shortName": "Doctrine ORM Module",
-  "slug": "DoctrineORMModule",
-  "docsSlug": "doctrine-orm-module",
+  "slug": "doctrine-orm-module",
   "versions": [
     {
       "name": "4.0",
@@ -21,21 +19,18 @@
       "name": "3.2",
       "branchName": "3.2.x",
       "slug": "3.2",
-      "current": false,
       "maintained": false
     },
     {
       "name": "3.1",
       "branchName": "3.1.x",
       "slug": "3.1",
-      "current": false,
       "maintained": false
     },
     {
       "name": "3.0",
       "branchName": "3.0.x",
-      "slug": "3.0.x",
-      "current": false,
+      "slug": "3.0",
       "maintained": false
     },
     {


### PR DESCRIPTION
This updates the slugs for this module used on the Doctrine website to be in line with all other Doctrine components, i.e. not using camel case. Besides, simplifies `.dotrine-project.json`.

When merging this PR, https://github.com/doctrine/doctrine-website/pull/421 needs to be merged as a follow-up to keep the slugs listed here in `.doctrine-project.json` and in the website repository in `projects.yml` in sync.