### PR TITLE
Add missing dependencies to composer.json to prevent unwanted soft dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,10 +46,20 @@
     },
     "require": {
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
+        "ext-json": "*",
+        "container-interop/container-interop": "^1.2.0",
         "doctrine/dbal": "^2.13.4 || ^3.1.3",
+        "doctrine/doctrine-laminas-hydrator": "^2.2.1",
         "doctrine/doctrine-module": "^4.2.1",
+        "doctrine/event-manager": "^1.1.1",
         "doctrine/orm": "^2.9.6",
         "doctrine/persistence": "^2.2.2",
+        "laminas/laminas-eventmanager": "^3.4.0",
+        "laminas/laminas-modulemanager": "^2.11.0",
+        "laminas/laminas-mvc": "^3.3.0",
+        "laminas/laminas-paginator": "^2.11.0",
+        "laminas/laminas-servicemanager": "^3.7.0",
+        "laminas/laminas-stdlib": "^3.6.1",
         "symfony/console": "^5.3.0"
     },
     "require-dev": {
@@ -60,7 +70,6 @@
         "laminas/laminas-developer-tools": "^2.2.0",
         "laminas/laminas-i18n": "^2.11.3",
         "laminas/laminas-log": "^2.13.1",
-        "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-serializer": "^2.11.0",
         "ocramius/proxy-manager": "^2.2.0",
         "phpstan/phpstan": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "container-interop/container-interop": "^1.2.0",
         "doctrine/dbal": "^2.13.4 || ^3.1.3",
         "doctrine/doctrine-laminas-hydrator": "^2.2.1",
-        "doctrine/doctrine-module": "^4.2.1",
+        "doctrine/doctrine-module": "^4.2.2",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/orm": "^2.9.6",
         "doctrine/persistence": "^2.2.2",


### PR DESCRIPTION
Using [composer-require-checker](https://github.com/maglnet/ComposerRequireChecker) I checked for symbols of libraries which are not in our `require` section of `composer.json`. Such dependencies are called soft dependencies and are usually a bad thing, because their version might change because of changes in upstream libraries, hence, causing bugs for end users. 

(The same has already been done for DoctrineModule in https://github.com/doctrine/DoctrineModule/pull/751.)

The output of composer-require-checker is now as follows:

```
ComposerRequireChecker 3.5.1@f1a5905265b9464d57a7e26ae80b05b7c1411830
The following 16 unknown symbols were found:
+-----------------------------------------------------------------------+--------------------+
| Unknown Symbol                                                        | Guessed Dependency |
+-----------------------------------------------------------------------+--------------------+
| DoctrineModule\Form\Element\ObjectMultiCheckbox                       |                    |
| DoctrineModule\Form\Element\ObjectRadio                               |                    |
| DoctrineModule\Form\Element\ObjectSelect                              |                    |
| Doctrine\DBAL\Tools\Console\Command\ImportCommand                     |                    |
| Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper                   |                    |
| Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager |                    |
| Doctrine\Migrations\Configuration\Migration\ConfigurationArray        |                    |
| Doctrine\Migrations\DependencyFactory                                 |                    |
| Doctrine\Migrations\Tools\Console\Command\DoctrineCommand             |                    |
| Doctrine\Migrations\Tools\Console\Command\VersionCommand              |                    |
| Laminas\DeveloperTools\Collector\AutoHideInterface                    |                    |
| Laminas\DeveloperTools\Collector\CollectorInterface                   |                    |
| Laminas\DeveloperTools\ProfilerEvent                                  |                    |
| Laminas\Http\Client                                                   |                    |
| Laminas\Http\Request                                                  |                    |
| Laminas\Http\Response                                                 |                    |
+-----------------------------------------------------------------------+--------------------+
```

- The first three issues on DoctrineModule is because the tool doesn't understand the polyfillls, so that's all fine.
- The two issues regarding DBAL is because we some symbols of DBAL 2 are not in DBAL 3 anymore, so that's fine as well.
- The issues regarding Doctrine\Migrations are because that is an optional dependency, so that's fine as well.
- The issues regarding Laminas\DeveloperTools are for the same reason, optional dependency.
- The issues regarding Laminas\Http are only related to scenarios when Laminas\DeveloperTools is used. We could add that to `suggest`, but I do not think that is needed. Feel free to comment.