### PR TITLE
Upgraded to doctrine/doctrine-module ^6.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,22 +14,22 @@
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-json": "*",
         "doctrine/dbal": "^3.3.2",
-        "doctrine/doctrine-laminas-hydrator": "^3.0.0",
-        "doctrine/doctrine-module": "^5.3.0 || ^6.0.5",
+        "doctrine/doctrine-laminas-hydrator": "^3.2.0",
+        "doctrine/doctrine-module": "^6.2.0",
         "doctrine/event-manager": "^2.0.0",
         "doctrine/orm": "^2.13.0",
-        "doctrine/persistence": "^2.3.0 || ^3.0.0",
-        "laminas/laminas-eventmanager": "^3.4.0",
+        "doctrine/persistence": "^3.0.0",
+        "laminas/laminas-eventmanager": "^3.5.0",
         "laminas/laminas-modulemanager": "^2.11.0",
-        "laminas/laminas-mvc": "^3.3.2",
-        "laminas/laminas-paginator": "^2.12.2",
+        "laminas/laminas-mvc": "^3.3.5",
+        "laminas/laminas-paginator": "^2.13.0",
         "laminas/laminas-servicemanager": "^3.17.0",
-        "laminas/laminas-stdlib": "^3.7.1",
+        "laminas/laminas-stdlib": "^3.13.0",
         "psr/container": "^1.1.2",
-        "symfony/console": "^5.4.3 || ^6.0.3"
+        "symfony/console": "^6.1.2 || ^7.0.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.13.2",
+        "doctrine/annotations": "^2.0.0",
         "doctrine/coding-standard": "^9.0.0",
         "doctrine/data-fixtures": "^1.5.2",
         "doctrine/migrations": "^3.8.0",
@@ -45,7 +45,8 @@
         "squizlabs/php_codesniffer": "^3.6.2"
     },
     "conflict": {
-        "doctrine/migrations": "<3.8"
+        "doctrine/migrations": "<3.8",
+        "laminas/laminas-form": "<3.10"
     },
     "suggest": {
         "doctrine/migrations": "doctrine migrations if you want to keep your schema definitions versioned",

--- a/tests/CliConfiguratorTest.php
+++ b/tests/CliConfiguratorTest.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace DoctrineORMModuleTest\Listener;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Tools\Console\Command\ImportCommand;
 use Doctrine\DBAL\Tools\Console\Command\ReservedWordsCommand;
 use Doctrine\DBAL\Tools\Console\Command\RunSqlCommand;
-use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use Doctrine\Migrations\Tools\Console\Command\ExecuteCommand;
 use Doctrine\Migrations\Tools\Console\Command\GenerateCommand;
@@ -30,7 +28,6 @@ use DoctrineORMModuleTest\ServiceManagerFactory;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 
 use function assert;
 use function class_exists;
@@ -112,15 +109,6 @@ class CliConfiguratorTest extends TestCase
         assert($emHelper instanceof EntityManagerHelper);
         $this->assertInstanceOf(EntityManagerHelper::class, $emHelper);
         $this->assertSame($this->objectManager, $emHelper->getEntityManager());
-
-        if (! class_exists(ConnectionHelper::class)) {
-            return;
-        }
-
-        $dbHelper = $helperSet->get('db');
-        assert($dbHelper instanceof ConnectionHelper);
-        $this->assertInstanceOf(ConnectionHelper::class, $dbHelper);
-        $this->assertSame($this->objectManager->getConnection(), $dbHelper->getConnection());
     }
 
     /**
@@ -140,7 +128,6 @@ class CliConfiguratorTest extends TestCase
         $cliConfigurator->configure($application);
 
         $command = $application->get($commandName);
-        assert($command instanceof Command);
         $this->assertInstanceOf($className, $command);
 
         // check for the entity-manager option
@@ -161,7 +148,7 @@ class CliConfiguratorTest extends TestCase
      */
     public function dataProviderForTestValidCommands(): array
     {
-        $data = [
+        return [
             [
                 'dbal:run-sql',
                 RunSqlCommand::class,
@@ -223,15 +210,5 @@ class CliConfiguratorTest extends TestCase
                 ExecuteCommand::class,
             ],
         ];
-
-        // this is only available with DBAL 2.x
-        if (class_exists(ImportCommand::class)) {
-            $data[] = [
-                'dbal:import',
-                ImportCommand::class,
-            ];
-        }
-
-        return $data;
     }
 }


### PR DESCRIPTION
This PR upgrades `doctrine/doctrine-module` to 6.2.x, disallowing the 5.x series. This update brings a couple of changes, see the release notes of DoctrineModule 6.2.0:

> ### [Release Notes for 6.2.0](https://github.com/doctrine/DoctrineModule/releases/tag/6.2.0)
> 
> Feature release (minor)
> 
> ### Changed
> 
> - doctrine/annotations ^2 is now required (1.x is not supported anymore)
> - doctrine/cache ^2 is now required (1.x is not supported anymore) - **Note:** This change implies that laminas-cache is now used for caching, as doctrine/cache v2 does not contain implementations anymore. Using laminas-cache, however, is the default config since the 6.0.0 release. If you are using other adapters than `array` and `filesystem`, you might need to require additional laminas packages!
> - doctrine/collections ^2 is now required (1.x is not supported anymore)
> - doctrine/event-manager ^2 is now required (1.x is not supported anymore)
> - doctrine/persistence ^3 is now required (2.x is not supported anymore)
> - symfony/console ^7 is now alled besides 6.x (5.x is not supported anymore)
> 
> ### Dropped
> 
> - Support for PHP 8.0 has been dropped


Users coming from DoctrineModule 5.x should additionally carefully read the release notes of [6.0.0](https://github.com/doctrine/DoctrineModule/releases/tag/6.0.0)!