### PR TITLE
Fix schema_assets_filter configuration docs

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -293,7 +293,8 @@ module.
 How to Exclude Tables from a Schema Diff
 ----------------------------------------
 
-The "schema_assets_filter" option can be used to exclude certain tables from being created or deleted in a schema update:
+The "schema_assets_filter" option can be used to exclude certain tables from being deleted in a schema update.
+It should be set with a filter callback that will receive the table name and should return `false` for any tables that must be excluded.
 
 .. code:: php
 
@@ -302,7 +303,7 @@ The "schema_assets_filter" option can be used to exclude certain tables from bei
             'configuration' => [
                 'orm_default' => [
                     'schema_assets_filter' => fn (string $tableName): bool => (
-                        ! in_array($tableName, ['migrations', 'doNotRemoveThisTable'])
+                        ! in_array($tableName, ['doNotRemoveThisTable', 'alsoDoNotRemoveThisTable'])
                     ),
                 ],
             ],

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -294,7 +294,7 @@ How to Exclude Tables from a Schema Diff
 ----------------------------------------
 
 The "schema_assets_filter" option can be used to exclude certain tables from being deleted in a schema update.
-It should be set with a filter callback that will receive the table name and should return `false` for any tables that must be excluded.
+It should be set with a filter callback that will receive the table name and should return `false` for any tables that must be excluded and `true` for any other tables.
 
 .. code:: php
 

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -302,7 +302,7 @@ The "schema_assets_filter" option can be used to exclude certain tables from bei
             'configuration' => [
                 'orm_default' => [
                     'schema_assets_filter' => fn (string $tableName): bool => (
-                        ! in_array($tableName, ['migrations', 'doNotRemoveThisTable']);
+                        ! in_array($tableName, ['migrations', 'doNotRemoveThisTable'])
                     ),
                 ],
             ],

--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -302,7 +302,7 @@ The "schema_assets_filter" option can be used to exclude certain tables from bei
             'configuration' => [
                 'orm_default' => [
                     'schema_assets_filter' => fn (string $tableName): bool => (
-                        in_array($tableName, ['migrations', 'doNotRemoveThisTable']);
+                        ! in_array($tableName, ['migrations', 'doNotRemoveThisTable']);
                     ),
                 ],
             ],

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,9 +15,5 @@ parameters:
         -
             message: '#Parameter \#1 .* of method DoctrineORMModule\\Options\\Configuration.* stdClass given#'
             path: tests/Options/ConfigurationOptionsTest.php
-        -
-            message: '#Parameter \#1 .* of method Doctrine\\Common\\DataFixtures\\Executor\\ORMExecutor::execute\(\)#'
-            path: tests/Paginator/AdapterTest.php
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon
-


### PR DESCRIPTION
The callable set as schemaAssetsFilter should return false for tables that you want filtered out 

See for example https://github.com/doctrine/dbal/blob/3.6.x/src/Configuration.php#L168 and https://github.com/doctrine/dbal/blob/4.0.x/src/Schema/AbstractSchemaManager.php#L204