### PR TITLE
use addCommands([$command]) instead of add($command) to be compatible with symfony8

### DIFF
--- a/src/CliConfigurator.php
+++ b/src/CliConfigurator.php
@@ -70,7 +70,7 @@ class CliConfigurator
             $command = $this->container->get($commandName);
             $command->getDefinition()->addOption($this->createObjectManagerInputOption());
 
-            $cli->add($command);
+            $cli->addCommands([$command]);
         }
 
         $objectManager = $this->container->get($this->getObjectManagerName());


### PR DESCRIPTION
I got this deprecation message in my logs:
```
E_USER_DEPRECATED: Since symfony/console 7.4: The "Symfony\Component\Console\Application::add()" method is deprecated and will be removed in Symfony 8.0, use "Symfony\Component\Console\Application::addCommand()" instead.
```
Sadly `addCommand()` was added in symfony/console 7.4, the constraint in the composer.json allows for older versions. So this workaround works for 6, 7 and 8.

Alternative suggestion: restrain symfony/console to `^7.4`, then `addCommand()` could be used.

Im not sure if this is all it takes to be symfony/console 8.0 compatible, for my other projets this change was the only one I needed to do.