### PR TITLE
Set version_column_length to 191 to work with MySQL 8.0 and MariaDB 10.5

### DIFF
--- a/ci/config/ci.config.php
+++ b/ci/config/ci.config.php
@@ -27,7 +27,7 @@ return [
                 'table_storage' => [
                     'table_name' => 'DoctrineMigrationVersions',
                     'version_column_name' => 'version',
-                    'version_column_length' => 1024,
+                    'version_column_length' => 191,
                     'executed_at_column_name' => 'executedAt',
                     'execution_time_column_name' => 'executionTime',
                 ],

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -154,7 +154,7 @@ $result = [
                 'table_storage' => [
                     'table_name' => 'DoctrineMigrationVersions',
                     'version_column_name' => 'version',
-                    'version_column_length' => 1024,
+                    'version_column_length' => 191,
                     'executed_at_column_name' => 'executedAt',
                     'execution_time_column_name' => 'executionTime',
                 ],

--- a/docs/en/migrations.rst
+++ b/docs/en/migrations.rst
@@ -18,7 +18,7 @@ Configure
                     'table_storage' => [
                         'table_name' => 'DoctrineMigrationVersions',
                         'version_column_name' => 'version',
-                        'version_column_length' => 1024,
+                        'version_column_length' => 191,
                         'executed_at_column_name' => 'executedAt',
                         'execution_time_column_name' => 'executionTime',
                     ],

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -73,7 +73,7 @@ return [
                 'table_storage' => [
                     'table_name' => 'DoctrineMigrationVersions',
                     'version_column_name' => 'version',
-                    'version_column_length' => 1024,
+                    'version_column_length' => 191,
                     'executed_at_column_name' => 'executedAt',
                     'execution_time_column_name' => 'executionTime',
                 ],
@@ -88,7 +88,7 @@ return [
                 'table_storage' => [
                     'table_name' => 'DoctrineMigrationVersionsOther',
                     'version_column_name' => 'versionOther',
-                    'version_column_length' => 1024,
+                    'version_column_length' => 191,
                     'executed_at_column_name' => 'executedAtOther',
                     'execution_time_column_name' => 'executionTimeOther',
                 ],


### PR DESCRIPTION
Lower version_column_length from 1024 tot 191
Fixes https://github.com/doctrine/DoctrineORMModule/issues/720