### PR TITLE
Deprecate `createService()` methods as laminas-servicemanager 3.x is already required

### DIFF
--- a/src/Service/CliConfiguratorFactory.php
+++ b/src/Service/CliConfiguratorFactory.php
@@ -21,6 +21,8 @@ class CliConfiguratorFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -165,6 +165,9 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
         return $config;
     }
 
+    /**
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     */
     public function createService(ServiceLocatorInterface $serviceLocator): Configuration
     {
         return $this($serviceLocator, Configuration::class);

--- a/src/Service/DBALConfigurationFactory.php
+++ b/src/Service/DBALConfigurationFactory.php
@@ -44,6 +44,8 @@ class DBALConfigurationFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return Configuration
      */
     public function createService(ServiceLocatorInterface $serviceLocator)

--- a/src/Service/DBALConnectionFactory.php
+++ b/src/Service/DBALConnectionFactory.php
@@ -74,6 +74,8 @@ class DBALConnectionFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return Connection
      */
     public function createService(ServiceLocatorInterface $serviceLocator)

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -21,6 +21,8 @@ class DoctrineObjectHydratorFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/EntityManagerAliasCompatFactory.php
+++ b/src/Service/EntityManagerAliasCompatFactory.php
@@ -32,6 +32,7 @@ class EntityManagerAliasCompatFactory implements FactoryInterface
      *
      * @deprecated this method was introduced to allow aliasing of service `Doctrine\ORM\EntityManager`
      *             from `doctrine.entitymanager.orm_default`
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      *
      * @return EntityManager
      */

--- a/src/Service/EntityManagerFactory.php
+++ b/src/Service/EntityManagerFactory.php
@@ -36,6 +36,8 @@ class EntityManagerFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return EntityManager
      */
     public function createService(ContainerInterface $container)

--- a/src/Service/EntityResolverFactory.php
+++ b/src/Service/EntityResolverFactory.php
@@ -45,6 +45,8 @@ class EntityResolverFactory extends AbstractFactory
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $container)
     {

--- a/src/Service/MappingCollectorFactory.php
+++ b/src/Service/MappingCollectorFactory.php
@@ -31,6 +31,8 @@ class MappingCollectorFactory extends AbstractFactory
     /**
      * {@inheritDoc}
      *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @return MappingCollector
      */
     public function createService(ServiceLocatorInterface $container)

--- a/src/Service/MigrationsCommandFactory.php
+++ b/src/Service/MigrationsCommandFactory.php
@@ -105,6 +105,8 @@ class MigrationsCommandFactory implements FactoryInterface
     }
 
     /**
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
+     *
      * @throws InvalidArgumentException
      */
     public function createService(ServiceLocatorInterface $serviceLocator): DoctrineCommand

--- a/src/Service/ObjectMultiCheckboxFactory.php
+++ b/src/Service/ObjectMultiCheckboxFactory.php
@@ -32,6 +32,8 @@ class ObjectMultiCheckboxFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/ObjectRadioFactory.php
+++ b/src/Service/ObjectRadioFactory.php
@@ -32,6 +32,8 @@ class ObjectRadioFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/ObjectSelectFactory.php
+++ b/src/Service/ObjectSelectFactory.php
@@ -32,6 +32,8 @@ class ObjectSelectFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/ReservedWordsCommandFactory.php
+++ b/src/Service/ReservedWordsCommandFactory.php
@@ -24,6 +24,8 @@ class ReservedWordsCommandFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/RunSqlCommandFactory.php
+++ b/src/Service/RunSqlCommandFactory.php
@@ -24,6 +24,8 @@ class RunSqlCommandFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Service/SQLLoggerCollectorFactory.php
+++ b/src/Service/SQLLoggerCollectorFactory.php
@@ -59,6 +59,8 @@ class SQLLoggerCollectorFactory implements FactoryInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {

--- a/src/Yuml/YumlControllerFactory.php
+++ b/src/Yuml/YumlControllerFactory.php
@@ -17,6 +17,8 @@ class YumlControllerFactory implements FactoryInterface
 {
     /**
      * Create service
+     *
+     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
      */
     public function createService(ServiceLocatorInterface $serviceLocator): YumlController
     {


### PR DESCRIPTION
This deprecates the `createService()` methods which are a left-over from laminas-servicemanager 2.x. Since we already require laminas-servicemanager 3.x for a while, we should remove these methods in the next major release, hence, in the next minor release we mark them as deprecated. That is what this PR does.