### PR TITLE
Require orm ^2.11 and adapt cache implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "doctrine/doctrine-laminas-hydrator": "^2.2.1",
         "doctrine/doctrine-module": "^4.2.2",
         "doctrine/event-manager": "^1.1.1",
-        "doctrine/orm": "^2.9.6",
+        "doctrine/orm": "^2.11.1",
         "doctrine/persistence": "^2.2.2",
         "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-modulemanager": "^2.11.0",

--- a/src/Service/ConfigurationFactory.php
+++ b/src/Service/ConfigurationFactory.php
@@ -136,7 +136,7 @@ class ConfigurationFactory extends DoctrineConfigurationFactory
             }
 
             // As Second Level Cache caches queries results, we reuse the result cache impl
-            $cacheFactory = new DefaultCacheFactory($regionsConfig, $config->getResultCacheImpl());
+            $cacheFactory = new DefaultCacheFactory($regionsConfig, $config->getResultCache());
             $cacheFactory->setFileLockRegionDirectory($secondLevelCache->getFileLockRegionDirectory());
 
             $cacheConfiguration = new CacheConfiguration();

--- a/tests/Service/ConfigurationFactoryTest.php
+++ b/tests/Service/ConfigurationFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DoctrineORMModuleTest\Service;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\Psr6\CacheAdapter;
 use Doctrine\ORM\Cache\CacheConfiguration;
 use Doctrine\ORM\Cache\DefaultCacheFactory;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
@@ -346,8 +347,10 @@ class ConfigurationFactoryTest extends TestCase
 
         // Doctrine does not allow to retrieve the cache adapter from cache factory, so we are forced to use
         // reflection here
-        $reflProperty = new ReflectionProperty($cacheFactory, 'cache');
+        $reflProperty = new ReflectionProperty($cacheFactory, 'cacheItemPool');
         $reflProperty->setAccessible(true);
-        $this->assertInstanceOf(ArrayCache::class, $reflProperty->getValue($cacheFactory));
+        $cacheDecorator = $reflProperty->getValue($cacheFactory);
+        $this->assertInstanceOf(CacheAdapter::class, $cacheDecorator);
+        $this->assertInstanceOf(ArrayCache::class, $cacheDecorator->getCache());
     }
 }

--- a/tests/Service/DBALConnectionFactoryTest.php
+++ b/tests/Service/DBALConnectionFactoryTest.php
@@ -122,7 +122,6 @@ class DBALConnectionFactoryTest extends TestCase
         $type     = Type::getType($platform->getDoctrineTypeMapping('money'));
 
         $this->assertInstanceOf(MoneyType::class, $type);
-        $this->assertTrue($platform->isCommentedDoctrineType($type));
     }
 
     public function testGettingPlatformFromContainer(): void


### PR DESCRIPTION
With orm ^2.11, cache adapters are always wrapped in a PSR6 object. This has caused issues with our CI pipeline in #708 and #709.

This PR upgrades orm to ^2.11.1 and changes unit tests to fix all CI errors. Targeted at the 4.2.x branch, which currently is still maintained.