### PR TITLE
Update dependencies with DoctrineModule 5.0

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,4 +14,3 @@ jobs:
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
     with:
       php-version: '8.1'
-      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,20 +30,20 @@ jobs:
           - false
         include:
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "2.13.0"
+            dependencies: "lowest"
             optional-dependencies: false
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "3.1.0"
+            dependencies: "lowest"
             optional-dependencies: false
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "2.13.0"
+            dependencies: "lowest"
             optional-dependencies: true
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "3.1.0"
+            dependencies: "lowest"
             optional-dependencies: true
 
     services:
@@ -77,25 +77,13 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
-        if: "! startsWith(matrix.php-version, '8')"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist --no-suggest"
 
-      - name: "Install dependencies with Composer (--ignore-platform-req=php)"
-        uses: "ramsey/composer-install@v1"
-        if: "startsWith(matrix.php-version, '8')"
-        with:
-          dependency-versions: "${{ matrix.dependencies }}"
-          composer-options: "--prefer-dist --no-suggest --ignore-platform-req=php"
-
       - name: "Remove optional dependencies"
-        if: "! startsWith(matrix.php-version, '8') && ! matrix.optional-dependencies"
+        if: "! matrix.optional-dependencies"
         run: "composer remove --dev doctrine/data-fixtures doctrine/migrations"
-
-      - name: "Remove optional dependencies (--ignore-platform-req=php)"
-        if: "startsWith(matrix.php-version, '8') && ! matrix.optional-dependencies"
-        run: "composer remove --ignore-platform-req=php --dev doctrine/data-fixtures doctrine/migrations"
 
       - name: "Configure test application"
         run: "cp ci/config/application.config.php config/application.config.php"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,4 +14,3 @@ jobs:
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.4.1"
     with:
       php-version: '8.1'
-      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/README.md
+++ b/README.md
@@ -23,32 +23,6 @@ Run the following to install this library using [Composer](https://getcomposer.o
 composer require doctrine/doctrine-orm-module
 ```
 
-### Note on PHP 8.0 or later
-
-[DoctrineModule](https://github.com/doctrine/DoctrineModule/) provides an integration with 
-[laminas-cache](https://docs.laminas.dev/laminas-cache/), which currently comes with some storage adapters which 
-are not compatible with PHP 8.0 or later. To prevent installation of these unused cache adapters, you will need 
-to add the following to your `composer.json` file:
-
-```json
-    "require": {
-         "doctrine/doctrine-orm-module": "^4.1.0"
-    },
-    "replace": {
-        "laminas/laminas-cache-storage-adapter-apc": "*",
-        "laminas/laminas-cache-storage-adapter-dba": "*",
-        "laminas/laminas-cache-storage-adapter-memcache": "*",
-        "laminas/laminas-cache-storage-adapter-memcached": "*",
-        "laminas/laminas-cache-storage-adapter-mongodb": "*",
-        "laminas/laminas-cache-storage-adapter-wincache": "*",
-        "laminas/laminas-cache-storage-adapter-xcache": "*",
-        "laminas/laminas-cache-storage-adapter-zend-server": "*"
-    }
-```
-
-Consult the [laminas-cache documentation](https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed)
-for further information on this issue.
-
 ## Documentation
 
 Please check the [documentation on the Doctrine website](https://www.doctrine-project.org/projects/doctrine-orm-module.html)

--- a/composer.json
+++ b/composer.json
@@ -48,19 +48,19 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "container-interop/container-interop": "^1.2.0",
-        "doctrine/dbal": "^2.13.4 || ^3.1.3",
-        "doctrine/doctrine-laminas-hydrator": "^2.2.1",
-        "doctrine/doctrine-module": "^4.2.2",
+        "doctrine/dbal": "^2.13.4 || ^3.1.4",
+        "doctrine/doctrine-laminas-hydrator": "^2.2.1 || ^3.0.0",
+        "doctrine/doctrine-module": "^5.0.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/orm": "^2.9.6",
-        "doctrine/persistence": "^2.2.2",
+        "doctrine/persistence": "^2.2.3",
         "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc": "^3.3.0",
         "laminas/laminas-paginator": "^2.11.0",
-        "laminas/laminas-servicemanager": "^3.7.0",
-        "laminas/laminas-stdlib": "^3.6.1",
-        "symfony/console": "^5.3.0 || ^6.0.0"
+        "laminas/laminas-servicemanager": "^3.10.0",
+        "laminas/laminas-stdlib": "^3.6.4",
+        "symfony/console": "^5.4.1 || ^6.0.1"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13.2",
@@ -76,7 +76,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.10",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "vimeo/psalm": "^4.13.0"
+        "vimeo/psalm": "^4.15.0"
     },
     "conflict": {
         "doctrine/migrations": "<3.3"

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -20,34 +20,6 @@ Run the following to install this library using `Composer <https://getcomposer.o
 
    $ composer require doctrine/doctrine-orm-module
 
-Note on PHP 8.0 or later
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-`DoctrineModule <https://www.doctrine-project.org/projects/doctrine-module/en/current/index.html>`__
-provides an integration with `laminas-cache <https://docs.laminas.dev/laminas-cache/>`__, which
-currently comes with some storage adapters which are not compatible with PHP 8.0 or later. To
-prevent installation of these unused cache adapters, you will need to add the following to your
-``composer.json`` file:
-
-.. code:: json
-
-    "require": {
-         "doctrine/doctrine-orm-module": "^4.1.0"
-    },
-    "replace": {
-        "laminas/laminas-cache-storage-adapter-apc": "*",
-        "laminas/laminas-cache-storage-adapter-dba": "*",
-        "laminas/laminas-cache-storage-adapter-memcache": "*",
-        "laminas/laminas-cache-storage-adapter-memcached": "*",
-        "laminas/laminas-cache-storage-adapter-mongodb": "*",
-        "laminas/laminas-cache-storage-adapter-wincache": "*",
-        "laminas/laminas-cache-storage-adapter-xcache": "*",
-        "laminas/laminas-cache-storage-adapter-zend-server": "*"
-    }
-
-Consult the `laminas-cache documentation <https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed>`__
-for further information on this issue.
-
 Next Steps
 ----------
 


### PR DESCRIPTION
This PR updates DoctrineModule to [version 5.0.0](https://github.com/doctrine/DoctrineModule/releases/tag/5.0.0). A few other dependencies are updated to be in line with DoctrineModule 5.0.0.

By upgrading DoctrineModule, support for laminas-cache 2.x is dropped and laminas-cache 3.x is required. This solves the installation issues with PHP 8, i.e. we do no longer need to use `--ingore-platform-req=php` in our CI actions and users do not need to supress cache adapters on installation.