### PR TITLE
Remove PHP version config from `composer.json`

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -1,41 +1,16 @@
-
 name: "Coding Standards"
 
 on:
   pull_request:
     branches:
       - "*.x"
-      - "master"
   push:
     branches:
       - "*.x"
-      - "master"
 
 jobs:
   coding-standards:
     name: "Coding Standards"
-    runs-on: "ubuntu-20.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "7.4"
-          - "8.0"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php-version }}"
-          tools: "cs2pr"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
-
-      # https://github.com/doctrine/.github/issues/3
-      - name: "Run PHP_CodeSniffer"
-        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.2.0"
+    with:
+      php-version: '7.4'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -59,13 +59,25 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+        if: "! startsWith(matrix.php-version, '8')"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist --no-suggest"
 
+      - name: "Install dependencies with Composer (--ignore-platform-req=php)"
+        uses: "ramsey/composer-install@v1"
+        if: "startsWith(matrix.php-version, '8')"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "--prefer-dist --no-suggest --ignore-platform-req=php"
+
       - name: "Remove optional dependencies"
-        if: "${{ !matrix.optional_dependencies }}"
+        if: "! startsWith(matrix.php-version, '8') && ! matrix.optional_dependencies"
         run: "composer remove --dev doctrine/data-fixtures doctrine/migrations"
+
+      - name: "Remove optional dependencies (--ignore-platform-req=php)"
+        if: "startsWith(matrix.php-version, '8') && ! matrix.optional_dependencies"
+        run: "composer remove --ignore-platform-req=php --dev doctrine/data-fixtures doctrine/migrations"
 
       - name: "Configure test application"
         run: "cp ci/config/application.config.php config/application.config.php"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,4 +1,3 @@
-
 name: "Continuous Integration"
 
 on:

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,38 +8,10 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    runs-on: "ubuntu-20.04"
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@v2"
-
-      - name: "Release"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:release"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-      - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:create-merge-up-pull-request"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-      - name: "Create new milestones"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:create-milestones"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.2.0"
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+      GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
+      ORGANIZATION_ADMIN_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+      SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,4 +1,3 @@
-
 name: "Static Analysis"
 
 on:

--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,6 @@
         }
     ],
     "config": {
-        "platform": {
-            "php": "7.3"
-        },
         "sort-packages": true
     },
     "extra": {
@@ -48,7 +45,7 @@
         }
     },
     "require":           {
-        "php":                                  "^7.3 || ^8.0",
+        "php":                                  "^7.3 || ~8.0.0",
         "composer/package-versions-deprecated": "^1.11",
         "doctrine/dbal":                        "^2.10",
         "doctrine/doctrine-module":             "^4.0",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.11.2@6fba5eb554f9507b72932f9c75533d8af593688d">
+  <file src="vendor/laminas/laminas-servicemanager/src/Exception/CyclicAliasException.php">
+    <ParseError occurrences="7">
+      <code>)</code>
+      <code>,</code>
+      <code>,</code>
+      <code>:</code>
+      <code>=&gt;</code>
+      <code>fn</code>
+      <code>fn</code>
+    </ParseError>
+  </file>
+  <file src="vendor/laminas/laminas-servicemanager/src/ServiceManager.php">
+    <ParseError occurrences="2">
+      <code>=&gt;</code>
+      <code>fn</code>
+    </ParseError>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -5,6 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />


### PR DESCRIPTION
The PHP version should not be set to a simulated version, but rather be the real version tests are running with. This requries --ignore-platform-req=php for tests with PHP 8.0 or later. See installation notes of DoctrineModule or laminas-cache, which explains why this is needed to get legacy cache adapters running.