### PR TITLE
Mark `Module`, `ConfigProvider`, option classes and factories as final

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -7,7 +7,7 @@ namespace DoctrineORMModule;
 /**
  * Config provider for DoctrineORMModule config
  */
-class ConfigProvider
+final class ConfigProvider
 {
     /**
      * @return mixed[]

--- a/src/Module.php
+++ b/src/Module.php
@@ -16,7 +16,7 @@ use function class_exists;
 /**
  * Base module for Doctrine ORM.
  */
-class Module implements
+final class Module implements
     ControllerProviderInterface,
     ConfigProviderInterface,
     DependencyIndicatorInterface

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -19,7 +19,7 @@ use function sprintf;
 /**
  * Configuration options for an ORM Configuration
  */
-class Configuration extends DBALConfiguration
+final class Configuration extends DBALConfiguration
 {
     /**
      * Set the cache key for the metadata cache. Cache key

--- a/src/Options/DBALConnection.php
+++ b/src/Options/DBALConnection.php
@@ -13,7 +13,7 @@ use PDO;
 /**
  * DBAL Connection options
  */
-class DBALConnection extends AbstractOptions
+final class DBALConnection extends AbstractOptions
 {
     /**
      * Set the configuration key for the Configuration. Configuration key

--- a/src/Options/EntityManager.php
+++ b/src/Options/EntityManager.php
@@ -6,7 +6,7 @@ namespace DoctrineORMModule\Options;
 
 use Laminas\Stdlib\AbstractOptions;
 
-class EntityManager extends AbstractOptions
+final class EntityManager extends AbstractOptions
 {
     /**
      * Set the configuration key for the Configuration. Configuration key

--- a/src/Options/EntityResolver.php
+++ b/src/Options/EntityResolver.php
@@ -10,7 +10,7 @@ use Laminas\Stdlib\AbstractOptions;
 use function class_exists;
 use function sprintf;
 
-class EntityResolver extends AbstractOptions
+final class EntityResolver extends AbstractOptions
 {
     /**
      * Set the configuration key for the EventManager. Event manager key

--- a/src/Options/SQLLoggerCollectorOptions.php
+++ b/src/Options/SQLLoggerCollectorOptions.php
@@ -9,7 +9,7 @@ use Laminas\Stdlib\AbstractOptions;
 /**
  * Configuration options for an collector
  */
-class SQLLoggerCollectorOptions extends AbstractOptions
+final class SQLLoggerCollectorOptions extends AbstractOptions
 {
     /** @var string name to be assigned to the collector */
     protected string $name = 'orm_default';

--- a/src/Options/SecondLevelCacheConfiguration.php
+++ b/src/Options/SecondLevelCacheConfiguration.php
@@ -9,7 +9,7 @@ use Laminas\Stdlib\AbstractOptions;
 /**
  * Configuration options for Second Level Cache
  */
-class SecondLevelCacheConfiguration extends AbstractOptions
+final class SecondLevelCacheConfiguration extends AbstractOptions
 {
     /**
      * Enable the second level cache configuration

--- a/src/Service/CliConfiguratorFactory.php
+++ b/src/Service/CliConfiguratorFactory.php
@@ -8,7 +8,7 @@ use DoctrineORMModule\CliConfigurator;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-class CliConfiguratorFactory implements FactoryInterface
+final class CliConfiguratorFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -18,7 +18,7 @@ use function is_string;
 use function method_exists;
 use function sprintf;
 
-class ConfigurationFactory extends DoctrineConfigurationFactory
+final class ConfigurationFactory extends DoctrineConfigurationFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/DBALConnectionFactory.php
+++ b/src/Service/DBALConnectionFactory.php
@@ -20,7 +20,7 @@ use function is_string;
 /**
  * DBAL Connection ServiceManager factory
  */
-class DBALConnectionFactory extends AbstractFactory
+final class DBALConnectionFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/DoctrineObjectHydratorFactory.php
+++ b/src/Service/DoctrineObjectHydratorFactory.php
@@ -8,7 +8,7 @@ use Doctrine\Laminas\Hydrator\DoctrineObject;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-class DoctrineObjectHydratorFactory implements FactoryInterface
+final class DoctrineObjectHydratorFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/EntityManagerAliasCompatFactory.php
+++ b/src/Service/EntityManagerAliasCompatFactory.php
@@ -11,7 +11,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 /**
  * Factory that provides the `Doctrine\ORM\EntityManager` alias for `doctrine.entitymanager.orm_default`
  */
-class EntityManagerAliasCompatFactory implements FactoryInterface
+final class EntityManagerAliasCompatFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/EntityManagerFactory.php
+++ b/src/Service/EntityManagerFactory.php
@@ -11,7 +11,7 @@ use Interop\Container\ContainerInterface;
 
 use function assert;
 
-class EntityManagerFactory extends AbstractFactory
+final class EntityManagerFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/EntityResolverFactory.php
+++ b/src/Service/EntityResolverFactory.php
@@ -11,7 +11,7 @@ use Interop\Container\ContainerInterface;
 
 use function assert;
 
-class EntityResolverFactory extends AbstractFactory
+final class EntityResolverFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/MappingCollectorFactory.php
+++ b/src/Service/MappingCollectorFactory.php
@@ -12,7 +12,7 @@ use Interop\Container\ContainerInterface;
 /**
  * Service factory responsible for instantiating {@see \DoctrineORMModule\Collector\MappingCollector}
  */
-class MappingCollectorFactory extends AbstractFactory
+final class MappingCollectorFactory extends AbstractFactory
 {
     /**
      * {@inheritDoc}

--- a/src/Service/MigrationsCommandFactory.php
+++ b/src/Service/MigrationsCommandFactory.php
@@ -22,7 +22,7 @@ use function ucfirst;
 /**
  * Service factory for migrations command
  */
-class MigrationsCommandFactory implements FactoryInterface
+final class MigrationsCommandFactory implements FactoryInterface
 {
     private string $commandClassName;
 

--- a/src/Service/ObjectMultiCheckboxFactory.php
+++ b/src/Service/ObjectMultiCheckboxFactory.php
@@ -12,7 +12,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 /**
  * Factory for {@see ObjectMultiCheckbox}
  */
-class ObjectMultiCheckboxFactory implements FactoryInterface
+final class ObjectMultiCheckboxFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/ObjectRadioFactory.php
+++ b/src/Service/ObjectRadioFactory.php
@@ -12,7 +12,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 /**
  * Factory for {@see ObjectRadio}
  */
-class ObjectRadioFactory implements FactoryInterface
+final class ObjectRadioFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/ObjectSelectFactory.php
+++ b/src/Service/ObjectSelectFactory.php
@@ -12,7 +12,7 @@ use Laminas\ServiceManager\Factory\FactoryInterface;
 /**
  * Factory for {@see ObjectSelect}
  */
-class ObjectSelectFactory implements FactoryInterface
+final class ObjectSelectFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/ReservedWordsCommandFactory.php
+++ b/src/Service/ReservedWordsCommandFactory.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-class ReservedWordsCommandFactory implements FactoryInterface
+final class ReservedWordsCommandFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/RunSqlCommandFactory.php
+++ b/src/Service/RunSqlCommandFactory.php
@@ -9,7 +9,7 @@ use Doctrine\DBAL\Tools\Console\ConnectionProvider\SingleConnectionProvider;
 use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 
-class RunSqlCommandFactory implements FactoryInterface
+final class RunSqlCommandFactory implements FactoryInterface
 {
     /**
      * {@inheritDoc}

--- a/src/Service/SQLLoggerCollectorFactory.php
+++ b/src/Service/SQLLoggerCollectorFactory.php
@@ -17,7 +17,7 @@ use function sprintf;
 /**
  * DBAL Configuration ServiceManager factory
  */
-class SQLLoggerCollectorFactory implements FactoryInterface
+final class SQLLoggerCollectorFactory implements FactoryInterface
 {
     protected string $name;
 


### PR DESCRIPTION
The Module and ConfigProvider classes, as well as the option classes and all factories are no valid extension points. They are now marked as final.

This is in line with doctrine/DoctrineModule#766.