### PR TITLE
Raise DoctrineModule to ^5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
         "container-interop/container-interop": "^1.2.0",
         "doctrine/dbal": "^2.13.7 || ^3.3.2",
         "doctrine/doctrine-laminas-hydrator": "^3.0.0",
-        "doctrine/doctrine-module": "^5.1.0",
+        "doctrine/doctrine-module": "^5.2.0",
         "doctrine/event-manager": "^1.1.1",
         "doctrine/orm": "^2.11.1",
         "doctrine/persistence": "^2.3.0 || ^3.0.0",


### PR DESCRIPTION
In #722 a CI error occured because of an error with lowest dependencies. 

This can be fixed by raising the minimum version of DoctrineModule from 5.1.0 to 5.2.0.