### PR TITLE
Removed signatures related to laminas-servicemanager 2.x 

### DIFF
--- a/src/Service/CliConfiguratorFactory.php
+++ b/src/Service/CliConfiguratorFactory.php
@@ -6,8 +6,7 @@ namespace DoctrineORMModule\Service;
 
 use DoctrineORMModule\CliConfigurator;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class CliConfiguratorFactory implements FactoryInterface
 {
@@ -17,15 +16,5 @@ class CliConfiguratorFactory implements FactoryInterface
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, ?array $options = null)
     {
         return new CliConfigurator($serviceLocator);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, CliConfigurator::class);
     }
 }

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -13,7 +13,6 @@ use DoctrineORMModule\Options\Configuration as DoctrineORMModuleConfiguration;
 use DoctrineORMModule\Service\DBALConfigurationFactory as DoctrineConfigurationFactory;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Exception\InvalidArgumentException;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function is_string;
 use function method_exists;
@@ -163,14 +162,6 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
         $this->setupDBALConfiguration($serviceLocator, $config);
 
         return $config;
-    }
-
-    /**
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator): Configuration
-    {
-        return $this($serviceLocator, Configuration::class);
     }
 
     protected function getOptionsClass(): string

--- a/src/Service/DBALConfigurationFactory.php
+++ b/src/Service/DBALConfigurationFactory.php
@@ -8,8 +8,7 @@ use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Types\Type;
 use DoctrineORMModule\Options\Configuration as DoctrineORMModuleConfiguration;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use RuntimeException;
 
 use function is_string;
@@ -38,18 +37,6 @@ class DBALConfigurationFactory implements FactoryInterface
         $this->setupDBALConfiguration($serviceLocator, $config);
 
         return $config;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return Configuration
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, Configuration::class);
     }
 
     public function setupDBALConfiguration(ContainerInterface $serviceLocator, Configuration $config): void

--- a/src/Service/DBALConnectionFactory.php
+++ b/src/Service/DBALConnectionFactory.php
@@ -10,7 +10,6 @@ use Doctrine\DBAL\Types\Type;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\DBALConnection;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 use PDO;
 
 use function array_key_exists;
@@ -72,18 +71,6 @@ class DBALConnectionFactory extends AbstractFactory
         }
 
         return $connection;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return Connection
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, Connection::class);
     }
 
     /**

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -6,8 +6,7 @@ namespace DoctrineORMModule\Service;
 
 use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class DoctrineObjectHydratorFactory implements FactoryInterface
 {
@@ -17,15 +16,5 @@ class DoctrineObjectHydratorFactory implements FactoryInterface
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, ?array $options = null)
     {
         return new DoctrineObject($serviceLocator->get('doctrine.entitymanager.orm_default'));
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, DoctrineObject::class);
     }
 }

--- a/src/Service/EntityManagerAliasCompatFactory.php
+++ b/src/Service/EntityManagerAliasCompatFactory.php
@@ -6,8 +6,7 @@ namespace DoctrineORMModule\Service;
 
 use Doctrine\ORM\EntityManager;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory that provides the `Doctrine\ORM\EntityManager` alias for `doctrine.entitymanager.orm_default`
@@ -25,19 +24,5 @@ class EntityManagerAliasCompatFactory implements FactoryInterface
     public function __invoke(ContainerInterface $serviceLocator, $requestedName, ?array $options = null)
     {
         return $serviceLocator->get('doctrine.entitymanager.orm_default');
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated this method was introduced to allow aliasing of service `Doctrine\ORM\EntityManager`
-     *             from `doctrine.entitymanager.orm_default`
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return EntityManager
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, EntityManager::class);
     }
 }

--- a/src/Service/EntityManagerFactory.php
+++ b/src/Service/EntityManagerFactory.php
@@ -33,18 +33,6 @@ class EntityManagerFactory extends AbstractFactory
         return EntityManager::create($connection, $config);
     }
 
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return EntityManager
-     */
-    public function createService(ContainerInterface $container)
-    {
-        return $this($container, EntityManager::class);
-    }
-
     public function getOptionsClass(): string
     {
         return DoctrineORMModuleEntityManager::class;

--- a/src/Service/EntityResolverFactory.php
+++ b/src/Service/EntityResolverFactory.php
@@ -8,8 +8,6 @@ use Doctrine\ORM\Tools\ResolveTargetEntityListener;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Options\EntityResolver;
 use Interop\Container\ContainerInterface;
-use Laminas\EventManager\EventManager;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 use function assert;
 
@@ -34,16 +32,6 @@ class EntityResolverFactory extends AbstractFactory
         $eventManager->addEventSubscriber($targetEntityListener);
 
         return $eventManager;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, EventManager::class);
     }
 
     /**

--- a/src/Service/MappingCollectorFactory.php
+++ b/src/Service/MappingCollectorFactory.php
@@ -8,7 +8,6 @@ use BadMethodCallException;
 use DoctrineModule\Service\AbstractFactory;
 use DoctrineORMModule\Collector\MappingCollector;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
 
 /**
  * Service factory responsible for instantiating {@see \DoctrineORMModule\Collector\MappingCollector}
@@ -26,18 +25,6 @@ class MappingCollectorFactory extends AbstractFactory
         $objectManager = $container->get('doctrine.entitymanager.' . $name);
 
         return new MappingCollector($objectManager->getMetadataFactory(), 'doctrine.mapping_collector.' . $name);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @return MappingCollector
-     */
-    public function createService(ServiceLocatorInterface $container)
-    {
-        return $this($container, MappingCollector::class);
     }
 
     public function getOptionsClass(): string

--- a/src/Service/MigrationsCommandFactory.php
+++ b/src/Service/MigrationsCommandFactory.php
@@ -10,8 +10,7 @@ use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
 use Interop\Container\ContainerInterface;
 use InvalidArgumentException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use RuntimeException;
 use Symfony\Component\Console\Input\ArgvInput;
 
@@ -100,16 +99,6 @@ class MigrationsCommandFactory implements FactoryInterface
         // An object manager may not have a migrations configuration and that's OK.
         // Use default values in that case.
         return new $commandClassName($dependencyFactory);
-    }
-
-    /**
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     *
-     * @throws InvalidArgumentException
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator): DoctrineCommand
-    {
-        return $this($serviceLocator, $this->commandClassName);
     }
 
     private function getObjectManagerName(): string

--- a/src/Service/ObjectMultiCheckboxFactory.php
+++ b/src/Service/ObjectMultiCheckboxFactory.php
@@ -7,8 +7,7 @@ namespace DoctrineORMModule\Service;
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectMultiCheckbox;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory for {@see ObjectMultiCheckbox}
@@ -28,15 +27,5 @@ class ObjectMultiCheckboxFactory implements FactoryInterface
         $element->getProxy()->setObjectManager($entityManager);
 
         return $element;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ObjectMultiCheckbox::class);
     }
 }

--- a/src/Service/ObjectRadioFactory.php
+++ b/src/Service/ObjectRadioFactory.php
@@ -7,8 +7,7 @@ namespace DoctrineORMModule\Service;
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectRadio;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory for {@see ObjectRadio}
@@ -28,15 +27,5 @@ class ObjectRadioFactory implements FactoryInterface
         $element->getProxy()->setObjectManager($entityManager);
 
         return $element;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ObjectRadio::class);
     }
 }

--- a/src/Service/ObjectSelectFactory.php
+++ b/src/Service/ObjectSelectFactory.php
@@ -7,8 +7,7 @@ namespace DoctrineORMModule\Service;
 use Doctrine\ORM\EntityManager;
 use DoctrineModule\Form\Element\ObjectSelect;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 /**
  * Factory for {@see ObjectSelect}
@@ -28,15 +27,5 @@ class ObjectSelectFactory implements FactoryInterface
         $element->getProxy()->setObjectManager($entityManager);
 
         return $element;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ObjectSelect::class);
     }
 }

--- a/src/Service/ReservedWordsCommandFactory.php
+++ b/src/Service/ReservedWordsCommandFactory.php
@@ -7,8 +7,7 @@ namespace DoctrineORMModule\Service;
 use Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class ReservedWordsCommandFactory implements FactoryInterface
 {
@@ -20,15 +19,5 @@ class ReservedWordsCommandFactory implements FactoryInterface
         return new ReservedWordsCommand(
             new SingleConnectionProvider($serviceLocator->get('doctrine.connection.orm_default'))
         );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, ReservedWordsCommand::class);
     }
 }

--- a/src/Service/RunSqlCommandFactory.php
+++ b/src/Service/RunSqlCommandFactory.php
@@ -7,8 +7,7 @@ namespace DoctrineORMModule\Service;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
 use Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 class RunSqlCommandFactory implements FactoryInterface
 {
@@ -20,15 +19,5 @@ class RunSqlCommandFactory implements FactoryInterface
         return new RunSqlCommand(
             new SingleConnectionProvider($serviceLocator->get('doctrine.connection.orm_default'))
         );
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, RunSqlCommand::class);
     }
 }

--- a/src/Service/SQLLoggerCollectorFactory.php
+++ b/src/Service/SQLLoggerCollectorFactory.php
@@ -9,8 +9,7 @@ use Doctrine\DBAL\Logging\LoggerChain;
 use DoctrineORMModule\Collector\SQLLoggerCollector;
 use DoctrineORMModule\Options\SQLLoggerCollectorOptions;
 use Interop\Container\ContainerInterface;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 use RuntimeException;
 
 use function sprintf;
@@ -54,16 +53,6 @@ class SQLLoggerCollectorFactory implements FactoryInterface
         }
 
         return new SQLLoggerCollector($debugStackLogger, 'doctrine.sql_logger_collector.' . $options->getName());
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator)
-    {
-        return $this($serviceLocator, SQLLoggerCollector::class);
     }
 
     /**

--- a/src/Yuml/YumlControllerFactory.php
+++ b/src/Yuml/YumlControllerFactory.php
@@ -6,29 +6,13 @@ namespace DoctrineORMModule\Yuml;
 
 use Interop\Container\ContainerInterface;
 use Laminas\Http\Client;
-use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
-use Laminas\ServiceManager\FactoryInterface;
-use Laminas\ServiceManager\ServiceLocatorInterface;
+use Laminas\ServiceManager\Factory\FactoryInterface;
 
 use function sprintf;
 
 class YumlControllerFactory implements FactoryInterface
 {
-    /**
-     * Create service
-     *
-     * @deprecated 4.1.0 With laminas-servicemanager v3 this method is obsolete and will be removed in 5.0.0.
-     */
-    public function createService(ServiceLocatorInterface $serviceLocator): YumlController
-    {
-        if ($serviceLocator instanceof AbstractPluginManager) {
-            $serviceLocator = $serviceLocator->getServiceLocator();
-        }
-
-        return $this($serviceLocator, YumlController::class);
-    }
-
     /**
      * Create an object
      *

--- a/tests/ConfigProviderTest.php
+++ b/tests/ConfigProviderTest.php
@@ -16,7 +16,7 @@ class ConfigProviderTest extends TestCase
 {
     public function testInvokeHasDependencyKeyAndNotServiceManager(): void
     {
-        $config = (new ConfigProvider())->__invoke();
+        $config = (new ConfigProvider())();
 
         self::assertArrayHasKey('dependencies', $config, 'Expected config to have "dependencies" array key');
         self::assertArrayNotHasKey('service_manager', $config, 'Config should not have "service_manager" array key');

--- a/tests/Service/ConfigurationFactoryTest.php
+++ b/tests/Service/ConfigurationFactoryTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\Mapping\EntityListenerResolver;
 use Doctrine\ORM\Mapping\NamingStrategy;
 use Doctrine\ORM\Mapping\QuoteStrategy;
 use Doctrine\Persistence\Mapping\Driver\MappingDriver;
+use DoctrineORMModule\Options\Configuration;
 use DoctrineORMModule\Service\ConfigurationFactory;
 use DoctrineORMModuleTest\Assets\RepositoryClass;
 use Laminas\ServiceManager\Exception\InvalidArgumentException;
@@ -47,7 +48,7 @@ class ConfigurationFactoryTest extends TestCase
             ],
         ];
         $this->serviceManager->setService('config', $config);
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
         $this->assertInstanceOf(NamingStrategy::class, $ormConfig->getNamingStrategy());
     }
 
@@ -64,7 +65,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $factory   = new ConfigurationFactory('test_default');
-        $ormConfig = $factory->createService($this->serviceManager);
+        $ormConfig = $factory($this->serviceManager, Configuration::class);
         $this->assertSame($namingStrategy, $ormConfig->getNamingStrategy());
     }
 
@@ -80,7 +81,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('test_naming_strategy', $namingStrategy);
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
         $this->assertSame($namingStrategy, $ormConfig->getNamingStrategy());
     }
 
@@ -95,7 +96,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $this->expectException(InvalidArgumentException::class);
-        $this->factory->createService($this->serviceManager);
+        ($this->factory)($this->serviceManager, Configuration::class);
     }
 
     public function testWillInstantiateConfigWithQuoteStrategyObject(): void
@@ -111,7 +112,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $factory   = new ConfigurationFactory('test_default');
-        $ormConfig = $factory->createService($this->serviceManager);
+        $ormConfig = $factory($this->serviceManager, Configuration::class);
         $this->assertSame($quoteStrategy, $ormConfig->getQuoteStrategy());
     }
 
@@ -127,7 +128,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('test_quote_strategy', $quoteStrategy);
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
         $this->assertSame($quoteStrategy, $ormConfig->getQuoteStrategy());
     }
 
@@ -142,7 +143,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $this->expectException(InvalidArgumentException::class);
-        $this->factory->createService($this->serviceManager);
+        ($this->factory)($this->serviceManager, Configuration::class);
     }
 
     public function testWillInstantiateConfigWithHydrationCacheSetting(): void
@@ -156,7 +157,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $factory   = new ConfigurationFactory('test_default');
-        $ormConfig = $factory->createService($this->serviceManager);
+        $ormConfig = $factory($this->serviceManager, Configuration::class);
         $this->assertInstanceOf(ArrayCache::class, $ormConfig->getHydrationCacheImpl());
     }
 
@@ -176,7 +177,7 @@ class ConfigurationFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
 
         $factory   = new ConfigurationFactory('test_default');
-        $ormConfig = $factory->createService($this->serviceManager);
+        $ormConfig = $factory($this->serviceManager, Configuration::class);
         $this->assertInstanceOf(ArrayCache::class, $ormConfig->getHydrationCacheImpl());
     }
 
@@ -191,7 +192,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $factory   = new ConfigurationFactory('test_default');
-        $ormConfig = $factory->createService($this->serviceManager);
+        $ormConfig = $factory($this->serviceManager, Configuration::class);
         $this->assertEquals('Factory', $ormConfig->getClassMetadataFactoryName());
     }
 
@@ -206,7 +207,7 @@ class ConfigurationFactoryTest extends TestCase
         ];
         $this->serviceManager->setService('config', $config);
         $factory   = new ConfigurationFactory('test_default');
-        $ormConfig = $factory->createService($this->serviceManager);
+        $ormConfig = $factory($this->serviceManager, Configuration::class);
         $this->assertEquals(
             ClassMetadataFactory::class,
             $ormConfig->getClassMetadataFactoryName()
@@ -225,7 +226,7 @@ class ConfigurationFactoryTest extends TestCase
 
         $this->serviceManager->setService('config', $config);
 
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
 
         $this->assertInstanceOf(
             EntityListenerResolver::class,
@@ -247,7 +248,7 @@ class ConfigurationFactoryTest extends TestCase
 
         $this->serviceManager->setService('config', $config);
 
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
 
         $this->assertSame($entityListenerResolver, $ormConfig->getEntityListenerResolver());
     }
@@ -267,7 +268,7 @@ class ConfigurationFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('test_entity_listener_resolver', $entityListenerResolver);
 
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
 
         $this->assertSame($entityListenerResolver, $ormConfig->getEntityListenerResolver());
     }
@@ -284,7 +285,7 @@ class ConfigurationFactoryTest extends TestCase
 
         $this->serviceManager->setService('config', $config);
 
-        $ormConfig = $this->factory->createService($this->serviceManager);
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
 
         $this->assertNull($ormConfig->getSecondLevelCacheConfiguration());
     }
@@ -322,7 +323,7 @@ class ConfigurationFactoryTest extends TestCase
 
         $this->serviceManager->setService('config', $config);
 
-        $ormConfig        = $this->factory->createService($this->serviceManager);
+        $ormConfig        = ($this->factory)($this->serviceManager, Configuration::class);
         $secondLevelCache = $ormConfig->getSecondLevelCacheConfiguration();
 
         $this->assertInstanceOf(CacheConfiguration::class, $secondLevelCache);

--- a/tests/Service/DBALConnectionFactoryTest.php
+++ b/tests/Service/DBALConnectionFactoryTest.php
@@ -6,6 +6,7 @@ namespace DoctrineORMModuleTest\Service;
 
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\EventManager;
+use Doctrine\DBAL\Connection as DBALConnection;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -53,7 +54,7 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
 
-        $dbal = $this->factory->createService($this->serviceManager);
+        $dbal = ($this->factory)($this->serviceManager, DBALConnection::class);
         $this->assertFalse($dbal->isConnected());
     }
 
@@ -78,7 +79,7 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
 
-        $dbal     = $this->factory->createService($this->serviceManager);
+        $dbal     = ($this->factory)($this->serviceManager, DBALConnection::class);
         $platform = $dbal->getDatabasePlatform();
         $this->assertSame('string', $platform->getDoctrineTypeMapping('money'));
     }
@@ -113,9 +114,9 @@ class DBALConnectionFactoryTest extends TestCase
         $configurationFactory = new ConfigurationFactory('orm_default');
         $this->serviceManager->setService(
             'doctrine.configuration.orm_default',
-            $configurationFactory->createService($this->serviceManager)
+            $configurationFactory($this->serviceManager, Configuration::class)
         );
-        $dbal     = $this->factory->createService($this->serviceManager);
+        $dbal     = ($this->factory)($this->serviceManager, DBALConnection::class);
         $platform = $dbal->getDatabasePlatform();
         $type     = Type::getType($platform->getDoctrineTypeMapping('money'));
 
@@ -148,7 +149,7 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('Configuration', $config);
         $this->serviceManager->setService('platform_service', $platformMock);
 
-        $dbal     = $this->factory->createService($this->serviceManager);
+        $dbal     = ($this->factory)($this->serviceManager, DBALConnection::class);
         $platform = $dbal->getDatabasePlatform();
         $this->assertSame($platformMock, $platform);
     }
@@ -173,7 +174,7 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
 
-        $dbal = $this->factory->createService($this->serviceManager);
+        $dbal = ($this->factory)($this->serviceManager, DBALConnection::class);
         $this->assertFalse($dbal->getNestTransactionsWithSavepoints());
     }
 
@@ -198,7 +199,7 @@ class DBALConnectionFactoryTest extends TestCase
         $this->serviceManager->setService('config', $config);
         $this->serviceManager->setService('Configuration', $config);
 
-        $dbal = $this->factory->createService($this->serviceManager);
+        $dbal = ($this->factory)($this->serviceManager, DBALConnection::class);
         $this->assertTrue($dbal->getNestTransactionsWithSavepoints());
     }
 }

--- a/tests/Service/MigrationsCommandFactoryTest.php
+++ b/tests/Service/MigrationsCommandFactoryTest.php
@@ -30,6 +30,7 @@ use DoctrineORMModuleTest\ServiceManagerFactory;
 use InvalidArgumentException;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 use function class_exists;
 
@@ -59,7 +60,7 @@ class MigrationsCommandFactoryTest extends TestCase
 
         $this->assertInstanceOf(
             ExecuteCommand::class,
-            $factory->createService($this->serviceLocator)
+            $factory($this->serviceLocator, ExecuteCommand::class)
         );
     }
 
@@ -75,7 +76,7 @@ class MigrationsCommandFactoryTest extends TestCase
 
         $this->assertInstanceOf(
             DiffCommand::class,
-            $factory->createService($this->serviceLocator)
+            $factory($this->serviceLocator, DiffCommand::class)
         );
     }
 
@@ -84,7 +85,7 @@ class MigrationsCommandFactoryTest extends TestCase
         $factory = new MigrationsCommandFactory('unknowncommand');
 
         $this->expectException(InvalidArgumentException::class);
-        $factory->createService($this->serviceLocator);
+        $factory($this->serviceLocator, stdClass::class);
     }
 
     public function testDefineDependencyFactoryServicesFromConfig(): void
@@ -115,7 +116,7 @@ class MigrationsCommandFactoryTest extends TestCase
                 ['myService', 'test'],
             ]);
 
-        $factory->createService($serviceLocator);
+        $factory($serviceLocator, DiffCommand::class);
     }
 
     public function testNoDefineDependencyFactoryServicesFromConfig(): void
@@ -143,6 +144,6 @@ class MigrationsCommandFactoryTest extends TestCase
                 ['doctrine.entitymanager.orm_default', $entityManager],
             ]);
 
-        $factory->createService($serviceLocator);
+        $factory($serviceLocator, DiffCommand::class);
     }
 }

--- a/tests/Service/RunSqlCommandFactoryTest.php
+++ b/tests/Service/RunSqlCommandFactoryTest.php
@@ -28,7 +28,7 @@ class RunSqlCommandFactoryTest extends TestCase
 
         $this->assertInstanceOf(
             RunSqlCommand::class,
-            $factory->createService($this->serviceLocator)
+            $factory($this->serviceLocator, RunSqlCommand::class)
         );
     }
 }

--- a/tests/Service/SQLLoggerCollectorFactoryTest.php
+++ b/tests/Service/SQLLoggerCollectorFactoryTest.php
@@ -41,7 +41,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
                 ],
             ]
         );
-        $service = $this->factory->createService($this->services);
+        $service = ($this->factory)($this->services, SQLLoggerCollector::class);
         $this->assertInstanceOf(SQLLoggerCollector::class, $service);
         $this->assertInstanceOf(SQLLogger::class, $configuration->getSQLLogger());
     }
@@ -60,7 +60,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
                 ],
             ]
         );
-        $this->factory->createService($this->services);
+        ($this->factory)($this->services, SQLLoggerCollector::class);
         $this->assertInstanceOf(SQLLogger::class, $configuration->getSQLLogger());
     }
 
@@ -91,7 +91,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
                 ],
             ]
         );
-        $this->factory->createService($this->services);
+        ($this->factory)($this->services, SQLLoggerCollector::class);
         $logger = $configuration->getSQLLogger();
         assert($logger instanceof SQLLogger);
         $logger->startQuery('test query');
@@ -113,7 +113,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
                 ],
             ]
         );
-        $this->factory->createService($this->services);
+        ($this->factory)($this->services, SQLLoggerCollector::class);
         $this->assertSame($logger, $configuration->getSQLLogger());
     }
 
@@ -130,7 +130,7 @@ class SQLLoggerCollectorFactoryTest extends TestCase
                 ],
             ]
         );
-        $service = $this->factory->createService($this->services);
+        $service = ($this->factory)($this->services, SQLLoggerCollector::class);
         assert($service instanceof SQLLoggerCollector);
         $this->assertSame('doctrine.sql_logger_collector.test_collector_name', $service->getName());
     }

--- a/tests/Yuml/YumlControllerFactoryTest.php
+++ b/tests/Yuml/YumlControllerFactoryTest.php
@@ -6,7 +6,6 @@ namespace DoctrineORMModuleTest\Yuml;
 
 use DoctrineORMModule\Yuml\YumlController;
 use DoctrineORMModule\Yuml\YumlControllerFactory;
-use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\TestCase;
@@ -22,15 +21,10 @@ class YumlControllerFactoryTest extends TestCase
         ];
 
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-        $pluginManager  = $this->getMockBuilder(AbstractPluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
-        $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
 
         $factory    = new YumlControllerFactory();
-        $controller = $factory->createService($pluginManager);
+        $controller = $factory($serviceLocator, YumlController::class);
 
         $this->assertInstanceOf(YumlController::class, $controller);
     }
@@ -44,17 +38,12 @@ class YumlControllerFactoryTest extends TestCase
         ];
 
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-        $pluginManager  = $this->getMockBuilder(AbstractPluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
-        $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
 
         $factory = new YumlControllerFactory();
 
         $this->expectException(ServiceNotFoundException::class);
-        $factory->createService($pluginManager);
+        $factory($serviceLocator, YumlController::class);
     }
 
     public function testCreateServiceWithNoConfigKey(): void
@@ -64,16 +53,11 @@ class YumlControllerFactoryTest extends TestCase
         ];
 
         $serviceLocator = $this->createMock(ServiceLocatorInterface::class);
-        $pluginManager  = $this->getMockBuilder(AbstractPluginManager::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
         $serviceLocator->expects($this->once())->method('get')->with('config')->willReturn($config);
-        $pluginManager->expects($this->once())->method('getServiceLocator')->willReturn($serviceLocator);
 
         $factory = new YumlControllerFactory();
 
         $this->expectException(ServiceNotFoundException::class);
-        $factory->createService($pluginManager);
+        $factory($serviceLocator, YumlController::class);
     }
 }


### PR DESCRIPTION
In laminas-servicemanager 2.x, the `FactoryInterface` included the following methods:
 - `public function createService(ServiceLocatorInterface $serviceLocator)`
 - `public function setCreationOptions(array $options)`

These methods are replaced by the following method in laminas-servicemanager 3.x:
 - `public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)`

Since DoctrineORMModule already requires laminas-servicemanager 3.x since version 3.0.0, i.e. for nearly two years, it is time to drop the obsolete functions `createService()` and `setCreationOptions()` in all factories. All factories already implement a `__invoke()` method.

This is the same as done in doctrine/DoctrineModule#763