### PR TITLE
Fixed deprecation on Serializable interface

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
+          ini-values: "error_reporting=E_ALL, zend.assertions=1"
           extensions: "pdo_mysql"
 
       - name: "Require specific DBAL version"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
     convertErrorsToExceptions="true"
     convertNoticesToExceptions="true"
     convertWarningsToExceptions="true"
+    convertDeprecationsToExceptions="true"
     verbose="true"
     stopOnFailure="false"
     processIsolation="false"

--- a/src/Collector/MappingCollector.php
+++ b/src/Collector/MappingCollector.php
@@ -85,26 +85,43 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
     }
 
     /**
-     * {@inheritDoc}
+     * @return array{name: string, classes: ClassMetadata[]}
      */
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize(
-            [
-                'name'    => $this->name,
-                'classes' => $this->classes,
-            ]
-        );
+        return [
+            'name'    => $this->name,
+            'classes' => $this->classes,
+        ];
     }
 
     /**
      * {@inheritDoc}
+     *
+     * @deprecated 4.2.0 This function will be removed in 5.0.0. Use __serialize() instead.
+     */
+    public function serialize()
+    {
+        return serialize($this->__serialize());
+    }
+
+    /**
+     * @param array{name: string, classes: ClassMetadata[]} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->name    = $data['name'];
+        $this->classes = $data['classes'];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated 4.2.0 This function will be removed in 5.0.0. Use __unserialize() instead.
      */
     public function unserialize($serialized)
     {
-        $data          = unserialize($serialized);
-        $this->name    = $data['name'];
-        $this->classes = $data['classes'];
+        $this->__unserialize(unserialize($serialized));
     }
 
     /**


### PR DESCRIPTION
fixes #695 

This sets `convertDeprecationsToExceptions="true"` in PHPUnit configuration, so that in the future we can see failings tests when there are deprecation messages in PHP.