### PR TITLE
Updated docs and readme to include installation notes for PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 Doctrine ORM Module for Laminas
 ===============================
 
-[![Build Status](https://github.com/doctrine/DoctrineORMModule/workflows/Continuous%20Integration/badge.svg)](https://github.com/doctrine/DoctrineORMModule/actions)
-[![Code Coverage](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/4.0.x/graph/badge.svg)](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/4.0.x)
+[![Build Status](https://github.com/doctrine/DoctrineORMModule/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/doctrine/DoctrineORMModule/actions/workflows/continuous-integration.yml?query=branch%3A4.1.x)
+[![Code Coverage](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/4.1.x/graph/badge.svg)](https://codecov.io/gh/doctrine/DoctrineORMModule/branch/4.1.x)
 [![Latest Stable Version](https://poser.pugx.org/doctrine/doctrine-orm-module/v/stable.png)](https://packagist.org/packages/doctrine/doctrine-orm-module)
 [![Total Downloads](https://poser.pugx.org/doctrine/doctrine-orm-module/downloads.png)](https://packagist.org/packages/doctrine/doctrine-orm-module)
 
-DoctrineORMModule integrates Doctrine ORM with Laminas quickly and easily.
+The DoctrineORMModule leverages [DoctrineModule](https://github.com/doctrine/DoctrineModule/) and integrates
+[Doctrine ORM](https://github.com/doctrine/orm) with [Laminas](https://getlaminas.org/) quickly
+and easily. The following features are intended to work out of the box: 
 
   - Doctrine ORM support
   - Multiple ORM entity managers
@@ -21,8 +23,40 @@ The sources files for the documentation can be found in the [`docs` dir](./docs/
 
 ## Installation
 
-Run the following to install this library:
+Run the following to install this library using [Composer](https://getcomposer.org/):
 
 ```bash
 composer require doctrine/doctrine-orm-module
 ```
+
+### Note on PHP 8.0 or later
+
+[DoctrineModule](https://github.com/doctrine/DoctrineModule/) provides an integration with 
+[laminas-cache](https://docs.laminas.dev/laminas-cache/), which currently comes with some storage adapters which 
+are not compatible with PHP 8.0 or later. To prevent installation of these unused cache adapters, you will need 
+to add the following to your `composer.json` file:
+
+```
+    "require": {
+         "doctrine/doctrine-orm-module": "^4.1.0"
+    },
+    "replace": {
+        "laminas/laminas-cache-storage-adapter-apc": "*",
+        "laminas/laminas-cache-storage-adapter-dba": "*",
+        "laminas/laminas-cache-storage-adapter-memcache": "*",
+        "laminas/laminas-cache-storage-adapter-memcached": "*",
+        "laminas/laminas-cache-storage-adapter-mongodb": "*",
+        "laminas/laminas-cache-storage-adapter-wincache": "*",
+        "laminas/laminas-cache-storage-adapter-xcache": "*",
+        "laminas/laminas-cache-storage-adapter-zend-server": "*"
+    }
+```
+
+Consult the [laminas-cache documentation](https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed)
+for further information on this issue.
+
+## Documentation
+
+Please check the [documentation on the Doctrine website](https://www.doctrine-project.org/projects/doctrine-orm-module.html)
+for more detailed information on features provided by this component. The source files for the documentation can be
+found in the [docs directory](./docs/en).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ composer require doctrine/doctrine-orm-module
 are not compatible with PHP 8.0 or later. To prevent installation of these unused cache adapters, you will need 
 to add the following to your `composer.json` file:
 
-```
+```json
     "require": {
          "doctrine/doctrine-orm-module": "^4.1.0"
     },

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1,8 +1,55 @@
 Doctrine ORM Module for Laminas
 ===============================
 
-This module integrates `Doctrine ORM <https://www.doctrine-project.org/projects/orm.html>`_
-with `Laminas <https://getlaminas.org/>`_.
+The DoctrineORMModule leverages `DoctrineModule <https://www.doctrine-project.org/projects/doctrine-module/en/current/index.html>`__
+and integrates `Doctrine ORM <https://www.doctrine-project.org/projects/doctrine-orm/en/current/index.html>`__
+with `Laminas <https://getlaminas.org/>`__ quickly and easily. The following features are intended
+to work out of the box:
+
+  - Doctrine ORM support
+  - Multiple ORM entity managers
+  - Multiple DBAL connections
+  - Reuse existing PDO connections in DBAL connection
+
+Installation
+------------
+
+Run the following to install this library using `Composer <https://getcomposer.org/>`__:
+
+.. code:: bash
+
+   $ composer require doctrine/doctrine-orm-module
+
+Note on PHP 8.0 or later
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+`DoctrineModule <https://www.doctrine-project.org/projects/doctrine-module/en/current/index.html>`__
+provides an integration with `laminas-cache <https://docs.laminas.dev/laminas-cache/>`__, which
+currently comes with some storage adapters which are not compatible with PHP 8.0 or later. To
+prevent installation of these unused cache adapters, you will need to add the following to your
+``composer.json`` file:
+
+.. code::
+
+    "require": {
+         "doctrine/doctrine-orm-module": "^4.1.0"
+    },
+    "replace": {
+        "laminas/laminas-cache-storage-adapter-apc": "*",
+        "laminas/laminas-cache-storage-adapter-dba": "*",
+        "laminas/laminas-cache-storage-adapter-memcache": "*",
+        "laminas/laminas-cache-storage-adapter-memcached": "*",
+        "laminas/laminas-cache-storage-adapter-mongodb": "*",
+        "laminas/laminas-cache-storage-adapter-wincache": "*",
+        "laminas/laminas-cache-storage-adapter-xcache": "*",
+        "laminas/laminas-cache-storage-adapter-zend-server": "*"
+    }
+
+Consult the `laminas-cache documentation <https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed>`__
+for further information on this issue.
+
+Next Steps
+----------
 
 .. toctree::
     :caption: Table of Contents
@@ -13,4 +60,3 @@ with `Laminas <https://getlaminas.org/>`_.
     cache
     migrations
     miscellaneous
-

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -29,7 +29,7 @@ currently comes with some storage adapters which are not compatible with PHP 8.0
 prevent installation of these unused cache adapters, you will need to add the following to your
 ``composer.json`` file:
 
-.. code::
+.. code:: json
 
     "require": {
          "doctrine/doctrine-orm-module": "^4.1.0"


### PR DESCRIPTION
Since end users might not directly look into the documentation of `DoctrineModule`, I have added the installation notes regarding PHP 8 to the documentation of `DoctrineORMModule` as well.

Technically, the troubles installing with PHP 8 come from the laminas-cache integration in `DoctrineModule`, but since that is a requirement of `DoctrineORMModule`, the same limitations apply here.