### PR TITLE
Add support for schema assets filter option

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -299,9 +299,9 @@ The "schema_assets_filter" option can be used to exclude certain tables from bei
         'doctrine' => [
             'configuration' => [
                 'orm_default' => [
-                    'schema_assets_filter' => static function ($tableName) {
-                        return $tableName === 'foobar';
-                    }
+                    'schema_assets_filter' => fn (string $tableName): bool => (
+                        in_array($tableName, ['migrations', 'doNotRemoveThisTable']);
+                    ),
                 ],
             ],
         ],

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -288,3 +288,22 @@ module.
         ],
     ];
 
+How to exclude tables from a schema diff
+----------------------------------------
+
+The "schema_assets_filter" option can be used to exclude certain tables from being created or deleted in a schema update:
+
+.. code:: php
+
+    return [
+        'doctrine' => [
+            'configuration' => [
+                'orm_default' => [
+                    'schema_assets_filter' => static function ($tableName) {
+                        return $tableName === 'foobar';
+                    }
+                ],
+            ],
+        ],
+    ];
+

--- a/src/Options/Configuration.php
+++ b/src/Options/Configuration.php
@@ -191,6 +191,13 @@ final class Configuration extends DBALConfiguration
     protected ?string $filterSchemaAssetsExpression = null;
 
     /**
+     * Configuration option for the schema assets filter callable
+     *
+     * @var callable|null
+     */
+    protected $schemaAssetsFilter = null;
+
+    /**
      * @param mixed[] $datetimeFunctions
      */
     public function setDatetimeFunctions(array $datetimeFunctions): self
@@ -605,6 +612,18 @@ final class Configuration extends DBALConfiguration
     public function getFilterSchemaAssetsExpression(): ?string
     {
         return $this->filterSchemaAssetsExpression;
+    }
+
+    public function setSchemaAssetsFilter(callable $schemaAssetsFilter): self
+    {
+        $this->schemaAssetsFilter = $schemaAssetsFilter;
+
+        return $this;
+    }
+
+    public function getSchemaAssetsFilter(): ?callable
+    {
+        return $this->schemaAssetsFilter;
     }
 
     /**

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -154,6 +154,14 @@ final class ConfigurationFactory extends DoctrineConfigurationFactory
             }
         }
 
+        // DBAL 2.x
+        if (method_exists($config, 'setSchemaAssetsFilter')) {
+            $schemaAssetsFilter = $options->getSchemaAssetsFilter();
+            if ($schemaAssetsFilter) {
+                $config->setSchemaAssetsFilter($schemaAssetsFilter);
+            }
+        }
+
         $className = $options->getDefaultRepositoryClassName();
         if ($className) {
             $config->setDefaultRepositoryClassName($className);

--- a/tests/Service/ConfigurationFactoryTest.php
+++ b/tests/Service/ConfigurationFactoryTest.php
@@ -263,9 +263,7 @@ class ConfigurationFactoryTest extends TestCase
         $config = [
             'doctrine' => [
                 'configuration' => [
-                    'test_default' => [
-                        'schema_assets_filter' => $schemaAssetsFilter,
-                    ],
+                    'test_default' => ['schema_assets_filter' => $schemaAssetsFilter],
                 ],
             ],
         ];

--- a/tests/Service/ConfigurationFactoryTest.php
+++ b/tests/Service/ConfigurationFactoryTest.php
@@ -254,6 +254,29 @@ class ConfigurationFactoryTest extends TestCase
         $this->assertSame($entityListenerResolver, $ormConfig->getEntityListenerResolver());
     }
 
+    public function testWillInstantiateConfigWithSchemaAssetsFilterCallback(): void
+    {
+        $schemaAssetsFilter = static function ($tableName) {
+            return $tableName === 'foobar';
+        };
+
+        $config = [
+            'doctrine' => [
+                'configuration' => [
+                    'test_default' => [
+                        'schema_assets_filter' => $schemaAssetsFilter,
+                    ],
+                ],
+            ],
+        ];
+
+        $this->serviceManager->setService('config', $config);
+
+        $ormConfig = ($this->factory)($this->serviceManager, Configuration::class);
+
+        $this->assertSame($schemaAssetsFilter, $ormConfig->getSchemaAssetsFilter());
+    }
+
     public function testWillInstantiateConfigWithEntityListenerResolverReference(): void
     {
         $entityListenerResolver = $this->createMock(EntityListenerResolver::class);


### PR DESCRIPTION
`$filterSchemaAssetsExpression` was deprecated, but its `$schemaAssetsFilter` callback replacement hasn't been implemented in doctrine-orm-module yet. This PR tries to correct that by defining the option on `Configuration`.

If there is any additional documentation/testing needed just point me in the right direction and I'll get that sorted!