### PR TITLE
Use typed properties where possible

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -14,4 +14,3 @@ jobs:
     uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
     with:
       php-version: '8.1'
-      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,20 +30,20 @@ jobs:
           - false
         include:
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "2.13.0"
+            dependencies: "lowest"
             optional-dependencies: false
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "3.1.0"
+            dependencies: "lowest"
             optional-dependencies: false
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "2.13.0"
+            dependencies: "lowest"
             optional-dependencies: true
           - php-version: "7.4"
-            dependencies: "lowest"
             dbal-version: "3.1.0"
+            dependencies: "lowest"
             optional-dependencies: true
 
     services:
@@ -77,25 +77,13 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
-        if: "! startsWith(matrix.php-version, '8')"
         with:
           dependency-versions: "${{ matrix.dependencies }}"
           composer-options: "--prefer-dist --no-suggest"
 
-      - name: "Install dependencies with Composer (--ignore-platform-req=php)"
-        uses: "ramsey/composer-install@v1"
-        if: "startsWith(matrix.php-version, '8')"
-        with:
-          dependency-versions: "${{ matrix.dependencies }}"
-          composer-options: "--prefer-dist --no-suggest --ignore-platform-req=php"
-
       - name: "Remove optional dependencies"
-        if: "! startsWith(matrix.php-version, '8') && ! matrix.optional-dependencies"
+        if: "! matrix.optional-dependencies"
         run: "composer remove --dev doctrine/data-fixtures doctrine/migrations"
-
-      - name: "Remove optional dependencies (--ignore-platform-req=php)"
-        if: "startsWith(matrix.php-version, '8') && ! matrix.optional-dependencies"
-        run: "composer remove --ignore-platform-req=php --dev doctrine/data-fixtures doctrine/migrations"
 
       - name: "Configure test application"
         run: "cp ci/config/application.config.php config/application.config.php"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -14,4 +14,3 @@ jobs:
     uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.4.1"
     with:
       php-version: '8.1'
-      composer-options: '--prefer-dist --ignore-platform-req=php'

--- a/README.md
+++ b/README.md
@@ -23,32 +23,6 @@ Run the following to install this library using [Composer](https://getcomposer.o
 composer require doctrine/doctrine-orm-module
 ```
 
-### Note on PHP 8.0 or later
-
-[DoctrineModule](https://github.com/doctrine/DoctrineModule/) provides an integration with 
-[laminas-cache](https://docs.laminas.dev/laminas-cache/), which currently comes with some storage adapters which 
-are not compatible with PHP 8.0 or later. To prevent installation of these unused cache adapters, you will need 
-to add the following to your `composer.json` file:
-
-```json
-    "require": {
-         "doctrine/doctrine-orm-module": "^4.1.0"
-    },
-    "replace": {
-        "laminas/laminas-cache-storage-adapter-apc": "*",
-        "laminas/laminas-cache-storage-adapter-dba": "*",
-        "laminas/laminas-cache-storage-adapter-memcache": "*",
-        "laminas/laminas-cache-storage-adapter-memcached": "*",
-        "laminas/laminas-cache-storage-adapter-mongodb": "*",
-        "laminas/laminas-cache-storage-adapter-wincache": "*",
-        "laminas/laminas-cache-storage-adapter-xcache": "*",
-        "laminas/laminas-cache-storage-adapter-zend-server": "*"
-    }
-```
-
-Consult the [laminas-cache documentation](https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed)
-for further information on this issue.
-
 ## Documentation
 
 Please check the [documentation on the Doctrine website](https://www.doctrine-project.org/projects/doctrine-orm-module.html)

--- a/composer.json
+++ b/composer.json
@@ -48,19 +48,19 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0",
         "ext-json": "*",
         "container-interop/container-interop": "^1.2.0",
-        "doctrine/dbal": "^2.13.4 || ^3.1.3",
-        "doctrine/doctrine-laminas-hydrator": "^2.2.1",
-        "doctrine/doctrine-module": "^4.2.2",
+        "doctrine/dbal": "^2.13.4 || ^3.1.4",
+        "doctrine/doctrine-laminas-hydrator": "^2.2.1 || ^3.0.0",
+        "doctrine/doctrine-module": "^5.0.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/orm": "^2.9.6",
-        "doctrine/persistence": "^2.2.2",
+        "doctrine/persistence": "^2.2.3",
         "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-modulemanager": "^2.11.0",
         "laminas/laminas-mvc": "^3.3.0",
         "laminas/laminas-paginator": "^2.11.0",
-        "laminas/laminas-servicemanager": "^3.7.0",
-        "laminas/laminas-stdlib": "^3.6.1",
-        "symfony/console": "^5.3.0 || ^6.0.0"
+        "laminas/laminas-servicemanager": "^3.10.0",
+        "laminas/laminas-stdlib": "^3.6.4",
+        "symfony/console": "^5.4.1 || ^6.0.1"
     },
     "require-dev": {
         "doctrine/annotations": "^1.13.2",
@@ -76,7 +76,7 @@
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.10",
         "squizlabs/php_codesniffer": "^3.6.1",
-        "vimeo/psalm": "^4.13.0"
+        "vimeo/psalm": "^4.15.0"
     },
     "conflict": {
         "doctrine/migrations": "<3.3"

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -20,34 +20,6 @@ Run the following to install this library using `Composer <https://getcomposer.o
 
    $ composer require doctrine/doctrine-orm-module
 
-Note on PHP 8.0 or later
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-`DoctrineModule <https://www.doctrine-project.org/projects/doctrine-module/en/current/index.html>`__
-provides an integration with `laminas-cache <https://docs.laminas.dev/laminas-cache/>`__, which
-currently comes with some storage adapters which are not compatible with PHP 8.0 or later. To
-prevent installation of these unused cache adapters, you will need to add the following to your
-``composer.json`` file:
-
-.. code:: json
-
-    "require": {
-         "doctrine/doctrine-orm-module": "^4.1.0"
-    },
-    "replace": {
-        "laminas/laminas-cache-storage-adapter-apc": "*",
-        "laminas/laminas-cache-storage-adapter-dba": "*",
-        "laminas/laminas-cache-storage-adapter-memcache": "*",
-        "laminas/laminas-cache-storage-adapter-memcached": "*",
-        "laminas/laminas-cache-storage-adapter-mongodb": "*",
-        "laminas/laminas-cache-storage-adapter-wincache": "*",
-        "laminas/laminas-cache-storage-adapter-xcache": "*",
-        "laminas/laminas-cache-storage-adapter-zend-server": "*"
-    }
-
-Consult the `laminas-cache documentation <https://docs.laminas.dev/laminas-cache/installation/#avoid-unused-cache-adapters-are-being-installed>`__
-for further information on this issue.
-
 Next Steps
 ----------
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,8 +6,8 @@
     <arg name="cache" value=".phpcs.cache"/>
     <arg name="colors"/>
 
-    <!-- set minimal required PHP version (7.3) -->
-    <config name="php_version" value="70300"/>
+    <!-- set minimal required PHP version (7.4) -->
+    <config name="php_version" value="70400"/>
 
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>

--- a/src/CliConfigurator.php
+++ b/src/CliConfigurator.php
@@ -21,11 +21,10 @@ use function class_exists;
 
 class CliConfigurator
 {
-    /** @var string */
-    private $defaultObjectManagerName = 'doctrine.entitymanager.orm_default';
+    private string $defaultObjectManagerName = 'doctrine.entitymanager.orm_default';
 
     /** @var string[] */
-    private $commands = [
+    private array $commands = [
         'doctrine.dbal_cmd.runsql',
         'doctrine.dbal_cmd.reserved_words',
         'doctrine.orm_cmd.clear_cache_metadata',
@@ -46,7 +45,7 @@ class CliConfigurator
     ];
 
     /** @var string[] */
-    private $migrationCommands = [
+    private array $migrationCommands = [
         'doctrine.migrations_cmd.current',
         'doctrine.migrations_cmd.diff',
         'doctrine.migrations_cmd.dumpschema',
@@ -62,8 +61,7 @@ class CliConfigurator
         'doctrine.migrations_cmd.uptodate',
     ];
 
-    /** @var ContainerInterface */
-    private $container;
+    private ContainerInterface $container;
 
     public function __construct(ContainerInterface $container)
     {

--- a/src/Collector/MappingCollector.php
+++ b/src/Collector/MappingCollector.php
@@ -25,14 +25,12 @@ class MappingCollector implements CollectorInterface, AutoHideInterface, Seriali
      */
     public const PRIORITY = 10;
 
-    /** @var string */
-    protected $name;
+    protected string $name;
 
-    /** @var ClassMetadataFactory|null */
-    protected $classMetadataFactory = null;
+    protected ?ClassMetadataFactory $classMetadataFactory = null;
 
     /** @var ClassMetadata[] indexed by class name */
-    protected $classes = [];
+    protected array $classes = [];
 
     public function __construct(ClassMetadataFactory $classMetadataFactory, string $name)
     {

--- a/src/Collector/SQLLoggerCollector.php
+++ b/src/Collector/SQLLoggerCollector.php
@@ -21,11 +21,9 @@ class SQLLoggerCollector implements CollectorInterface, AutoHideInterface
      */
     public const PRIORITY = 10;
 
-    /** @var DebugStack */
-    protected $sqlLogger;
+    protected DebugStack $sqlLogger;
 
-    /** @var string */
-    protected $name;
+    protected string $name;
 
     public function __construct(DebugStack $sqlLogger, string $name)
     {

--- a/src/Form/Annotation/DoctrineAnnotationListener.php
+++ b/src/Form/Annotation/DoctrineAnnotationListener.php
@@ -19,8 +19,7 @@ use function in_array;
 
 class DoctrineAnnotationListener extends AbstractListenerAggregate
 {
-    /** @var ObjectManager */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
 
     public function __construct(ObjectManager $objectManager)
     {

--- a/src/Form/Annotation/EntityBasedFormBuilder.php
+++ b/src/Form/Annotation/EntityBasedFormBuilder.php
@@ -33,11 +33,9 @@ final class EntityBasedFormBuilder
     public const EVENT_EXCLUDE_FIELD         = 'excludeField';
     public const EVENT_EXCLUDE_ASSOCIATION   = 'excludeAssociation';
 
-    /** @var AbstractBuilder */
-    protected $builder;
+    protected AbstractBuilder $builder;
 
-    /** @var ObjectManager */
-    protected $objectManager;
+    protected ObjectManager $objectManager;
 
     /**
      * Constructor. Ensures ObjectManager is present.

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -25,74 +25,58 @@ class Configuration extends DBALConfiguration
      * Set the cache key for the metadata cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $metadataCache = 'array';
+    protected string $metadataCache = 'array';
 
     /**
      * Set the cache key for the query cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $queryCache = 'array';
+    protected string $queryCache = 'array';
 
     /**
      * Set the cache key for the result cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $resultCache = 'array';
+    protected string $resultCache = 'array';
 
     /**
      * Set the cache key for the hydration cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $hydrationCache = 'array';
+    protected string $hydrationCache = 'array';
 
     /**
      * Set the driver key for the metadata driver. Driver key
      * is assembled as "doctrine.driver.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $driver = 'orm_default';
+    protected string $driver = 'orm_default';
 
     /**
      * Automatic generation of proxies (disable for production!)
-     *
-     * @var bool
      */
-    protected $generateProxies = true;
+    protected bool $generateProxies = true;
 
     /**
      * Proxy directory.
-     *
-     * @var string
      */
-    protected $proxyDir = 'data';
+    protected string $proxyDir = 'data';
 
     /**
      * Proxy namespace.
-     *
-     * @var string
      */
-    protected $proxyNamespace = 'DoctrineORMModule\Proxy';
+    protected string $proxyNamespace = 'DoctrineORMModule\Proxy';
 
     /**
      * Entity alias map.
      *
      * @var mixed[]
      */
-    protected $entityNamespaces = [];
+    protected array $entityNamespaces = [];
 
     /**
      * Keys must be function names and values the FQCN of the implementing class.
@@ -100,7 +84,7 @@ class Configuration extends DBALConfiguration
      *
      * @var mixed[]
      */
-    protected $datetimeFunctions = [];
+    protected array $datetimeFunctions = [];
 
     /**
      * Keys must be function names and values the FQCN of the implementing class.
@@ -108,7 +92,7 @@ class Configuration extends DBALConfiguration
      *
      * @var mixed[]
      */
-    protected $stringFunctions = [];
+    protected array $stringFunctions = [];
 
     /**
      * Keys must be function names and values the FQCN of the implementing class.
@@ -116,7 +100,7 @@ class Configuration extends DBALConfiguration
      *
      * @var mixed[]
      */
-    protected $numericFunctions = [];
+    protected array $numericFunctions = [];
 
     /**
      * Keys must be the name of the custom filter and the value must be
@@ -124,14 +108,14 @@ class Configuration extends DBALConfiguration
      *
      * @var mixed[]
      */
-    protected $filters = [];
+    protected array $filters = [];
 
     /**
      * Keys must be the name of the query and values the DQL query string.
      *
      * @var mixed[]
      */
-    protected $namedQueries = [];
+    protected array $namedQueries = [];
 
     /**
      * Keys must be the name of the query and the value is an array containing
@@ -139,7 +123,7 @@ class Configuration extends DBALConfiguration
      *
      * @var mixed[]
      */
-    protected $namedNativeQueries = [];
+    protected array $namedNativeQueries = [];
 
     /**
      * Keys must be the name of the custom hydration method and the value must be
@@ -147,7 +131,7 @@ class Configuration extends DBALConfiguration
      *
      * @var mixed[]
      */
-    protected $customHydrationModes = [];
+    protected array $customHydrationModes = [];
 
     /**
      * Naming strategy or name of the naming strategy service to be set in ORM
@@ -167,10 +151,8 @@ class Configuration extends DBALConfiguration
 
     /**
      * Default repository class
-     *
-     * @var string|null
      */
-    protected $defaultRepositoryClassName;
+    protected ?string $defaultRepositoryClassName = null;
 
     /**
      * Repository factory or name of the repository factory service to be set in ORM
@@ -183,10 +165,8 @@ class Configuration extends DBALConfiguration
     /**
      * Class name of MetaData factory to be set in ORM.
      * The entityManager will create a new instance on construction.
-     *
-     * @var string
      */
-    protected $classMetadataFactoryName;
+    protected string $classMetadataFactoryName;
 
     /**
      * Entity listener resolver or service name of the entity listener resolver
@@ -202,17 +182,13 @@ class Configuration extends DBALConfiguration
      * Configuration for second level cache
      *
      * @link http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/second-level-cache.html
-     *
-     * @var SecondLevelCacheConfiguration|null
      */
-    protected $secondLevelCache;
+    protected ?SecondLevelCacheConfiguration $secondLevelCache = null;
 
     /**
      * Configuration option for the filter schema assets expression
-     *
-     * @var string|null
      */
-    protected $filterSchemaAssetsExpression;
+    protected ?string $filterSchemaAssetsExpression = null;
 
     /**
      * @param mixed[] $datetimeFunctions

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -139,7 +139,7 @@ class Configuration extends DBALConfiguration
      *
      * @var string|NamingStrategy|null
      */
-    protected $namingStrategy;
+    protected $namingStrategy = null;
 
     /**
      * Quote strategy or name of the quote strategy service to be set in ORM
@@ -147,7 +147,7 @@ class Configuration extends DBALConfiguration
      *
      * @var string|QuoteStrategy|null
      */
-    protected $quoteStrategy;
+    protected $quoteStrategy = null;
 
     /**
      * Default repository class
@@ -160,13 +160,13 @@ class Configuration extends DBALConfiguration
      *
      * @var string|RepositoryFactory|null
      */
-    protected $repositoryFactory;
+    protected $repositoryFactory = null;
 
     /**
      * Class name of MetaData factory to be set in ORM.
      * The entityManager will create a new instance on construction.
      */
-    protected string $classMetadataFactoryName;
+    protected ?string $classMetadataFactoryName = null;
 
     /**
      * Entity listener resolver or service name of the entity listener resolver
@@ -176,7 +176,7 @@ class Configuration extends DBALConfiguration
      *
      * @var string|EntityListenerResolver|null
      */
-    protected $entityListenerResolver;
+    protected $entityListenerResolver = null;
 
     /**
      * Configuration for second level cache

--- a/src/Options/DBALConfiguration.php
+++ b/src/Options/DBALConfiguration.php
@@ -15,17 +15,13 @@ class DBALConfiguration extends AbstractOptions
      * Set the cache key for the result cache. Cache key
      * is assembled as "doctrine.cache.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $resultCache = 'array';
+    protected string $resultCache = 'array';
 
     /**
      * Set the class name of the SQL Logger, or null, to disable.
-     *
-     * @var string
      */
-    protected $sqlLogger = null;
+    protected string $sqlLogger = null;
 
     /**
      * Keys must be the name of the type identifier and value is
@@ -33,7 +29,7 @@ class DBALConfiguration extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $types = [];
+    protected array $types = [];
 
     public function setResultCache(string $resultCache): void
     {

--- a/src/Options/DBALConfiguration.php
+++ b/src/Options/DBALConfiguration.php
@@ -21,7 +21,7 @@ class DBALConfiguration extends AbstractOptions
     /**
      * Set the class name of the SQL Logger, or null, to disable.
      */
-    protected string $sqlLogger = null;
+    protected ?string $sqlLogger = null;
 
     /**
      * Keys must be the name of the type identifier and value is

--- a/src/Options/DBALConnection.php
+++ b/src/Options/DBALConnection.php
@@ -19,19 +19,15 @@ class DBALConnection extends AbstractOptions
      * Set the configuration key for the Configuration. Configuration key
      * is assembled as "doctrine.configuration.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $configuration = 'orm_default';
+    protected string $configuration = 'orm_default';
 
     /**
      * Set the eventmanager key for the EventManager. EventManager key
      * is assembled as "doctrine.eventmanager.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $eventmanager = 'orm_default';
+    protected string $eventmanager = 'orm_default';
 
     /**
      * Set the PDO instance, if any, to use. If a string is set
@@ -44,34 +40,29 @@ class DBALConnection extends AbstractOptions
     /**
      * Setting the driver is deprecated. You should set the
      * driver class directly instead.
-     *
-     * @var string
      */
-    protected $driverClass = PDOMySQLDriver::class;
+    protected string $driverClass = PDOMySQLDriver::class;
 
     /**
      * Set the wrapper class for the driver. In general, this should not
      * need to be changed.
-     *
-     * @var string|null
      */
-    protected $wrapperClass = null;
+    protected ?string $wrapperClass = null;
 
     /**
      * Driver specific connection parameters.
      *
      * @var mixed[]
      */
-    protected $params = [];
+    protected array $params = [];
 
     /** @var mixed[] */
-    protected $doctrineTypeMappings = [];
+    protected array $doctrineTypeMappings = [];
 
     /** @var mixed[] */
-    protected $doctrineCommentedTypes = [];
+    protected array $doctrineCommentedTypes = [];
 
-    /** @var bool */
-    protected $useSavepoints = false;
+    protected bool $useSavepoints = false;
 
     public function setConfiguration(string $configuration): void
     {

--- a/src/Options/EntityManager.php
+++ b/src/Options/EntityManager.php
@@ -12,29 +12,23 @@ class EntityManager extends AbstractOptions
      * Set the configuration key for the Configuration. Configuration key
      * is assembled as "doctrine.configuration.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $configuration = 'orm_default';
+    protected string $configuration = 'orm_default';
 
     /**
      * Set the connection key for the Connection. Connection key
      * is assembled as "doctrine.connection.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $connection = 'orm_default';
+    protected string $connection = 'orm_default';
 
     /**
      * Set the connection key for the EntityResolver, which is
      * a service of type {@see \Doctrine\ORM\Tools\ResolveTargetEntityListener}.
      * The EntityResolver service name is assembled
      * as "doctrine.entity_resolver.{key}"
-     *
-     * @var string
      */
-    protected $entityResolver = 'orm_default';
+    protected string $entityResolver = 'orm_default';
 
     public function setConfiguration(string $configuration): self
     {

--- a/src/Options/EntityResolver.php
+++ b/src/Options/EntityResolver.php
@@ -16,10 +16,8 @@ class EntityResolver extends AbstractOptions
      * Set the configuration key for the EventManager. Event manager key
      * is assembled as "doctrine.eventmanager.{key}" and pulled from
      * service locator.
-     *
-     * @var string
      */
-    protected $eventManager = 'orm_default';
+    protected string $eventManager = 'orm_default';
 
     /**
      * An array that maps a class name (or interface name) to another class
@@ -27,7 +25,7 @@ class EntityResolver extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $resolvers = [];
+    protected array $resolvers = [];
 
     public function setEventManager(string $eventManager): self
     {

--- a/src/Options/SQLLoggerCollectorOptions.php
+++ b/src/Options/SQLLoggerCollectorOptions.php
@@ -12,13 +12,13 @@ use Laminas\Stdlib\AbstractOptions;
 class SQLLoggerCollectorOptions extends AbstractOptions
 {
     /** @var string name to be assigned to the collector */
-    protected $name = 'orm_default';
+    protected string $name = 'orm_default';
 
     /** @var string|null service name of the configuration where the logger has to be put */
-    protected $configuration;
+    protected ?string $configuration = null;
 
     /** @var string|null service name of the SQLLogger to be used */
-    protected $sqlLogger;
+    protected ?string $sqlLogger = null;
 
     public function setName(?string $name): void
     {

--- a/src/Options/SecondLevelCacheConfiguration.php
+++ b/src/Options/SecondLevelCacheConfiguration.php
@@ -13,31 +13,23 @@ class SecondLevelCacheConfiguration extends AbstractOptions
 {
     /**
      * Enable the second level cache configuration
-     *
-     * @var bool
      */
-    protected $enabled = false;
+    protected bool $enabled = false;
 
     /**
      * Default lifetime
-     *
-     * @var int
      */
-    protected $defaultLifetime = 3600;
+    protected int $defaultLifetime = 3600;
 
     /**
      * Default lock lifetime
-     *
-     * @var int
      */
-    protected $defaultLockLifetime = 60;
+    protected int $defaultLockLifetime = 60;
 
     /**
      * The file lock region directory (needed for some cache usage)
-     *
-     * @var string
      */
-    protected $fileLockRegionDirectory = '';
+    protected string $fileLockRegionDirectory = '';
 
     /**
      * Configure the lifetime and lock lifetime per region. You must pass an associative array like this:
@@ -48,7 +40,7 @@ class SecondLevelCacheConfiguration extends AbstractOptions
      *
      * @var mixed[]
      */
-    protected $regions = [];
+    protected array $regions = [];
 
     public function setEnabled(bool $enabled): void
     {

--- a/src/Paginator/Adapter/DoctrinePaginator.php
+++ b/src/Paginator/Adapter/DoctrinePaginator.php
@@ -14,8 +14,7 @@ use ReturnTypeWillChange;
  */
 class DoctrinePaginator implements AdapterInterface, JsonSerializable
 {
-    /** @var Paginator */
-    protected $paginator;
+    protected Paginator $paginator;
 
     /**
      * Constructor

--- a/src/Service/DBALConfigurationFactory.php
+++ b/src/Service/DBALConfigurationFactory.php
@@ -20,8 +20,7 @@ use function sprintf;
  */
 class DBALConfigurationFactory implements FactoryInterface
 {
-    /** @var string */
-    protected $name;
+    protected string $name;
 
     public function __construct(string $name)
     {

--- a/src/Service/MigrationsCommandFactory.php
+++ b/src/Service/MigrationsCommandFactory.php
@@ -25,11 +25,9 @@ use function ucfirst;
  */
 class MigrationsCommandFactory implements FactoryInterface
 {
-    /** @var string */
-    private $commandClassName;
+    private string $commandClassName;
 
-    /** @var string */
-    private $defaultObjectManagerName = 'doctrine.entitymanager.orm_default';
+    private string $defaultObjectManagerName = 'doctrine.entitymanager.orm_default';
 
     public function __construct(string $name)
     {

--- a/src/Service/SQLLoggerCollectorFactory.php
+++ b/src/Service/SQLLoggerCollectorFactory.php
@@ -20,8 +20,7 @@ use function sprintf;
  */
 class SQLLoggerCollectorFactory implements FactoryInterface
 {
-    /** @var string */
-    protected $name;
+    protected string $name;
 
     public function __construct(string $name)
     {

--- a/src/Yuml/MetadataGrapher.php
+++ b/src/Yuml/MetadataGrapher.php
@@ -23,17 +23,17 @@ class MetadataGrapher
      *
      * @var mixed[]
      */
-    protected $visitedAssociations = [];
+    protected array $visitedAssociations = [];
 
     /** @var ClassMetadata[] */
-    private $metadata;
+    private array $metadata;
 
     /**
      * Temporary array where reverse association name are stored
      *
      * @var ClassMetadata[]
      */
-    private $classByNames = [];
+    private array $classByNames = [];
 
     /**
      * Generate a YUML compatible `dsl_text` to describe a given array

--- a/src/Yuml/YumlController.php
+++ b/src/Yuml/YumlController.php
@@ -17,8 +17,7 @@ use function assert;
  */
 class YumlController extends AbstractActionController
 {
-    /** @var Client */
-    protected $httpClient;
+    protected Client $httpClient;
 
     public function __construct(Client $httpClient)
     {

--- a/tests/Assets/Entity/Category.php
+++ b/tests/Assets/Entity/Category.php
@@ -16,17 +16,11 @@ class Category
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string
-     */
-    protected $name;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected string $name;
 
     public function getId(): ?int
     {

--- a/tests/Assets/Entity/City.php
+++ b/tests/Assets/Entity/City.php
@@ -16,24 +16,14 @@ class City
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string
-     */
-    protected $name;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected string $name;
 
-    /**
-     * @ORM\OneToOne(targetEntity="Country")
-     *
-     * @var Country
-     */
-    protected $country;
+    /** @ORM\OneToOne(targetEntity="Country") */
+    protected Country $country;
 
     public function getId(): ?int
     {

--- a/tests/Assets/Entity/Country.php
+++ b/tests/Assets/Entity/Country.php
@@ -16,17 +16,11 @@ class Country
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string
-     */
-    protected $name;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected string $name;
 
     public function getId(): ?int
     {

--- a/tests/Assets/Entity/Date.php
+++ b/tests/Assets/Entity/Date.php
@@ -17,17 +17,11 @@ class Date
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="date", nullable=true)
-     *
-     * @var DateTime
-     */
-    protected $date;
+    /** @ORM\Column(type="date", nullable=true) */
+    protected DateTime $date;
 
     public function getId(): ?int
     {

--- a/tests/Assets/Entity/EntityWithoutRepository.php
+++ b/tests/Assets/Entity/EntityWithoutRepository.php
@@ -15,10 +15,8 @@ class EntityWithoutRepository
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var ?int
      */
-    private $id;
+    private ?int $id = null;
 
     public function getId(): ?int
     {

--- a/tests/Assets/Entity/FormEntity.php
+++ b/tests/Assets/Entity/FormEntity.php
@@ -18,130 +18,62 @@ class FormEntity
     /**
      * @ORM\Id
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="boolean")
-     *
-     * @var bool
-     */
-    protected $bool;
+    /** @ORM\Column(type="boolean") */
+    protected bool $bool;
 
-    /**
-     * @ORM\Column(type="boolean")
-     *
-     * @var bool
-     */
-    protected $boolean;
+    /** @ORM\Column(type="boolean") */
+    protected bool $boolean;
 
-    /**
-     * @ORM\Column(type="float")
-     *
-     * @var float
-     */
-    protected $float;
+    /** @ORM\Column(type="float") */
+    protected float $float;
 
-    /**
-     * @ORM\Column(type="bigint")
-     *
-     * @var int
-     */
-    protected $bigint;
+    /** @ORM\Column(type="bigint") */
+    protected int $bigint;
 
-    /**
-     * @ORM\Column(type="integer")
-     *
-     * @var int
-     */
-    protected $integer;
+    /** @ORM\Column(type="integer") */
+    protected int $integer;
 
-    /**
-     * @ORM\Column(type="smallint")
-     *
-     * @var int
-     */
-    protected $smallint;
+    /** @ORM\Column(type="smallint") */
+    protected int $smallint;
 
-    /**
-     * @ORM\Column(type="datetime")
-     *
-     * @var DateTime
-     */
-    protected $datetime;
+    /** @ORM\Column(type="datetime") */
+    protected DateTime $datetime;
 
-    /**
-     * @ORM\Column(type="datetime_immutable")
-     *
-     * @var DateTime
-     */
-    protected $datetimeImmutable;
+    /** @ORM\Column(type="datetime_immutable") */
+    protected DateTime $datetimeImmutable;
 
-    /**
-     * @ORM\Column(type="datetimetz")
-     *
-     * @var DateTimeImmutable
-     */
-    protected $datetimetz;
+    /** @ORM\Column(type="datetimetz") */
+    protected DateTimeImmutable $datetimetz;
 
-    /**
-     * @ORM\Column(type="datetimetz_immutable")
-     *
-     * @var DateTimeImmutable
-     */
-    protected $datetimetzImmutable;
+    /** @ORM\Column(type="datetimetz_immutable") */
+    protected DateTimeImmutable $datetimetzImmutable;
 
-    /**
-     * @ORM\Column(type="date")
-     *
-     * @var DateTime
-     */
-    protected $date;
+    /** @ORM\Column(type="date") */
+    protected DateTime $date;
 
-    /**
-     * @ORM\Column(type="time")
-     *
-     * @var DateTime
-     */
-    protected $time;
+    /** @ORM\Column(type="time") */
+    protected DateTime $time;
 
-    /**
-     * @ORM\Column(type="text")
-     *
-     * @var string
-     */
-    protected $text;
+    /** @ORM\Column(type="text") */
+    protected string $text;
 
-    /**
-     * @ORM\Column(type="string", nullable=false, length=20)
-     *
-     * @var string
-     */
-    protected $string;
+    /** @ORM\Column(type="string", nullable=false, length=20) */
+    protected string $string;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string|null
-     */
-    protected $stringNullable;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected ?string $stringNullable = null;
 
-    /**
-     * @ORM\OneToOne(targetEntity="Target")
-     *
-     * @var Target
-     */
-    protected $targetOne;
+    /** @ORM\OneToOne(targetEntity="Target") */
+    protected Target $targetOne;
 
     /**
      * @ORM\OneToOne(targetEntity="Target")
      * @ORM\JoinColumn(nullable=true)
-     *
-     * @var Target|null
      */
-    protected $targetOneNullable;
+    protected ?Target $targetOneNullable = null;
 
    /**
     * @ORM\OneToOne(targetEntity="Target")
@@ -149,27 +81,23 @@ class FormEntity
     *
     * @Form\Type("DoctrineModule\Form\Element\ObjectSelect")
     * @Form\Options({"empty_option":null})
-    *
-    * @var Target|null
     */
-    protected $noDisplayEmptyOption;
+    protected ?Target $noDisplayEmptyOption = null;
 
     /**
      * @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntity")
      *
      * @var Target[]
      */
-    protected $targetMany;
+    protected array $targetMany;
 
     /**
      * @ORM\Column(type="integer")
      *
      * @Form\Options({"label":"Please Choose", "value_options":{"f":"false","t":"true"}})
      * @Form\Type("Radio")
-     *
-     * @var int
      */
-    protected $specificType;
+    protected int $specificType;
 
     /**
      * @ORM\OneToMany(targetEntity="FormEntityTarget", mappedBy="formEntityMulti")
@@ -178,17 +106,15 @@ class FormEntity
      *
      * @var FormEntityTarget[]
      */
-    protected $specificMultiType;
+    protected array $specificMultiType;
 
     /**
      * @ORM\Column(type="integer")
      *
      * @Form\Options({"label":"Please Choose", "value_options":{"f":"false","t":"true"}})
      * @Form\Attributes({"type":"textarea"})
-     *
-     * @var int
      */
-    protected $specificAttributeType;
+    protected int $specificAttributeType;
 
     /**
      * @ORM\Column(type="string", length=256)
@@ -196,8 +122,6 @@ class FormEntity
      *
      * @Form\Type("File")
      * @Form\Options({"label":"Image"})
-     *
-     * @var string
      */
-    protected $image;
+    protected string $image;
 }

--- a/tests/Assets/Entity/FormEntityTarget.php
+++ b/tests/Assets/Entity/FormEntityTarget.php
@@ -15,8 +15,6 @@ class FormEntityTarget
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 }

--- a/tests/Assets/Entity/Issue237.php
+++ b/tests/Assets/Entity/Issue237.php
@@ -16,8 +16,6 @@ class Issue237
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="IDENTITY")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 }

--- a/tests/Assets/Entity/Product.php
+++ b/tests/Assets/Entity/Product.php
@@ -16,24 +16,18 @@ class Product
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string
-     */
-    protected $name;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected string $name;
 
     /**
      * @ORM\ManyToMany(targetEntity="Category")
      *
      * @var Category[]
      */
-    protected $categories;
+    protected array $categories;
 
     public function getId(): ?int
     {

--- a/tests/Assets/Entity/ResolveTarget.php
+++ b/tests/Assets/Entity/ResolveTarget.php
@@ -15,15 +15,9 @@ class ResolveTarget
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\OneToOne(targetEntity="Target")
-     *
-     * @var Target
-     */
-    protected $target;
+    /** @ORM\OneToOne(targetEntity="Target") */
+    protected Target $target;
 }

--- a/tests/Assets/Entity/TargetEntity.php
+++ b/tests/Assets/Entity/TargetEntity.php
@@ -15,10 +15,8 @@ class TargetEntity implements Target
      * @ORM\Id
      * @ORM\Column(type="integer")
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    private $id;
+    private int $id;
 
     public function getId(): int
     {

--- a/tests/Assets/Entity/Test.php
+++ b/tests/Assets/Entity/Test.php
@@ -16,24 +16,14 @@ class Test
      * @ORM\Id
      * @ORM\Column(type="integer");
      * @ORM\GeneratedValue(strategy="AUTO")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string
-     */
-    protected $username;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected string $username;
 
-    /**
-     * @ORM\Column(type="string", nullable=true)
-     *
-     * @var string
-     */
-    protected $password;
+    /** @ORM\Column(type="string", nullable=true) */
+    protected string $password;
 
     public function getId(): ?int
     {

--- a/tests/Assets/GraphEntity/Address.php
+++ b/tests/Assets/GraphEntity/Address.php
@@ -19,8 +19,6 @@ class Address
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 }

--- a/tests/Assets/GraphEntity/Session.php
+++ b/tests/Assets/GraphEntity/Session.php
@@ -19,15 +19,9 @@ class Session
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
-    /**
-     * @ORM\ManyToOne(targetEntity="User", inversedBy="address")
-     *
-     * @var User
-     */
-    protected $user;
+    /** @ORM\ManyToOne(targetEntity="User", inversedBy="address") */
+    protected User $user;
 }

--- a/tests/Assets/GraphEntity/User.php
+++ b/tests/Assets/GraphEntity/User.php
@@ -21,31 +21,25 @@ class User
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
     /**
      * @ORM\ManyToMany(targetEntity="UserGroup", mappedBy="users")
      *
      * @var Collection|UserGroup[]
      */
-    protected $groups;
+    protected Collection $groups;
 
     /**
      * @ORM\OneToMany(targetEntity="Session", mappedBy="user")
      *
      * @var Collection|Session[]
      */
-    protected $sessions;
+    protected Collection $sessions;
 
-    /**
-     * @ORM\OneToOne(targetEntity="Address")
-     *
-     * @var Address
-     */
-    protected $address;
+    /** @ORM\OneToOne(targetEntity="Address") */
+    protected Address $address;
 
     public function __construct()
     {

--- a/tests/Assets/GraphEntity/UserGroup.php
+++ b/tests/Assets/GraphEntity/UserGroup.php
@@ -21,17 +21,15 @@ class UserGroup
      * @ORM\Id()
      * @ORM\GeneratedValue(strategy="AUTO")
      * @ORM\Column(type="integer")
-     *
-     * @var int
      */
-    protected $id;
+    protected int $id;
 
     /**
      * @ORM\ManyToMany(targetEntity="User", inversedBy="groups")
      *
      * @var Collection|User[]
      */
-    protected $users;
+    protected Collection $users;
 
     public function __construct()
     {

--- a/tests/CliConfiguratorTest.php
+++ b/tests/CliConfiguratorTest.php
@@ -40,11 +40,9 @@ use function class_exists;
  */
 class CliConfiguratorTest extends TestCase
 {
-    /** @var ServiceManager */
-    protected $serviceManager;
+    protected ServiceManager $serviceManager;
 
-    /** @var EntityManager */
-    protected $objectManager;
+    protected EntityManager $objectManager;
 
     public function setUp(): void
     {

--- a/tests/Collector/MappingCollectorTest.php
+++ b/tests/Collector/MappingCollectorTest.php
@@ -23,8 +23,7 @@ class MappingCollectorTest extends TestCase
     /** @var ClassMetadataFactory&MockObject */
     protected $metadataFactory;
 
-    /** @var MappingCollector */
-    protected $collector;
+    protected MappingCollector $collector;
 
     /**
      * @covers \DoctrineORMModule\Collector\MappingCollector::__construct

--- a/tests/Collector/SQLLoggerCollectorTest.php
+++ b/tests/Collector/SQLLoggerCollectorTest.php
@@ -14,14 +14,11 @@ use function sleep;
 
 class SQLLoggerCollectorTest extends TestCase
 {
-    /** @var DebugStack */
-    protected $logger;
+    protected DebugStack $logger;
 
-    /** @var string */
-    protected $name = 'test-collector-name';
+    protected string $name = 'test-collector-name';
 
-    /** @var SQLLoggerCollector */
-    protected $collector;
+    protected SQLLoggerCollector $collector;
 
     public function setUp(): void
     {

--- a/tests/Form/Annotation/DoctrineAnnotationListenerTest.php
+++ b/tests/Form/Annotation/DoctrineAnnotationListenerTest.php
@@ -22,8 +22,7 @@ use Laminas\Form\Element\Time;
 
 class DoctrineAnnotationListenerTest extends TestCase
 {
-    /** @var DoctrineAnnotationListener */
-    protected $listener;
+    protected DoctrineAnnotationListener $listener;
 
     public function setUp(): void
     {

--- a/tests/Form/Annotation/EntityBasedFormBuilderTest.php
+++ b/tests/Form/Annotation/EntityBasedFormBuilderTest.php
@@ -20,8 +20,7 @@ use function sprintf;
 
 class EntityBasedFormBuilderTest extends TestCase
 {
-    /** @var EntityBasedFormBuilder */
-    protected $builder;
+    protected EntityBasedFormBuilder $builder;
 
     public function setUp(): void
     {

--- a/tests/Framework/TestCase.php
+++ b/tests/Framework/TestCase.php
@@ -14,11 +14,9 @@ use PHPUnit\Framework\TestCase as PHPUnitTestCase;
  */
 class TestCase extends PHPUnitTestCase
 {
-    /** @var bool */
-    protected $hasDb = false;
+    protected bool $hasDb = false;
 
-    /** @var ?EntityManager */
-    private $entityManager = null;
+    private ?EntityManager $entityManager = null;
 
     /**
      * Creates a database if not done already.

--- a/tests/Paginator/AdapterTest.php
+++ b/tests/Paginator/AdapterTest.php
@@ -19,14 +19,11 @@ use function count;
 
 class AdapterTest extends TestCase
 {
-    /** @var QueryBuilder */
-    protected $queryBuilder;
+    protected QueryBuilder $queryBuilder;
 
-    /** @var PaginatorAdapter */
-    protected $paginatorAdapter;
+    protected PaginatorAdapter $paginatorAdapter;
 
-    /** @var DoctrinePaginator */
-    protected $paginator;
+    protected DoctrinePaginator $paginator;
 
     public function setUp(): void
     {

--- a/tests/Service/ConfigurationFactoryTest.php
+++ b/tests/Service/ConfigurationFactoryTest.php
@@ -23,10 +23,8 @@ use function assert;
 
 class ConfigurationFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
-    protected $serviceManager;
-    /** @var ConfigurationFactory */
-    protected $factory;
+    protected ServiceManager $serviceManager;
+    protected ConfigurationFactory $factory;
 
     public function setUp(): void
     {

--- a/tests/Service/DBALConnectionFactoryTest.php
+++ b/tests/Service/DBALConnectionFactoryTest.php
@@ -22,10 +22,8 @@ use PHPUnit\Framework\TestCase;
  */
 class DBALConnectionFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
-    protected $serviceManager;
-    /** @var DBALConnectionFactory */
-    protected $factory;
+    protected ServiceManager $serviceManager;
+    protected DBALConnectionFactory $factory;
 
     public function setUp(): void
     {

--- a/tests/Service/MigrationsCommandFactoryTest.php
+++ b/tests/Service/MigrationsCommandFactoryTest.php
@@ -40,8 +40,7 @@ use function class_exists;
  */
 class MigrationsCommandFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
-    private $serviceLocator;
+    private ServiceManager $serviceLocator;
 
     public function setUp(): void
     {

--- a/tests/Service/RunSqlCommandFactoryTest.php
+++ b/tests/Service/RunSqlCommandFactoryTest.php
@@ -15,8 +15,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RunSqlCommandFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
-    private $serviceLocator;
+    private ServiceManager $serviceLocator;
 
     public function setUp(): void
     {

--- a/tests/Service/SQLLoggerCollectorFactoryTest.php
+++ b/tests/Service/SQLLoggerCollectorFactoryTest.php
@@ -16,11 +16,9 @@ use function assert;
 
 class SQLLoggerCollectorFactoryTest extends TestCase
 {
-    /** @var ServiceManager */
-    protected $services;
+    protected ServiceManager $services;
 
-    /** @var SQLLoggerCollectorFactory */
-    protected $factory;
+    protected SQLLoggerCollectorFactory $factory;
 
     public function setUp(): void
     {

--- a/tests/Yuml/MetadataGrapherTest.php
+++ b/tests/Yuml/MetadataGrapherTest.php
@@ -19,8 +19,7 @@ use function strtoupper;
  */
 class MetadataGrapherTest extends TestCase
 {
-    /** @var MetadataGrapher */
-    protected $grapher;
+    protected MetadataGrapher $grapher;
 
     public function setUp(): void
     {

--- a/tests/Yuml/YumlControllerTest.php
+++ b/tests/Yuml/YumlControllerTest.php
@@ -20,8 +20,7 @@ use UnexpectedValueException;
  */
 class YumlControllerTest extends TestCase
 {
-    /** @var YumlController */
-    protected $controller;
+    protected YumlController $controller;
 
     /** @var Client&MockObject */
     protected $httpClient;


### PR DESCRIPTION
As the upcoming 5.0.0 release of DoctrineORMModule will require PHP 7.4 at least, we can use typed properties in all places. Obviously, this will be a BC break in several places, but we should accept that in favour of code quality improvements. As 5.0.0 is a major release, this should be fine.

This is currently based on #702, as it requires DoctrineModule 5.0, which is strongly typed as well.