### PR TITLE
docs: fix entity resolver mapping example

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -105,8 +105,7 @@ How to Define Relationships with Abstract Classes and Interfaces (ResolveTargetE
             'entity_resolver' => [
                 'orm_default' => [
                     'resolvers' => [
-                        \Acme\InvoiceModule\Model\InvoiceSubjectInterface::class,
-                        \Acme\CustomerModule\Entity\Customer::class,
+                        \Acme\InvoiceModule\Model\InvoiceSubjectInterface::class => \Acme\CustomerModule\Entity\Customer::class,
                     ],
                 ],
             ],


### PR DESCRIPTION
Fixes #770

Changes:
- `                    'resolvers' => [
                        \Acme\InvoiceModule\Model\InvoiceSubjectInterface::class,
                        \Acme\CustomerModule\Entity\Customer::class,
                    ],` -> `                    'resolvers' => [
                        \Acme\InvoiceModule\Model\InvoiceSubjectInterface::class => \Acme\CustomerModule\Entity\Customer::class,
                    ],` in `docs/en/configuration.rst` (1 occurrence(s))

Verification:
- Applied exact text replacements against the current upstream base branch.
- Confirmed the pull request diff contains only the intended documentation typo fix(es).
