### PR TITLE
Added EntityBasedFormBuilder for annotation-based form creation 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,6 +73,7 @@
         "laminas/laminas-serializer": "^2.11.0",
         "ocramius/proxy-manager": "^2.2.0",
         "phpstan/phpstan": "^1.2.0",
+        "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.10",
         "squizlabs/php_codesniffer": "^3.6.1",
         "vimeo/psalm": "^4.13.0"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,6 @@ parameters:
         -
             message: '#Parameter \#1 .* of method DoctrineORMModule\\Options\\Configuration.* stdClass given#'
             path: tests/Options/ConfigurationOptionsTest.php
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+

--- a/src/Form/Annotation/DoctrineAnnotationListener.php
+++ b/src/Form/Annotation/DoctrineAnnotationListener.php
@@ -1,0 +1,412 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModule\Form\Annotation;
+
+use ArrayObject;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use DoctrineORMModule\Form\Element\EntitySelect;
+use Laminas\EventManager\AbstractListenerAggregate;
+use Laminas\EventManager\EventInterface;
+use Laminas\EventManager\EventManagerInterface;
+use Laminas\Form\Element as LaminasFormElement;
+
+use function array_key_exists;
+use function array_merge;
+use function in_array;
+
+class DoctrineAnnotationListener extends AbstractListenerAggregate
+{
+    /** @var ObjectManager */
+    protected $objectManager;
+
+    public function __construct(ObjectManager $objectManager)
+    {
+        $this->objectManager = $objectManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_FIELD,
+            [$this, 'handleFilterField']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_FIELD,
+            [$this, 'handleTypeField']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_FIELD,
+            [$this, 'handleValidatorField']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_FIELD,
+            [$this, 'handleRequiredField']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_EXCLUDE_FIELD,
+            [$this, 'handleExcludeField']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_ASSOCIATION,
+            [$this, 'handleToOne']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_ASSOCIATION,
+            [$this, 'handleToMany']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_CONFIGURE_ASSOCIATION,
+            [$this, 'handleRequiredAssociation']
+        );
+        $this->listeners[] = $events->attach(
+            EntityBasedFormBuilder::EVENT_EXCLUDE_ASSOCIATION,
+            [$this, 'handleExcludeAssociation']
+        );
+    }
+
+    /**
+     * @internal
+     */
+    public function handleToOne(EventInterface $event): void
+    {
+        $metadata = $event->getParam('metadata');
+        $mapping  = $this->getAssociationMapping($event);
+        if (! $mapping || ! $metadata->isSingleValuedAssociation($event->getParam('name'))) {
+            return;
+        }
+
+        $this->prepareEvent($event);
+        $this->mergeAssociationOptions($event->getParam('elementSpec'), $mapping['targetEntity']);
+    }
+
+    /**
+     * @internal
+     */
+    public function handleToMany(EventInterface $event): void
+    {
+        $metadata = $event->getParam('metadata');
+        $mapping  = $this->getAssociationMapping($event);
+        if (! $mapping || ! $metadata->isCollectionValuedAssociation($event->getParam('name'))) {
+            return;
+        }
+
+        $this->prepareEvent($event);
+
+        $elementSpec           = $event->getParam('elementSpec');
+        $inputSpec             = $event->getParam('inputSpec');
+        $inputSpec['required'] = false;
+
+        $this->mergeAssociationOptions($elementSpec, $mapping['targetEntity']);
+
+        $elementSpec['spec']['attributes']['multiple'] = true;
+    }
+
+    /**
+     * @internal
+     */
+    public function handleExcludeAssociation(EventInterface $event): bool
+    {
+        $metadata = $event->getParam('metadata');
+
+        return $metadata && $metadata->isAssociationInverseSide($event->getParam('name'));
+    }
+
+    /**
+     * @internal
+     */
+    public function handleExcludeField(EventInterface $event): bool
+    {
+        $metadata    = $event->getParam('metadata');
+        $identifiers = $metadata->getIdentifierFieldNames();
+
+        return in_array($event->getParam('name'), $identifiers) &&
+            $metadata->generatorType === ClassMetadata::GENERATOR_TYPE_IDENTITY;
+    }
+
+    /**
+     * @internal
+     */
+    public function handleFilterField(EventInterface $event): void
+    {
+        $metadata = $event->getParam('metadata');
+        if (! $metadata || ! $metadata->hasField($event->getParam('name'))) {
+            return;
+        }
+
+        $this->prepareEvent($event);
+
+        $inputSpec = $event->getParam('inputSpec');
+
+        switch ($metadata->getTypeOfField($event->getParam('name'))) {
+            case 'bool':
+            case 'boolean':
+                $inputSpec['filters'][] = ['name' => 'Boolean'];
+                break;
+            case 'bigint':
+            case 'integer':
+            case 'smallint':
+                $inputSpec['filters'][] = ['name' => 'Int'];
+                break;
+            case 'datetime':
+            case 'datetime_immutable':
+            case 'datetimetz':
+            case 'datetimetz_immutable':
+            case 'date':
+            case 'time':
+            case 'string':
+            case 'text':
+                $inputSpec['filters'][] = ['name' => 'StringTrim'];
+                break;
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function handleRequiredAssociation(EventInterface $event): void
+    {
+        $metadata = $event->getParam('metadata');
+        $mapping  = $this->getAssociationMapping($event);
+        if (! $mapping) {
+            return;
+        }
+
+        $this->prepareEvent($event);
+
+        $inputSpec   = $event->getParam('inputSpec');
+        $elementSpec = $event->getParam('elementSpec');
+
+        if ($metadata->isCollectionValuedAssociation($event->getParam('name'))) {
+            $inputSpec['required'] = false;
+        } elseif (isset($mapping['joinColumns'])) {
+            $required = true;
+            foreach ($mapping['joinColumns'] as $joinColumn) {
+                if (! isset($joinColumn['nullable']) || ! $joinColumn['nullable']) {
+                    continue;
+                }
+
+                $required = false;
+                if (
+                    (isset($elementSpec['spec']['options']) &&
+                        ! array_key_exists('empty_option', $elementSpec['spec']['options'])) ||
+                    ! isset($elementSpec['spec']['options'])
+                ) {
+                    $elementSpec['spec']['options']['empty_option'] = 'NULL';
+                }
+
+                break;
+            }
+
+            $inputSpec['required'] = $required;
+        }
+    }
+
+    /**
+     * @internal
+     */
+    public function handleRequiredField(EventInterface $event): void
+    {
+        $this->prepareEvent($event);
+
+        $metadata  = $event->getParam('metadata');
+        $inputSpec = $event->getParam('inputSpec');
+
+        if (! $metadata || ! $metadata->hasField($event->getParam('name'))) {
+            return;
+        }
+
+        $inputSpec['required'] = ! $metadata->isNullable($event->getParam('name'));
+    }
+
+    /**
+     * @internal
+     */
+    public function handleTypeField(EventInterface $event): void
+    {
+        $metadata = $event->getParam('metadata');
+        $mapping  = $this->getFieldMapping($event);
+        if (! $mapping) {
+            return;
+        }
+
+        $this->prepareEvent($event);
+
+        $elementSpec = $event->getParam('elementSpec');
+
+        if (isset($elementSpec['spec']['options']['target_class'])) {
+            $this->mergeAssociationOptions($elementSpec, $elementSpec['spec']['options']['target_class']);
+
+            return;
+        }
+
+        if (isset($elementSpec['spec']['type']) || isset($elementSpec['spec']['attributes']['type'])) {
+            return;
+        }
+
+        switch ($metadata->getTypeOfField($event->getParam('name'))) {
+            case 'bigint':
+            case 'integer':
+            case 'smallint':
+                $type = LaminasFormElement\Number::class;
+                break;
+            case 'bool':
+            case 'boolean':
+                $type = LaminasFormElement\Checkbox::class;
+                break;
+            case 'date':
+                $type = LaminasFormElement\Date::class;
+                break;
+            case 'datetime':
+            case 'datetime_immutable':
+            case 'datetimetz':
+            case 'datetimetz_immutable':
+                $type = LaminasFormElement\DateTimeLocal::class;
+                break;
+            case 'time':
+                $type = LaminasFormElement\Time::class;
+                break;
+            case 'text':
+                $type = LaminasFormElement\Textarea::class;
+                break;
+            default:
+                $type = LaminasFormElement::class;
+                break;
+        }
+
+        $elementSpec['spec']['type'] = $type;
+    }
+
+    /**
+     * @internal
+     */
+    public function handleValidatorField(EventInterface $event): void
+    {
+        $mapping = $this->getFieldMapping($event);
+        if (! $mapping) {
+            return;
+        }
+
+        $metadata = $event->getParam('metadata');
+
+        $this->prepareEvent($event);
+
+        $inputSpec = $event->getParam('inputSpec');
+
+        switch ($metadata->getTypeOfField($event->getParam('name'))) {
+            case 'bool':
+            case 'boolean':
+                $inputSpec['validators'][] = [
+                    'name'    => 'InArray',
+                    'options' => ['haystack' => ['0', '1']],
+                ];
+                break;
+            case 'float':
+                $inputSpec['validators'][] = ['name' => 'Float'];
+                break;
+            case 'bigint':
+            case 'integer':
+            case 'smallint':
+                $inputSpec['validators'][] = ['name' => 'Int'];
+                break;
+            case 'string':
+                $elementSpec = $event->getParam('elementSpec');
+                if (
+                    isset($elementSpec['spec']['type']) &&
+                    in_array($elementSpec['spec']['type'], ['File', LaminasFormElement\File::class])
+                ) {
+                    return;
+                }
+
+                if (isset($mapping['length'])) {
+                    $inputSpec['validators'][] = [
+                        'name'    => 'StringLength',
+                        'options' => ['max' => $mapping['length']],
+                    ];
+                }
+
+                break;
+        }
+    }
+
+    /**
+     * @return mixed[]|null
+     */
+    protected function getFieldMapping(EventInterface $event): ?array
+    {
+        $metadata = $event->getParam('metadata');
+        if ($metadata && $metadata->hasField($event->getParam('name'))) {
+            return $metadata->getFieldMapping($event->getParam('name'));
+        }
+
+        return null;
+    }
+
+    /**
+     * @return mixed[]|null
+     */
+    protected function getAssociationMapping(EventInterface $event): ?array
+    {
+        $metadata = $event->getParam('metadata');
+        if ($metadata && $metadata->hasAssociation($event->getParam('name'))) {
+            return $metadata->getAssociationMapping($event->getParam('name'));
+        }
+
+        return null;
+    }
+
+    protected function mergeAssociationOptions(ArrayObject $elementSpec, string $targetEntity): void
+    {
+        $options = $elementSpec['spec']['options'] ?? [];
+        $options = array_merge(
+            [
+                'object_manager' => $this->objectManager,
+                'target_class'   => $targetEntity,
+            ],
+            $options
+        );
+
+        $elementSpec['spec']['options'] = $options;
+        if (isset($elementSpec['spec']['type'])) {
+            return;
+        }
+
+        $elementSpec['spec']['type'] = EntitySelect::class;
+    }
+
+    /**
+     * Normalizes event setting all expected parameters.
+     */
+    protected function prepareEvent(EventInterface $event): void
+    {
+        foreach (['elementSpec', 'inputSpec'] as $type) {
+            if ($event->getParam($type)) {
+                continue;
+            }
+
+            $event->setParam($type, new ArrayObject());
+        }
+
+        $elementSpec = $event->getParam('elementSpec');
+        $inputSpec   = $event->getParam('inputSpec');
+
+        if (! isset($elementSpec['spec'])) {
+            $elementSpec['spec'] = [];
+        }
+
+        if (! isset($inputSpec['filters'])) {
+            $inputSpec['filters'] = [];
+        }
+
+        if (isset($inputSpec['validators'])) {
+            return;
+        }
+
+        $inputSpec['validators'] = [];
+    }
+}

--- a/src/Form/Annotation/EntityBasedFormBuilder.php
+++ b/src/Form/Annotation/EntityBasedFormBuilder.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModule\Form\Annotation;
+
+use ArrayObject;
+use Doctrine\Persistence\Mapping\ClassMetadata;
+use Doctrine\Persistence\ObjectManager;
+use DoctrineModule\Form\Element\ObjectMultiCheckbox;
+use DoctrineModule\Form\Element\ObjectRadio;
+use DoctrineModule\Form\Element\ObjectSelect;
+use DoctrineORMModule\Form\Element\EntityMultiCheckbox;
+use DoctrineORMModule\Form\Element\EntityRadio;
+use DoctrineORMModule\Form\Element\EntitySelect;
+use Laminas\Form\Annotation\AbstractBuilder;
+use Laminas\Form\Annotation\AnnotationBuilder as LaminasAnnotationBuilder;
+use Laminas\Form\Exception\InvalidArgumentException;
+use Laminas\Form\FormInterface;
+use Laminas\Stdlib\ArrayUtils;
+use RuntimeException;
+
+use function class_exists;
+use function get_class;
+use function in_array;
+use function is_object;
+use function sprintf;
+
+final class EntityBasedFormBuilder
+{
+    public const EVENT_CONFIGURE_FIELD       = 'configureField';
+    public const EVENT_CONFIGURE_ASSOCIATION = 'configureAssociation';
+    public const EVENT_EXCLUDE_FIELD         = 'excludeField';
+    public const EVENT_EXCLUDE_ASSOCIATION   = 'excludeAssociation';
+
+    /** @var AbstractBuilder */
+    protected $builder;
+
+    /** @var ObjectManager */
+    protected $objectManager;
+
+    /**
+     * Constructor. Ensures ObjectManager is present.
+     */
+    public function __construct(ObjectManager $objectManager, ?AbstractBuilder $builder = null)
+    {
+        if (! class_exists(AbstractBuilder::class)) {
+            throw new RuntimeException(sprintf(
+                'Usage of %s requires laminas-form 3.0.0 or newer, which currently is not installed.',
+                self::class
+            ));
+        }
+
+        $this->objectManager = $objectManager;
+        $this->builder       = $builder ?? new LaminasAnnotationBuilder();
+        (new DoctrineAnnotationListener($this->objectManager))->attach($this->builder->getEventManager());
+    }
+
+    /**
+     * @return AbstractBuilder the form builder from laminas-form
+     */
+    public function getBuilder(): AbstractBuilder
+    {
+        return $this->builder;
+    }
+
+    /**
+     * Overrides the base getFormSpecification() to additionally iterate through each
+     * field/association in the metadata and trigger the associated event.
+     *
+     * This allows building of a form from metadata instead of requiring annotations.
+     * Annotations are still allowed through the ElementAnnotationsListener.
+     *
+     * @param  class-string|object $entity Either an instance or a valid class name for an entity
+     *
+     * @throws InvalidArgumentException    If $entity is not an object or class name.
+     */
+    public function getFormSpecification($entity): ArrayObject
+    {
+        $formSpec    = $this->getBuilder()->getFormSpecification($entity);
+        $metadata    = $this->objectManager->getClassMetadata(is_object($entity) ? get_class($entity) : $entity);
+        $inputFilter = $formSpec['input_filter'];
+
+        $formElements = [
+            EntitySelect::class,
+            EntityMultiCheckbox::class,
+            EntityRadio::class,
+            ObjectSelect::class,
+            ObjectMultiCheckbox::class,
+            ObjectRadio::class,
+        ];
+
+        foreach ($formSpec['elements'] as $key => $elementSpec) {
+            $name          = $elementSpec['spec']['name'] ?? null;
+            $isFormElement = (isset($elementSpec['spec']['type']) &&
+                in_array($elementSpec['spec']['type'], $formElements));
+
+            if (! $name) {
+                continue;
+            }
+
+            if (! isset($inputFilter[$name])) {
+                $inputFilter[$name] = new ArrayObject();
+            }
+
+            $params = [
+                'metadata'    => $metadata,
+                'name'        => $name,
+                'elementSpec' => $elementSpec,
+                'inputSpec'   => $inputFilter[$name],
+            ];
+
+            if ($this->checkForExcludeElementFromMetadata($metadata, $name)) {
+                $elementSpec = $formSpec['elements'];
+                unset($elementSpec[$key]);
+                $formSpec['elements'] = $elementSpec;
+
+                if (isset($inputFilter[$name])) {
+                    unset($inputFilter[$name]);
+                }
+
+                $formSpec['input_filter'] = $inputFilter;
+                continue;
+            }
+
+            if ($metadata->hasField($name) || (! $metadata->hasAssociation($name) && $isFormElement)) {
+                $this->getBuilder()->getEventManager()->trigger(self::EVENT_CONFIGURE_FIELD, $this, $params);
+            } elseif ($metadata->hasAssociation($name)) {
+                $this->getBuilder()->getEventManager()->trigger(self::EVENT_CONFIGURE_ASSOCIATION, $this, $params);
+            }
+        }
+
+        $formSpec['options'] = ['prefer_form_input_filter' => true];
+
+        return $formSpec;
+    }
+
+    /**
+     * Create a form from an object.
+     *
+     * @param  class-string|object $entity
+     */
+    public function createForm($entity): FormInterface
+    {
+        $formSpec    = ArrayUtils::iteratorToArray($this->getFormSpecification($entity));
+        $formFactory = $this->getBuilder()->getFormFactory();
+
+        return $formFactory->createForm($formSpec);
+    }
+
+    private function checkForExcludeElementFromMetadata(ClassMetadata $metadata, string $name): bool
+    {
+        $params = ['metadata' => $metadata, 'name' => $name];
+        $result = false;
+
+        if ($metadata->hasField($name)) {
+            $result = $this->getBuilder()->getEventManager()->trigger(self::EVENT_EXCLUDE_FIELD, $this, $params);
+        } elseif ($metadata->hasAssociation($name)) {
+            $result = $this->getBuilder()->getEventManager()->trigger(self::EVENT_EXCLUDE_ASSOCIATION, $this, $params);
+        }
+
+        if ($result) {
+            $result = (bool) $result->last();
+        }
+
+        return $result;
+    }
+}

--- a/tests/Assets/Entity/FormEntity.php
+++ b/tests/Assets/Entity/FormEntity.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineORMModuleTest\Assets\Entity;
 
 use DateTime;
+use DateTimeImmutable;
 use Doctrine\ORM\Mapping as ORM;
 use Laminas\Form\Annotation as Form;
 
@@ -72,11 +73,25 @@ class FormEntity
     protected $datetime;
 
     /**
-     * @ORM\Column(type="datetimetz")
+     * @ORM\Column(type="datetime_immutable")
      *
      * @var DateTime
      */
+    protected $datetimeImmutable;
+
+    /**
+     * @ORM\Column(type="datetimetz")
+     *
+     * @var DateTimeImmutable
+     */
     protected $datetimetz;
+
+    /**
+     * @ORM\Column(type="datetimetz_immutable")
+     *
+     * @var DateTimeImmutable
+     */
+    protected $datetimetzImmutable;
 
     /**
      * @ORM\Column(type="date")

--- a/tests/Form/Annotation/DoctrineAnnotationListenerTest.php
+++ b/tests/Form/Annotation/DoctrineAnnotationListenerTest.php
@@ -1,0 +1,365 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModuleTest\Form\Annotation;
+
+use ArrayObject;
+use DoctrineORMModule\Form\Annotation\DoctrineAnnotationListener;
+use DoctrineORMModule\Form\Element\EntitySelect;
+use DoctrineORMModuleTest\Assets\Entity\FormEntity;
+use DoctrineORMModuleTest\Assets\Entity\FormEntityTarget;
+use DoctrineORMModuleTest\Assets\Entity\TargetEntity;
+use DoctrineORMModuleTest\Framework\TestCase;
+use Laminas\EventManager\Event;
+use Laminas\Form\Element;
+use Laminas\Form\Element\Checkbox;
+use Laminas\Form\Element\Date;
+use Laminas\Form\Element\DateTimeLocal;
+use Laminas\Form\Element\Number;
+use Laminas\Form\Element\Textarea;
+use Laminas\Form\Element\Time;
+
+class DoctrineAnnotationListenerTest extends TestCase
+{
+    /** @var DoctrineAnnotationListener */
+    protected $listener;
+
+    public function setUp(): void
+    {
+        $this->listener = new DoctrineAnnotationListener($this->getEntityManager());
+    }
+
+    /**
+     * @dataProvider eventNameProvider
+     */
+    public function testEventsWithNoMetadata(string $method): void
+    {
+        $event = $this->getMetadataEvent();
+        $this->listener->{$method}($event);
+
+        $this->addToAssertionCount(1);
+    }
+
+    public function testToOne(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $event->setParam('name', 'targetOne');
+        $listener->handleToOne($event);
+
+        $elementSpec = $event->getParam('elementSpec');
+        $this->assertEquals($this->getEntityManager(), $elementSpec['spec']['options']['object_manager']);
+        $this->assertEquals(
+            TargetEntity::class,
+            $elementSpec['spec']['options']['target_class']
+        );
+        $this->assertEquals(EntitySelect::class, $elementSpec['spec']['type']);
+    }
+
+    public function testToOneMergesOptions(): void
+    {
+        $listener                              = $this->listener;
+        $event                                 = $this->getMetadataEvent();
+        $elementSpec                           = new ArrayObject();
+        $elementSpec['spec']['options']['foo'] = 'bar';
+
+        $event->setParam('name', 'targetOne');
+        $event->setParam('elementSpec', $elementSpec);
+        $listener->handleToOne($event);
+
+        $this->assertEquals('bar', $elementSpec['spec']['options']['foo']);
+        $this->assertCount(3, $elementSpec['spec']['options']);
+    }
+
+    public function testToOneHasNoEffectOnToMany(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $event->setParam('name', 'targetMany');
+        $listener->handleToOne($event);
+
+        $this->assertNull($event->getParam('elementSpec'));
+        $this->assertNull($event->getParam('inputSpec'));
+    }
+
+    public function testToManyHasNoEffectOnToOne(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $event->setParam('name', 'targetOne');
+        $listener->handleToMany($event);
+
+        $this->assertNull($event->getParam('elementSpec'));
+        $this->assertNull($event->getParam('inputSpec'));
+    }
+
+    public function testToMany(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $event->setParam('name', 'targetMany');
+        $listener->handleToMany($event);
+
+        $elementSpec = $event->getParam('elementSpec');
+        $inputSpec   = $event->getParam('inputSpec');
+
+        $this->assertTrue($elementSpec['spec']['attributes']['multiple']);
+        $this->assertEquals($this->getEntityManager(), $elementSpec['spec']['options']['object_manager']);
+        $this->assertEquals(
+            FormEntityTarget::class,
+            $elementSpec['spec']['options']['target_class']
+        );
+        $this->assertEquals(EntitySelect::class, $elementSpec['spec']['type']);
+        $this->assertFalse($inputSpec['required']);
+    }
+
+    public function testToManyMergesOptions(): void
+    {
+        $listener                              = $this->listener;
+        $event                                 = $this->getMetadataEvent();
+        $elementSpec                           = new ArrayObject();
+        $elementSpec['spec']['options']['foo'] = 'bar';
+
+        $event->setParam('name', 'targetMany');
+        $event->setParam('elementSpec', $elementSpec);
+        $listener->handleToMany($event);
+
+        $this->assertEquals('bar', $elementSpec['spec']['options']['foo']);
+        $this->assertCount(3, $elementSpec['spec']['options']);
+    }
+
+    public function testHandleExcludeAssociation(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+        $event->setParam('name', 'targetMany');
+
+        $this->assertTrue($listener->handleExcludeAssociation($event));
+
+        $event->setParam('name', 'targetOne');
+        $this->assertFalse($listener->handleExcludeAssociation($event));
+    }
+
+    /**
+     * @dataProvider eventFilterProvider
+     */
+    public function testHandleFilterField(string $name, string $type): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $listener->handleFilterField($event);
+        $this->assertNull($event->getParam('inputSpec'));
+
+        $event->setParam('name', $name);
+        $listener->handleFilterField($event);
+
+        $inputSpec = $event->getParam('inputSpec');
+        $this->assertEquals($type, $inputSpec['filters'][0]['name']);
+    }
+
+    public function testHandlRequiredAssociation(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $listener->handleRequiredAssociation($event);
+        $this->assertNull($event->getParam('inputSpec'));
+
+        $event->setParam('name', 'targetMany');
+        $listener->handleRequiredAssociation($event);
+
+        $inputSpec = $event->getParam('inputSpec');
+        $this->assertFalse($inputSpec['required']);
+    }
+
+    public function testHandlRequiredAssociationSetsNullOption(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+        $event->setParam('name', 'targetOneNullable');
+        $listener->handleRequiredAssociation($event);
+
+        $elementSpec = $event->getParam('elementSpec');
+
+        $this->assertEquals('NULL', $elementSpec['spec']['options']['empty_option']);
+
+        $listener->handleRequiredAssociation($event);
+        $elementSpec['spec']['options']['empty_option'] = 'foo';
+
+        $this->assertEquals('foo', $elementSpec['spec']['options']['empty_option']);
+    }
+
+    public function testHandleRequiredField(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $event->setParam('name', 'datetime');
+        $listener->handleRequiredField($event);
+        $inputSpec = $event->getParam('inputSpec');
+        $this->assertTrue($inputSpec['required']);
+
+        $event->setParam('name', 'string');
+        $listener->handleRequiredField($event);
+        $this->assertTrue($inputSpec['required']);
+
+        $event->setParam('name', 'stringNullable');
+        $listener->handleRequiredField($event);
+        $this->assertFalse($inputSpec['required']);
+    }
+
+    public function testHandleRequiredFieldNonFieldProperty(): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+        $event->setParam('name', 'targetMany');
+        $listener->handleRequiredField($event);
+
+        $inputSpec = $event->getParam('inputSpec');
+        $this->assertFalse(isset($inputSpec['required']));
+    }
+
+    /**
+     * @dataProvider eventTypeProvider
+     */
+    public function testHandleTypeField(string $name, string $type): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $listener->handleFilterField($event);
+        $this->assertNull($event->getParam('elementSpec'));
+
+        $event->setParam('name', $name);
+        $listener->handleTypeField($event);
+
+        $elementSpec = $event->getParam('elementSpec');
+        $this->assertInstanceOf(ArrayObject::class, $elementSpec);
+        $this->assertEquals($type, $elementSpec['spec']['type']);
+    }
+
+    /**
+     * @dataProvider eventValidatorProvider
+     */
+    public function testHandleValidatorField(string $name, ?string $type): void
+    {
+        $listener = $this->listener;
+        $event    = $this->getMetadataEvent();
+
+        $listener->handleFilterField($event);
+        $this->assertNull($event->getParam('inputSpec'));
+
+        $event->setParam('name', $name);
+        $listener->handleValidatorField($event);
+
+        $inputSpec = $event->getParam('inputSpec');
+        $this->assertInstanceOf(ArrayObject::class, $inputSpec);
+
+        if ($type === null) {
+            $this->assertEmpty($inputSpec['validators']);
+        } else {
+            $this->assertEquals($type, $inputSpec['validators'][0]['name']);
+        }
+    }
+
+    /**
+     * @return list<array{string, string|null}>
+     */
+    public function eventValidatorProvider()
+    {
+        return [
+            ['bool', 'InArray'],
+            ['boolean', 'InArray'],
+            ['bigint', 'Int'],
+            ['float', 'Float'],
+            ['integer', 'Int'],
+            ['smallint', 'Int'],
+            ['datetime', null],
+            ['datetimetz', null],
+            ['date', null],
+            ['time', null],
+            ['string', 'StringLength'],
+            ['stringNullable', null],
+            ['text', null],
+        ];
+    }
+
+    /**
+     * @return list<array{string, string}>
+     */
+    public function eventFilterProvider()
+    {
+        return [
+            ['bool', 'Boolean'],
+            ['boolean', 'Boolean'],
+            ['bigint', 'Int'],
+            ['integer', 'Int'],
+            ['smallint', 'Int'],
+            ['datetime', 'StringTrim'],
+            ['datetimeImmutable', 'StringTrim'],
+            ['datetimetz', 'StringTrim'],
+            ['datetimetzImmutable', 'StringTrim'],
+            ['date', 'StringTrim'],
+            ['time', 'StringTrim'],
+            ['string', 'StringTrim'],
+            ['text', 'StringTrim'],
+        ];
+    }
+
+    /**
+     * @return list<array{string, class-string}>
+     */
+    public function eventTypeProvider()
+    {
+        return [
+            ['bool', Checkbox::class],
+            ['boolean', Checkbox::class],
+            ['bigint', Number::class],
+            ['integer', Number::class],
+            ['smallint', Number::class],
+            ['datetime', DateTimeLocal::class],
+            ['datetimeImmutable', DateTimeLocal::class],
+            ['datetimetz', DateTimeLocal::class],
+            ['datetimetzImmutable', DateTimeLocal::class],
+            ['date', Date::class],
+            ['time', Time::class],
+            ['string', Element::class],
+            ['text', Textarea::class],
+        ];
+    }
+
+    /**
+     * @return list<array{string}>
+     */
+    public function eventNameProvider(): array
+    {
+        return [
+            [
+                'handleFilterField',
+                'handleTypeField',
+                'handleValidatorField',
+                'handleRequiredField',
+                'handleRequiredAssociation',
+                'handleExcludeField',
+                'handleExcludeAssociation',
+                'handleToOne',
+                'handleToMany',
+            ],
+        ];
+    }
+
+    protected function getMetadataEvent(): Event
+    {
+        $event    = new Event();
+        $metadata = $this->getEntityManager()->getClassMetadata(FormEntity::class);
+        $event->setParam('metadata', $metadata);
+
+        return $event;
+    }
+}

--- a/tests/Form/Annotation/EntityBasedFormBuilderTest.php
+++ b/tests/Form/Annotation/EntityBasedFormBuilderTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineORMModuleTest\Form\Annotation;
+
+use DoctrineORMModule\Form\Annotation\EntityBasedFormBuilder;
+use DoctrineORMModuleTest\Assets\Entity\FormEntity;
+use DoctrineORMModuleTest\Assets\Entity\Issue237;
+use DoctrineORMModuleTest\Framework\TestCase;
+use Laminas\Form\Annotation\AbstractBuilder;
+use Laminas\Form\Annotation\AnnotationBuilder as LaminasAnnotationBuilder;
+use Laminas\Form\Form;
+
+use function array_key_exists;
+use function class_exists;
+use function get_class;
+use function in_array;
+use function sprintf;
+
+class EntityBasedFormBuilderTest extends TestCase
+{
+    /** @var EntityBasedFormBuilder */
+    protected $builder;
+
+    public function setUp(): void
+    {
+        if (! class_exists(AbstractBuilder::class)) {
+            $this->markTestSkipped(sprintf(
+                '%s requires laminas-form 3.0.0 or newer to be installed.',
+                EntityBasedFormBuilder::class
+            ));
+        }
+
+        $this->builder = new EntityBasedFormBuilder($this->getEntityManager());
+    }
+
+    /**
+     * @link https://github.com/doctrine/DoctrineORMModule/issues/237
+     */
+    public function testIssue237(): void
+    {
+        $entity = new Issue237();
+        $spec   = $this->builder->getFormSpecification($entity);
+
+        $this->assertCount(0, $spec['elements']);
+    }
+
+    public function testAnnotationBuilderSupportsClassNames(): void
+    {
+        $spec = $this->builder->getFormSpecification(Issue237::class);
+
+        $this->assertCount(0, $spec['elements'], 'Annotation builder allows also class names');
+    }
+
+    /**
+     * empty_option behavior - !isset can't evaluate null value
+     *
+     * @link https://github.com/doctrine/DoctrineORMModule/pull/247
+     */
+    public function testEmptyOptionNullDoesntGenerateValue(): void
+    {
+        $showEmptyValue = true;
+        $entity         = new FormEntity();
+        $spec           = $this->builder->getFormSpecification($entity);
+
+        foreach ($spec['elements'] as $elementSpec) {
+            if (! isset($elementSpec['spec']['options'])) {
+                continue;
+            }
+
+            if (
+                array_key_exists('empty_option', $elementSpec['spec']['options']) &&
+                $elementSpec['spec']['options']['empty_option'] === null
+            ) {
+                $showEmptyValue = false;
+                break;
+            }
+        }
+
+        $this->assertFalse($showEmptyValue);
+    }
+
+    /**
+     * Ensure user defined \Type or type attribute overrides the listener one
+     */
+    public function testEnsureCustomTypeOrAttributeTypeIsUsedInAnnotations(): void
+    {
+        $userDefinedTypeOverridesListenerType = true;
+        $entity                               = new FormEntity();
+
+        $laminasAnnotationBuilder = new LaminasAnnotationBuilder();
+        $laminasForm              = $laminasAnnotationBuilder->createForm($entity);
+
+        $spec           = $this->builder->getFormSpecification($entity);
+        $annotationForm = $this->builder->createForm($entity);
+
+        $attributesToTest = ['specificType', 'specificMultiType', 'specificAttributeType'];
+
+        foreach ($spec['elements'] as $element) {
+            $elementName = $element['spec']['name'];
+            if (! in_array($elementName, $attributesToTest)) {
+                continue;
+            }
+
+            $annotationFormElement = $annotationForm->get($elementName);
+            $laminasFormElement    = $laminasForm->get($elementName);
+
+            $annotationElementAttribute = $annotationFormElement->getAttribute('type');
+            $laminasElementAttribute    = $laminasFormElement->getAttribute('type');
+
+            if (
+                (get_class($laminasFormElement) === get_class($annotationFormElement)) &&
+                ($annotationElementAttribute === $laminasElementAttribute)
+            ) {
+                continue;
+            }
+
+            $userDefinedTypeOverridesListenerType = false;
+        }
+
+        $this->assertTrue($userDefinedTypeOverridesListenerType);
+    }
+
+    /**
+     * @link https://github.com/zendframework/zf2/issues/7096
+     */
+    public function testFileTypeDoesntGrabStringLengthValidator(): void
+    {
+        $validators = $this
+            ->builder
+            ->createForm(new FormEntity())
+            ->getInputFilter()
+            ->get('image')
+            ->getValidatorChain()
+            ->getValidators();
+
+        $this->assertCount(0, $validators);
+    }
+
+    /**
+     * Ensure prefer_form_input_filter is set to true for the generated form
+     */
+    public function testPreferFormInputFilterIsTrue(): void
+    {
+        $entity = new FormEntity();
+        $form   = $this->builder->createForm($entity);
+
+        $this->assertInstanceOf(Form::class, $form);
+        $this->assertTrue($form->getPreferFormInputFilter());
+    }
+}


### PR DESCRIPTION
This is a reimplementation of `AnnotationBuilder` from DoctrineORMModule version 3.x ([source](https://github.com/doctrine/DoctrineORMModule/blob/3.2.2/src/DoctrineORMModule/Form/Annotation/AnnotationBuilder.php)). It has been adapted to support both the AnnotationBuilder and the AttributeBuilder from laminas-form 3.x ([see docs](https://docs.laminas.dev/laminas-form/v3/form-creation/attributes-or-annotations/)).

## Initialization

```php
// using PhpDoc annotations
$entityManager = $container->get(\Doctrine\ORM\EntityManager::class);
$builder = new \DoctrineORMModule\Form\Annotation\EntityBasedFormBuilder($entityManager);

// alternatively, to use PHP8 attributes
$entityManager = $container->get(\Doctrine\ORM\EntityManager::class);
$attributeBuilder = new \Laminas\Form\Annotation\AttributeBuilder();
$builder = new \DoctrineORMModule\Form\Annotation\EntityBasedFormBuilder($entityManager, $attributeBuilder);
```

## Customization

```php
// if you need access to the event manager
$myListener = new MyListener();
$myListener->attach($builder->getBuilder()->getEventManager());

// if you need access to the form factory
$formElementManager = $container->get(\Laminas\Form\FormElementManager::class)
$builder->getBuilder()->getFormFactory()->setFormElementManager($formElementManager);
```

## Usage

```php
$entity = new User();

// get form specification only
$formSpec = $builder->getFormSpecification($entity);

// or directly get form
$form= $builder->createForm($entity);
```
