### PR TITLE
Update workflows and CI

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   coding-standards:
     name: "Coding Standards"
-    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.4.1"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.5.1"
     with:
       php-version: '8.1'

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
 
     services:
       mysql:
-        image: "mysql:5.7"
+        image: "mysql:8.0"
 
         options: >-
           --health-cmd "mysqladmin ping --silent"

--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.4.1"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.5.1"
     with:
       use-next-minor-as-default-branch: true
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   static-analysis:
     name: "Static Analysis"
-    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.4.1"
+    uses: "doctrine/.github/.github/workflows/static-analysis.yml@1.5.1"
     with:
       php-version: '8.1'


### PR DESCRIPTION
This updates upstream workflows and uses MySQL 8.0 instead of 5.7 in CI.

Hopefully, this should prevent issues like #720 in the future.