### PR TITLE
Setup PHPStan and upgrade upstream workflows

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.2.0"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.3.0"
     with:
-      php-version: '7.4'
+      php-version: '8.0'
+      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.2.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.3.0"
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,30 +9,9 @@ on:
       - "*.x"
 
 jobs:
-  static-analysis-psalm:
-    name: "Static Analysis with Psalm"
-    runs-on: "ubuntu-20.04"
-
-    strategy:
-      matrix:
-        php-version:
-          - "8.0"
-
-    steps:
-      - name: "Checkout code"
-        uses: "actions/checkout@v2"
-
-      - name: "Install PHP"
-        uses: "shivammathur/setup-php@v2"
-        with:
-          coverage: "none"
-          php-version: "${{ matrix.php-version }}"
-
-      - name: "Install dependencies with Composer"
-        uses: "ramsey/composer-install@v1"
-        with:
-          dependency-versions: "highest"
-          composer-options: "--prefer-dist --no-suggest --ignore-platform-req=php"
-
-      - name: "Run a static analysis with vimeo/psalm"
-        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc) --php-version=8.0"
+  static-analysis:
+    name: "Static Analysis"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.3.0"
+    with:
+      php-version: '8.0'
+      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-serializer": "^2.11.0",
         "ocramius/proxy-manager": "^2.2.0",
+        "phpstan/phpstan": "^1.1",
         "phpunit/phpunit": "^9.5.10",
         "squizlabs/php_codesniffer": "^3.6.1",
         "vimeo/psalm": "^4.12.0"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,5 @@
+parameters:
+    level: 1
+    paths:
+        - src
+        - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 1
+    level: 2
     paths:
         - src
         - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,15 @@
 parameters:
-    level: 2
+    level: 3
     paths:
         - src
         - tests
+    ignoreErrors:
+        -
+            message: '#Return type .* of method DoctrineORMModule\\Yuml\\YumlController::indexAction\(\)#'
+            path: src/Yuml/YumlController.php
+        -
+            message: '#Method DoctrineORMModule\\CliConfigurator::getHelpers\(\) should return#'
+            path: src/CliConfigurator.php
+        -
+            message: '#Method DoctrineORMModuleTest\\Listener\\CliConfiguratorTest::dataProviderForTestValidCommands\(\) should return#'
+            path: tests/CliConfiguratorTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="7"
+    phpVersion="8.0"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"

--- a/src/CliConfigurator.php
+++ b/src/CliConfigurator.php
@@ -95,7 +95,7 @@ class CliConfigurator
     }
 
     /**
-     * @return Helper[]
+     * @return array<string,Helper>
      */
     private function getHelpers(EntityManagerInterface $objectManager): array
     {
@@ -104,6 +104,7 @@ class CliConfigurator
             'em' => new EntityManagerHelper($objectManager),
         ];
 
+        // this is only available with DBAL 2.x
         if (class_exists(ConnectionHelper::class)) {
             $helpers['db'] = new ConnectionHelper($objectManager->getConnection());
         }

--- a/src/Collector/MappingCollector.php
+++ b/src/Collector/MappingCollector.php
@@ -29,7 +29,7 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
     protected $name;
 
     /** @var ClassMetadataFactory|null */
-    protected $classMetadataFactory = [];
+    protected $classMetadataFactory = null;
 
     /** @var ClassMetadata[] indexed by class name */
     protected $classes = [];

--- a/src/Options/EntityManager.php
+++ b/src/Options/EntityManager.php
@@ -55,9 +55,6 @@ class EntityManager extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return self
-     */
     public function getConnection(): string
     {
         return 'doctrine.connection.' . $this->connection;
@@ -70,9 +67,6 @@ class EntityManager extends AbstractOptions
         return $this;
     }
 
-    /**
-     * @return self
-     */
     public function getEntityResolver(): string
     {
         return 'doctrine.entity_resolver.' . $this->entityResolver;

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -16,6 +16,7 @@ use Laminas\ServiceManager\Exception\InvalidArgumentException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function is_string;
+use function method_exists;
 use function sprintf;
 
 class ConfigurationFactory extends DoctrineConfigurationFactory
@@ -146,9 +147,12 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
             $config->setSecondLevelCacheConfiguration($cacheConfiguration);
         }
 
-        $filterSchemaAssetsExpression = $options->getFilterSchemaAssetsExpression();
-        if ($filterSchemaAssetsExpression) {
-            $config->setFilterSchemaAssetsExpression($filterSchemaAssetsExpression);
+        // only works for DBAL 2.x, not for 3.x
+        if (method_exists($config, 'setFilterSchemaAssetsExpression')) {
+            $filterSchemaAssetsExpression = $options->getFilterSchemaAssetsExpression();
+            if ($filterSchemaAssetsExpression) {
+                $config->setFilterSchemaAssetsExpression($filterSchemaAssetsExpression);
+            }
         }
 
         $className = $options->getDefaultRepositoryClassName();
@@ -161,10 +165,7 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
         return $config;
     }
 
-    /**
-     * @return mixed
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function createService(ServiceLocatorInterface $serviceLocator): Configuration
     {
         return $this($serviceLocator, Configuration::class);
     }

--- a/src/Service/DBALConnectionFactory.php
+++ b/src/Service/DBALConnectionFactory.php
@@ -14,6 +14,7 @@ use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function array_key_exists;
 use function array_merge;
+use function assert;
 use function is_string;
 
 /**
@@ -29,7 +30,8 @@ class DBALConnectionFactory extends AbstractFactory
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, ?array $options = null)
     {
         $options = $this->getOptions($serviceLocator, 'connection');
-        $pdo     = $options->getPdo();
+        assert($options instanceof DBALConnection);
+        $pdo = $options->getPdo();
 
         if (is_string($pdo)) {
             $pdo = $serviceLocator->get($pdo);

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -24,6 +24,6 @@ class DoctrineObjectHydratorFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator->getServiceLocator(), DoctrineObject::class);
+        return $this($serviceLocator, DoctrineObject::class);
     }
 }

--- a/src/Service/EntityManagerFactory.php
+++ b/src/Service/EntityManagerFactory.php
@@ -9,6 +9,8 @@ use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\EntityManager as DoctrineORMModuleEntityManager;
 use Interop\Container\ContainerInterface;
 
+use function assert;
+
 class EntityManagerFactory extends AbstractFactory
 {
     /**
@@ -18,7 +20,8 @@ class EntityManagerFactory extends AbstractFactory
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $options    = $this->getOptions($container, 'entitymanager');
+        $options = $this->getOptions($container, 'entitymanager');
+        assert($options instanceof DoctrineORMModuleEntityManager);
         $connection = $container->get($options->getConnection());
         $config     = $container->get($options->getConfiguration());
 

--- a/src/Service/EntityResolverFactory.php
+++ b/src/Service/EntityResolverFactory.php
@@ -13,6 +13,8 @@ use Interop\Container\ContainerInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 
+use function assert;
+
 class EntityResolverFactory extends AbstractFactory
 {
     /**
@@ -20,7 +22,8 @@ class EntityResolverFactory extends AbstractFactory
      */
     public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
-        $options      = $this->getOptions($container, 'entity_resolver');
+        $options = $this->getOptions($container, 'entity_resolver');
+        assert($options instanceof EntityResolver);
         $eventManager = $container->get($options->getEventManager());
         $resolvers    = $options->getResolvers();
 

--- a/src/Service/MappingCollectorFactory.php
+++ b/src/Service/MappingCollectorFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineORMModule\Service;
 
+use BadMethodCallException;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Collector\MappingCollector;
 use Interop\Container\ContainerInterface;
@@ -39,5 +40,6 @@ class MappingCollectorFactory extends AbstractFactory
 
     public function getOptionsClass(): string
     {
+        throw new BadMethodCallException();
     }
 }

--- a/src/Service/ObjectMultiCheckboxFactory.php
+++ b/src/Service/ObjectMultiCheckboxFactory.php
@@ -35,6 +35,6 @@ class ObjectMultiCheckboxFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator->getServiceLocator(), ObjectMultiCheckbox::class);
+        return $this($serviceLocator, ObjectMultiCheckbox::class);
     }
 }

--- a/src/Service/ObjectRadioFactory.php
+++ b/src/Service/ObjectRadioFactory.php
@@ -35,6 +35,6 @@ class ObjectRadioFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator->getServiceLocator(), ObjectRadio::class);
+        return $this($serviceLocator, ObjectRadio::class);
     }
 }

--- a/src/Service/ObjectSelectFactory.php
+++ b/src/Service/ObjectSelectFactory.php
@@ -35,6 +35,6 @@ class ObjectSelectFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator->getServiceLocator(), ObjectSelect::class);
+        return $this($serviceLocator, ObjectSelect::class);
     }
 }

--- a/src/Yuml/YumlController.php
+++ b/src/Yuml/YumlController.php
@@ -10,6 +10,8 @@ use Laminas\Http\Response;
 use Laminas\Mvc\Controller\AbstractActionController;
 use UnexpectedValueException;
 
+use function assert;
+
 /**
  * Utility to generate Yuml compatible strings from metadata graphs
  */
@@ -31,6 +33,7 @@ class YumlController extends AbstractActionController
     public function indexAction(): Response
     {
         $request = $this->getRequest();
+        assert($request instanceof Request);
         $this->httpClient->setMethod(Request::METHOD_POST);
         $this->httpClient->setParameterPost(['dsl_text' => $request->getPost('dsl_text')]);
         $response = $this->httpClient->send();

--- a/tests/Assets/Entity/FormEntity.php
+++ b/tests/Assets/Entity/FormEntity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DoctrineORMModuleTest\Assets\Entity;
 
+use DateTime;
 use Doctrine\ORM\Mapping as ORM;
 use Laminas\Form\Annotation as Form;
 

--- a/tests/Assets/GraphEntity/Address.php
+++ b/tests/Assets/GraphEntity/Address.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineORMModuleTest\Assets\GraphEntity;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -24,9 +23,4 @@ class Address
      * @var int
      */
     protected $id;
-
-    public function __construct()
-    {
-        $this->groups = new ArrayCollection();
-    }
 }

--- a/tests/Assets/Types/MoneyType.php
+++ b/tests/Assets/Types/MoneyType.php
@@ -6,6 +6,7 @@ namespace DoctrineORMModuleTest\Assets\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
+use stdClass;
 
 /**
  * My custom datatype.
@@ -25,9 +26,9 @@ class MoneyType extends Type
     /**
      * @param mixed $value
      */
-    public function convertToPHPValue($value, AbstractPlatform $platform): Money
+    public function convertToPHPValue($value, AbstractPlatform $platform): object
     {
-        return new Money($value);
+        return new stdClass();
     }
 
     /**

--- a/tests/CliConfiguratorTest.php
+++ b/tests/CliConfiguratorTest.php
@@ -226,6 +226,7 @@ class CliConfiguratorTest extends TestCase
             ],
         ];
 
+        // this is only available with DBAL 2.x
         if (class_exists(ImportCommand::class)) {
             $data[] = [
                 'dbal:import',

--- a/tests/Collector/MappingCollectorTest.php
+++ b/tests/Collector/MappingCollectorTest.php
@@ -8,8 +8,8 @@ use Doctrine\Persistence\Mapping\ClassMetadata;
 use Doctrine\Persistence\Mapping\ClassMetadataFactory;
 use DoctrineORMModule\Collector\MappingCollector;
 use Laminas\Mvc\MvcEvent;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 
 use function assert;
 use function serialize;
@@ -20,7 +20,7 @@ use function unserialize;
  */
 class MappingCollectorTest extends TestCase
 {
-    /** @var ClassMetadataFactory|PHPUnit_Framework_MockObject_MockObject */
+    /** @var ClassMetadataFactory&MockObject */
     protected $metadataFactory;
 
     /** @var MappingCollector */

--- a/tests/Service/ConfigurationFactoryTest.php
+++ b/tests/Service/ConfigurationFactoryTest.php
@@ -19,6 +19,8 @@ use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
+use function assert;
+
 class ConfigurationFactoryTest extends TestCase
 {
     /** @var ServiceManager */
@@ -328,6 +330,7 @@ class ConfigurationFactoryTest extends TestCase
         $this->assertInstanceOf(CacheConfiguration::class, $secondLevelCache);
 
         $cacheFactory = $secondLevelCache->getCacheFactory();
+        assert($cacheFactory instanceof DefaultCacheFactory);
         $this->assertInstanceOf(DefaultCacheFactory::class, $cacheFactory);
         $this->assertEquals('my_dir', $cacheFactory->getFileLockRegionDirectory());
 

--- a/tests/Yuml/YumlControllerTest.php
+++ b/tests/Yuml/YumlControllerTest.php
@@ -9,8 +9,8 @@ use Laminas\Http\Client;
 use Laminas\Http\Response;
 use Laminas\Mvc\Controller\Plugin\Redirect;
 use Laminas\Mvc\Controller\PluginManager;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use PHPUnit_Framework_MockObject_MockObject;
 use UnexpectedValueException;
 
 /**
@@ -23,10 +23,10 @@ class YumlControllerTest extends TestCase
     /** @var YumlController */
     protected $controller;
 
-    /** @var Client|PHPUnit_Framework_MockObject_MockObject */
+    /** @var Client&MockObject */
     protected $httpClient;
 
-    /** @var PluginManager|PHPUnit_Framework_MockObject_MockObject */
+    /** @var PluginManager&MockObject */
     protected $pluginManager;
 
     /**


### PR DESCRIPTION
This PR adds PhpStan. Currently only with level 3, but might rise that in the future.

Beside, this PR lets both PhpStan and Psalm run under PHP 8.0 (before, Psalm was running with PHP 7.4). This works by upgrading the upstream workflows to 1.3.0, see https://github.com/doctrine/.github/pull/27 for further information.