### PR TITLE
Dropped support for doctrine/dbal 2.x

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,7 +33,6 @@ jobs:
           - "8.2"
           - "8.3"
         dbal-version:
-          - "2.13.0"
           - "3.3.0"
         dependencies:
           - "highest"
@@ -42,17 +41,9 @@ jobs:
           - false
         include:
           - php-version: "8.1"
-            dbal-version: "2.13.0"
-            dependencies: "lowest"
-            optional-dependencies: false
-          - php-version: "8.1"
             dbal-version: "3.3.0"
             dependencies: "lowest"
             optional-dependencies: false
-          - php-version: "8.1"
-            dbal-version: "2.13.0"
-            dependencies: "lowest"
-            optional-dependencies: true
           - php-version: "8.1"
             dbal-version: "3.3.0"
             dependencies: "lowest"

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "ext-json": "*",
         "doctrine/dbal": "^3.3.2",
         "doctrine/doctrine-laminas-hydrator": "^3.0.0",
-        "doctrine/doctrine-module": "^5.3.0 || ^6.0.2",
+        "doctrine/doctrine-module": "^5.3.0 || ^6.0.5",
         "doctrine/event-manager": "^2.0.0",
-        "doctrine/orm": "^2.11.1",
+        "doctrine/orm": "^2.13.0",
         "doctrine/persistence": "^2.3.0 || ^3.0.0",
         "laminas/laminas-eventmanager": "^3.4.0",
         "laminas/laminas-modulemanager": "^2.11.0",
@@ -32,21 +32,20 @@
         "doctrine/annotations": "^1.13.2",
         "doctrine/coding-standard": "^9.0.0",
         "doctrine/data-fixtures": "^1.5.2",
-        "doctrine/migrations": "^3.4.1",
+        "doctrine/migrations": "^3.8.0",
         "laminas/laminas-cache-storage-adapter-filesystem": "^2.0",
         "laminas/laminas-cache-storage-adapter-memory": "^2.0",
         "laminas/laminas-developer-tools": "^2.3.0",
         "laminas/laminas-i18n": "^2.13.0",
         "laminas/laminas-log": "^2.15.0",
         "laminas/laminas-serializer": "^2.12.0",
-        "ocramius/proxy-manager": "^2.2.0",
         "phpstan/phpstan": "^2.0.4",
         "phpstan/phpstan-phpunit": "^2.0.3",
         "phpunit/phpunit": "^10.5.40",
         "squizlabs/php_codesniffer": "^3.6.2"
     },
     "conflict": {
-        "doctrine/migrations": "<3.3"
+        "doctrine/migrations": "<3.8"
     },
     "suggest": {
         "doctrine/migrations": "doctrine migrations if you want to keep your schema definitions versioned",

--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-json": "*",
-        "doctrine/dbal": "^2.13.7 || ^3.3.2",
+        "doctrine/dbal": "^3.3.2",
         "doctrine/doctrine-laminas-hydrator": "^3.0.0",
         "doctrine/doctrine-module": "^5.3.0 || ^6.0.2",
-        "doctrine/event-manager": "^1.1.1 || ^2.0.0",
+        "doctrine/event-manager": "^2.0.0",
         "doctrine/orm": "^2.11.1",
         "doctrine/persistence": "^2.3.0 || ^3.0.0",
         "laminas/laminas-eventmanager": "^3.4.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,9 +12,6 @@ parameters:
         -
           identifier: function.alreadyNarrowedType
         -
-          message: '#Method .*CliConfigurator::getHelpers\(\) .*ConnectionHelper#'
-          path: src/CliConfigurator.php
-        -
           message: '#Method .*DBALConnection::getDriverClass\(\) never returns null#'
           path: src/Options/DBALConnection.php
         -

--- a/src/CliConfigurator.php
+++ b/src/CliConfigurator.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace DoctrineORMModule;
 
-use Doctrine\DBAL\Tools\Console\Command\ImportCommand;
-use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Console\Helper\EntityManagerHelper;
@@ -66,12 +64,6 @@ class CliConfigurator
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-
-        if (! class_exists(ImportCommand::class)) {
-            return;
-        }
-
-        $this->commands[] = 'doctrine.dbal_cmd.import';
     }
 
     public function configure(Application $cli): void
@@ -97,17 +89,10 @@ class CliConfigurator
      */
     private function getHelpers(EntityManagerInterface $objectManager): array
     {
-        $helpers = [
+        return [
             'dialog' => new QuestionHelper(),
             'em' => new EntityManagerHelper($objectManager),
         ];
-
-        // this is only available with DBAL 2.x
-        if (class_exists(ConnectionHelper::class)) {
-            $helpers['db'] = new ConnectionHelper($objectManager->getConnection());
-        }
-
-        return $helpers;
     }
 
     private function createObjectManagerInputOption(): InputOption


### PR DESCRIPTION
With this PR, doctrine/dbal ^3 is required and 2.x is not supported anymore.