### PR TITLE
Update symfony/console version constraint to include 8.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laminas/laminas-servicemanager": "^3.17.0",
         "laminas/laminas-stdlib": "^3.13.0",
         "psr/container": "^1.1.2",
-        "symfony/console": "^6.1.2 || ^7.0.0"
+        "symfony/console": "^6.1.2 || ^7.0.0 || ^8.0.0"
     },
     "require-dev": {
         "doctrine/annotations": "^2.0.0",


### PR DESCRIPTION
At the moment I get this error:
doctrine/doctrine-orm-module[6.2.0, ..., 6.3.0] require symfony/console ^6.1.2 || ^7.0.0 -> found symfony/console[v6.1.2, ..., v6.4.42, v7.0.0, ..., v7.4.14] but the package is fixed to v8.1.1 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.